### PR TITLE
Persist notes using local storage

### DIFF
--- a/lib/models/note.dart
+++ b/lib/models/note.dart
@@ -2,7 +2,7 @@ class Note {
   String id;
   String title;
   String content;
-  DateTime? alarmTime;
+  DateTime? remindAt;
   bool daily;
   bool active;
 
@@ -10,7 +10,7 @@ class Note {
     required this.id,
     required this.title,
     required this.content,
-    this.alarmTime,
+    this.remindAt,
     this.daily = false,
     this.active = false,
   });
@@ -19,7 +19,7 @@ class Note {
         id: j['id'],
         title: j['title'],
         content: j['content'],
-        alarmTime: j['alarmTime'] != null ? DateTime.parse(j['alarmTime']) : null,
+        remindAt: j['remindAt'] != null ? DateTime.parse(j['remindAt']) : null,
         daily: j['daily'] ?? false,
         active: j['active'] ?? false,
       );
@@ -28,7 +28,7 @@ class Note {
         'id': id,
         'title': title,
         'content': content,
-        'alarmTime': alarmTime?.toIso8601String(),
+        'remindAt': remindAt?.toIso8601String(),
         'daily': daily,
         'active': active,
       };

--- a/lib/screens/note_detail_screen.dart
+++ b/lib/screens/note_detail_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import '../services/tts_service.dart';
 import 'chat_screen.dart';
-import '../screens/home_screen.dart';
+import '../models/note.dart';
 
 class NoteDetailScreen extends StatelessWidget {
   final Note note;

--- a/lib/screens/note_list_for_day_screen.dart
+++ b/lib/screens/note_list_for_day_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'note_detail_screen.dart';
-import 'home_screen.dart';
+import '../models/note.dart';
 
 class NoteListForDayScreen extends StatelessWidget {
   final DateTime date;


### PR DESCRIPTION
## Summary
- Load saved notes in `HomeScreen` using `DbService`
- Persist note additions and deletions to storage
- Use shared `Note` model with unique `id` and reminder time support

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9abe1843483339cfa458065d5662f