### PR TITLE
Configure iOS notifications and timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,9 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Permissions
+
+The application requests notification permissions on iOS for alerts, badges,
+and sounds. Ensure these permissions are granted to allow scheduled
+notifications to appear.

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -11,11 +11,24 @@ class NotificationService {
 
   Future<void> init() async {
     tzdata.initializeTimeZones();
+    tz.setLocalLocation(tz.getLocation('Asia/Ho_Chi_Minh'));
 
     const androidSettings = AndroidInitializationSettings('@mipmap/ic_launcher');
-    const settings = InitializationSettings(android: androidSettings);
+    const iosSettings = DarwinInitializationSettings();
+    const settings = InitializationSettings(
+      android: androidSettings,
+      iOS: iosSettings,
+    );
 
     await _fln.initialize(settings);
+    await _fln
+        .resolvePlatformSpecificImplementation<
+            IOSFlutterLocalNotificationsPlugin>()
+        ?.requestPermissions(
+          alert: true,
+          badge: true,
+          sound: true,
+        );
   }
 
   Future<void> scheduleNotification({


### PR DESCRIPTION
## Summary
- set local timezone to Asia/Ho_Chi_Minh
- add iOS notification initialization and permission requests
- document iOS notification permission requirement in README

## Testing
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68b9abebc704833388908c122427f934