### PR TITLE
Use provider for notes and update imports

### DIFF
--- a/lib/providers/note_provider.dart
+++ b/lib/providers/note_provider.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/note.dart';
+import '../services/note_repository.dart';
+
+class NoteProvider extends ChangeNotifier {
+  final NoteRepository _repository;
+  List<Note> _notes = [];
+
+  NoteProvider({NoteRepository? repository})
+      : _repository = repository ?? NoteRepository() {
+    _loadNotes();
+  }
+
+  List<Note> get notes => _notes;
+
+  Future<void> _loadNotes() async {
+    _notes = await _repository.getNotes();
+    notifyListeners();
+  }
+
+  Future<void> addNote(Note note) async {
+    _notes.add(note);
+    await _repository.saveNotes(_notes);
+    notifyListeners();
+  }
+
+  Future<void> removeNoteAt(int index) async {
+    _notes.removeAt(index);
+    await _repository.saveNotes(_notes);
+    notifyListeners();
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,11 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
 import 'package:lottie/lottie.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 
 import '../models/note.dart';
+import '../providers/note_provider.dart';
 import '../services/notification_service.dart';
-import '../services/db_service.dart';
 import '../services/settings_service.dart';
 import 'note_detail_screen.dart';
 import 'note_list_for_day_screen.dart';
@@ -21,7 +22,6 @@ class HomeScreen extends StatefulWidget {
 
 class _HomeScreenState extends State<HomeScreen> {
   String _mascotPath = 'assets/lottie/mascot.json';
-  List<Note> notes = [];
   DateTime today = DateTime.now();
 
   @override
@@ -119,7 +119,7 @@ class _HomeScreenState extends State<HomeScreen> {
             TextButton(
                 onPressed: () => Navigator.pop(context),
                 child: const Text('Hủy')),
-            ElevatedButton(
+              ElevatedButton(
               onPressed: () async {
                 final note = Note(
                   id: DateTime.now().millisecondsSinceEpoch.toString(),
@@ -130,8 +130,7 @@ class _HomeScreenState extends State<HomeScreen> {
                   active: true,
                   snoozeMinutes: snoozeMinutes,
                 );
-                setState(() => notes.add(note));
-                await DbService().saveNotes(notes);
+                await context.read<NoteProvider>().addNote(note);
 
                 if (alarmTime != null) {
                   final id = DateTime.now().millisecondsSinceEpoch % 100000;
@@ -171,6 +170,7 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   List<Note> notesForDay(DateTime day) {
+    final notes = context.watch<NoteProvider>().notes;
     return notes
         .where((n) =>
             n.alarmTime != null &&
@@ -258,7 +258,10 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   Widget _buildNotesList() {
-    if (notes.isEmpty) return const Center(child: Text('Chưa có ghi chú nào'));
+    final notes = context.watch<NoteProvider>().notes;
+    if (notes.isEmpty) {
+      return const Center(child: Text('Chưa có ghi chú nào'));
+    }
     return ListView.builder(
       itemCount: notes.length,
       itemBuilder: (context, index) {
@@ -266,9 +269,11 @@ class _HomeScreenState extends State<HomeScreen> {
         return Card(
           child: ListTile(
             title: Text(note.title),
-            subtitle: Text(note.alarmTime != null
-                ? '${note.content}\n⏰ ${note.alarmTime}'
-                : note.content),
+            subtitle: Text(
+              note.alarmTime != null
+                  ? '${note.content}\n⏰ ${note.alarmTime}'
+                  : note.content,
+            ),
             onTap: () {
               Navigator.push(
                 context,
@@ -279,7 +284,8 @@ class _HomeScreenState extends State<HomeScreen> {
             },
             trailing: IconButton(
               icon: const Icon(Icons.delete),
-              onPressed: () => setState(() => notes.removeAt(index)),
+              onPressed: () =>
+                  context.read<NoteProvider>().removeNoteAt(index),
             ),
           ),
         );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   shared_preferences: ^2.3.2
   audioplayers: ^6.5.0
   intl: ^0.18.1
+  provider: ^6.1.2
   flutter_tts: ^4.2.3
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- add provider dependency and NoteProvider to manage notes list
- switch HomeScreen to use NoteProvider for note CRUD and filtering

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9dc65a72c8333992cfd38ad4178b8