### PR TITLE
refactor: use shared Note model

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,18 +1,13 @@
-import 'note_list_for_day_screen.dart';
 import 'package:flutter/material.dart';
-import 'package:lottie/lottie.dart';
 import 'package:intl/intl.dart';
-import '../services/settings_service.dart';
-import 'settings_screen.dart';
-import '../services/notification_service.dart';
-import 'note_detail_screen.dart';
+import 'package:lottie/lottie.dart';
 
-class Note {
-  final String title;
-  final String content;
-  final DateTime? remindAt;
-  Note({required this.title, required this.content, this.remindAt});
-}
+import '../models/note.dart';
+import '../services/notification_service.dart';
+import '../services/settings_service.dart';
+import 'note_detail_screen.dart';
+import 'note_list_for_day_screen.dart';
+import 'settings_screen.dart';
 
 class HomeScreen extends StatefulWidget {
   final Function(Color) onThemeChanged;
@@ -41,7 +36,7 @@ class _HomeScreenState extends State<HomeScreen> {
   void _addNote() {
     final titleCtrl = TextEditingController();
     final contentCtrl = TextEditingController();
-    DateTime? remindAt;
+    DateTime? alarmTime;
 
     showDialog(
       context: context,
@@ -70,7 +65,7 @@ class _HomeScreenState extends State<HomeScreen> {
                     );
                     if (!mounted) return;
                     if (time != null) {
-                      remindAt = DateTime(
+                      alarmTime = DateTime(
                         picked.year, picked.month, picked.day,
                         time.hour, time.minute,
                       );
@@ -87,21 +82,22 @@ class _HomeScreenState extends State<HomeScreen> {
           ElevatedButton(
             onPressed: () async {
               final note = Note(
+                id: DateTime.now().millisecondsSinceEpoch.toString(),
                 title: titleCtrl.text,
                 content: contentCtrl.text,
-                remindAt: remindAt,
+                alarmTime: alarmTime,
               );
               setState(() => notes.add(note));
 
-              if (remindAt != null) {
+              if (alarmTime != null) {
                 await NotificationService().scheduleNotification(
                   id: DateTime.now().millisecondsSinceEpoch % 100000,
                   title: note.title,
                   body: note.content,
-                  scheduledDate: remindAt!,
+                  scheduledDate: alarmTime!,
                 );
               }
-    if (!mounted) return;
+              if (!mounted) return;
               Navigator.pop(context); // FIX Lỗi 1: auto đóng dialog
             },
             child: const Text('Lưu'),
@@ -112,12 +108,13 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   List<Note> notesForDay(DateTime day) {
-    return notes.where((n) =>
-      n.remindAt != null &&
-      n.remindAt!.year == day.year &&
-      n.remindAt!.month == day.month &&
-      n.remindAt!.day == day.day
-    ).toList();
+    return notes
+        .where((n) =>
+            n.alarmTime != null &&
+            n.alarmTime!.year == day.year &&
+            n.alarmTime!.month == day.month &&
+            n.alarmTime!.day == day.day)
+        .toList();
   }
 
   @override
@@ -206,8 +203,8 @@ class _HomeScreenState extends State<HomeScreen> {
         return Card(
           child: ListTile(
             title: Text(note.title),
-            subtitle: Text(note.remindAt != null
-                ? '${note.content}\n⏰ ${note.remindAt}'
+            subtitle: Text(note.alarmTime != null
+                ? '${note.content}\n⏰ ${note.alarmTime}'
                 : note.content),
             onTap: () {
               Navigator.push(

--- a/lib/screens/note_detail_screen.dart
+++ b/lib/screens/note_detail_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
+import '../models/note.dart';
 import '../services/tts_service.dart';
 import 'chat_screen.dart';
-import '../screens/home_screen.dart';
 
 class NoteDetailScreen extends StatelessWidget {
   final Note note;
@@ -15,8 +15,9 @@ class NoteDetailScreen extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text('Nội dung: ${note.content}', style: const TextStyle(fontSize: 16)),
-          if (note.remindAt != null)
-            Text('Thời gian: ${note.remindAt}', style: const TextStyle(fontSize: 16)),
+          if (note.alarmTime != null)
+            Text('Thời gian: ${note.alarmTime}',
+                style: const TextStyle(fontSize: 16)),
           const SizedBox(height: 10),
           ElevatedButton(
             onPressed: () => TTSService().speak(note.content),

--- a/lib/screens/note_list_for_day_screen.dart
+++ b/lib/screens/note_list_for_day_screen.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+
+import '../models/note.dart';
 import 'note_detail_screen.dart';
-import 'home_screen.dart';
 
 class NoteListForDayScreen extends StatelessWidget {
   final DateTime date;
@@ -24,19 +25,20 @@ class NoteListForDayScreen extends StatelessWidget {
         ),
       );
     }
-    final sorted = [...notes]..sort((a, b) {
-      final at = a.remindAt?.millisecondsSinceEpoch ?? 0;
-      final bt = b.remindAt?.millisecondsSinceEpoch ?? 0;
-      return at.compareTo(bt);
-    });
+    final sorted = [...notes]
+      ..sort((a, b) {
+        final at = a.alarmTime?.millisecondsSinceEpoch ?? 0;
+        final bt = b.alarmTime?.millisecondsSinceEpoch ?? 0;
+        return at.compareTo(bt);
+      });
     return Scaffold(
       appBar: AppBar(title: Text(title)),
       body: ListView.builder(
         itemCount: sorted.length,
         itemBuilder: (context, index) {
           final note = sorted[index];
-          final timeStr = note.remindAt != null
-              ? DateFormat('HH:mm').format(note.remindAt!)
+          final timeStr = note.alarmTime != null
+              ? DateFormat('HH:mm').format(note.alarmTime!)
               : null;
           return Card(
             child: ListTile(


### PR DESCRIPTION
## Summary
- remove local Note class on home screen
- use shared Note model across screens and rename remindAt to alarmTime

## Testing
- `dart format lib/screens/home_screen.dart lib/screens/note_detail_screen.dart lib/screens/note_list_for_day_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9abdb84f8833394c7708e67d74ca3