### PR TITLE
Add unit and widget tests with CI

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -1,0 +1,20 @@
+name: Flutter CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter pub get
+      - run: flutter analyze
+      - run: flutter test
+      - run: flutter build apk

--- a/lib/services/note_repository.dart
+++ b/lib/services/note_repository.dart
@@ -1,0 +1,16 @@
+import '../models/note.dart';
+import 'db_service.dart';
+
+class NoteRepository {
+  final DbService _dbService;
+
+  NoteRepository({DbService? dbService}) : _dbService = dbService ?? DbService();
+
+  Future<List<Note>> getNotes() {
+    return _dbService.getNotes();
+  }
+
+  Future<void> saveNotes(List<Note> notes) {
+    return _dbService.saveNotes(notes);
+  }
+}

--- a/test/home_screen_test.dart
+++ b/test/home_screen_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:notes_reminder_app/screens/home_screen.dart';
+
+void main() {
+  testWidgets('add and delete notes', (tester) async {
+    await tester.pumpWidget(MaterialApp(home: HomeScreen(onThemeChanged: (_) {})));
+
+    expect(find.text('Chưa có ghi chú nào'), findsOneWidget);
+
+    await tester.tap(find.byType(FloatingActionButton));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField).at(0), 'title');
+    await tester.enterText(find.byType(TextField).at(1), 'content');
+
+    await tester.tap(find.text('Lưu'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('title'), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.delete));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Chưa có ghi chú nào'), findsOneWidget);
+  });
+}

--- a/test/note_detail_screen_test.dart
+++ b/test/note_detail_screen_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:notes_reminder_app/models/note.dart';
+import 'package:notes_reminder_app/screens/note_detail_screen.dart';
+
+void main() {
+  testWidgets('display note and trigger TTS', (tester) async {
+    const note = Note(id: '1', title: 'title', content: 'content');
+
+    const channel = MethodChannel('flutter_tts');
+    final calls = <MethodCall>[];
+    channel.setMockMethodCallHandler((call) async {
+      calls.add(call);
+      return null;
+    });
+
+    await tester.pumpWidget(const MaterialApp(home: NoteDetailScreen(note: note)));
+
+    expect(find.text('Nội dung: content'), findsOneWidget);
+
+    await tester.tap(find.text('Đọc Note'));
+    await tester.pump();
+
+    expect(calls.any((c) => c.method == 'speak'), isTrue);
+
+    channel.setMockMethodCallHandler(null);
+  });
+}

--- a/test/note_repository_test.dart
+++ b/test/note_repository_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:notes_reminder_app/services/note_repository.dart';
+import 'package:notes_reminder_app/models/note.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('NoteRepository', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    test('getNotes returns empty list when no data', () async {
+      final repo = NoteRepository();
+      final notes = await repo.getNotes();
+      expect(notes, isEmpty);
+    });
+
+    test('saveNotes and getNotes persist data', () async {
+      final repo = NoteRepository();
+      final note = Note(id: '1', title: 't', content: 'c');
+      await repo.saveNotes([note]);
+      final notes = await repo.getNotes();
+      expect(notes.length, 1);
+      expect(notes.first.title, 't');
+    });
+  });
+}

--- a/test/notification_service_test.dart
+++ b/test/notification_service_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/services.dart';
+import 'package:notes_reminder_app/services/notification_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('dexterx.dev/flutter_local_notifications');
+  final List<MethodCall> log = [];
+
+  setUp(() {
+    channel.setMockMethodCallHandler((MethodCall call) async {
+      log.add(call);
+      return null;
+    });
+    log.clear();
+  });
+
+  tearDown(() {
+    channel.setMockMethodCallHandler(null);
+  });
+
+  test('init initializes plugin', () async {
+    await NotificationService().init();
+    expect(log.any((c) => c.method == 'initialize'), isTrue);
+  });
+
+  test('scheduleNotification schedules notification', () async {
+    final service = NotificationService();
+    await service.scheduleNotification(
+      id: 1,
+      title: 't',
+      body: 'b',
+      scheduledDate: DateTime.now().add(const Duration(minutes: 1)),
+    );
+    expect(log.any((c) => c.method == 'zonedSchedule'), isTrue);
+  });
+}

--- a/test/settings_service_test.dart
+++ b/test/settings_service_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:notes_reminder_app/services/settings_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('save and load theme color', () async {
+    final service = SettingsService();
+    await service.saveThemeColor(Colors.red);
+    final color = await service.loadThemeColor();
+    expect(color, Colors.red);
+  });
+
+  test('save and load mascot path', () async {
+    final service = SettingsService();
+    await service.saveMascotPath('path.json');
+    final path = await service.loadMascotPath();
+    expect(path, 'path.json');
+  });
+
+  test('default values returned when not set', () async {
+    final service = SettingsService();
+    final color = await service.loadThemeColor();
+    final path = await service.loadMascotPath();
+    expect(color, Colors.blue);
+    expect(path, 'assets/lottie/mascot.json');
+  });
+}


### PR DESCRIPTION
## Summary
- add NoteRepository and service tests
- add HomeScreen and NoteDetailScreen widget tests
- add GitHub Actions workflow for analyze, test, build

## Testing
- `flutter analyze` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `flutter test` *(fails: command not found)*
- `flutter build apk` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c02fb5608333bc5173181b637ca0