### PR TITLE
Refactor ChatScreen to use GeminiService

### DIFF
--- a/lib/services/gemini_service.dart
+++ b/lib/services/gemini_service.dart
@@ -6,7 +6,7 @@ class GeminiService {
   static const _model = 'gemini-1.5-flash-latest';
 
   Future<String> chat(String userText) async {
-    if (_apiKey.isEmpty) return 'Chưa cấu hình GEMINI_API_KEY';
+    if (_apiKey.isEmpty) return 'Gemini API key chưa được cấu hình.';
 
     final uri = Uri.parse(
       'https://generativelanguage.googleapis.com/v1beta/models/$_model:generateContent?key=$_apiKey',


### PR DESCRIPTION
## Summary
- Move Gemini HTTP calls to GeminiService.chat
- Use GeminiService in ChatScreen and show friendly message when API key is missing

## Testing
- `flutter test` *(fails: command not found)*
- `dart --version` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b9abe5b760833388dfa44ac43f521a