### PR TITLE
feat: enable note editing with scheduling

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'providers/note_provider.dart';
 import 'screens/home_screen.dart';
 import 'services/notification_service.dart';
 import 'services/settings_service.dart';
@@ -8,12 +11,15 @@ void main() async {
   await NotificationService().init();
   final settings = SettingsService();
   final themeColor = await settings.loadThemeColor();
-  runApp(MyApp(themeColor: themeColor));
+  final noteProvider = NoteProvider();
+  await noteProvider.loadNotes();
+  runApp(MyApp(themeColor: themeColor, noteProvider: noteProvider));
 }
 
 class MyApp extends StatefulWidget {
   final Color themeColor;
-  const MyApp({super.key, required this.themeColor});
+  final NoteProvider noteProvider;
+  const MyApp({super.key, required this.themeColor, required this.noteProvider});
 
   @override
   State<MyApp> createState() => _MyAppState();
@@ -35,13 +41,16 @@ class _MyAppState extends State<MyApp> {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Notes & Reminders',
-      theme: ThemeData(
-        colorSchemeSeed: _themeColor,
-        useMaterial3: true,
+    return ChangeNotifierProvider.value(
+      value: widget.noteProvider,
+      child: MaterialApp(
+        title: 'Notes & Reminders',
+        theme: ThemeData(
+          colorSchemeSeed: _themeColor,
+          useMaterial3: true,
+        ),
+        home: HomeScreen(onThemeChanged: updateTheme),
       ),
-      home: HomeScreen(onThemeChanged: updateTheme),
     );
   }
 }

--- a/lib/providers/note_provider.dart
+++ b/lib/providers/note_provider.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/note.dart';
+import '../services/note_repository.dart';
+
+class NoteProvider extends ChangeNotifier {
+  final NoteRepository _repository;
+  List<Note> _notes = [];
+
+  NoteProvider({NoteRepository? repository})
+      : _repository = repository ?? NoteRepository();
+
+  List<Note> get notes => List.unmodifiable(_notes);
+
+  Future<void> loadNotes() async {
+    _notes = await _repository.getNotes();
+    notifyListeners();
+  }
+
+  Future<void> addNote(Note note) async {
+    _notes.add(note);
+    await _repository.saveNotes(_notes);
+    notifyListeners();
+  }
+
+  Future<void> updateNote(Note note) async {
+    final index = _notes.indexWhere((n) => n.id == note.id);
+    if (index != -1) {
+      _notes[index] = note;
+      await _repository.saveNotes(_notes);
+      notifyListeners();
+    }
+  }
+
+  Future<void> removeNoteAt(int index) async {
+    _notes.removeAt(index);
+    await _repository.saveNotes(_notes);
+    notifyListeners();
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -2,10 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:lottie/lottie.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:provider/provider.dart';
 
 import '../models/note.dart';
+import '../providers/note_provider.dart';
 import '../services/notification_service.dart';
-import '../services/db_service.dart';
 import '../services/settings_service.dart';
 import 'note_detail_screen.dart';
 import 'note_list_for_day_screen.dart';
@@ -21,7 +22,6 @@ class HomeScreen extends StatefulWidget {
 
 class _HomeScreenState extends State<HomeScreen> {
   String _mascotPath = 'assets/lottie/mascot.json';
-  List<Note> notes = [];
   DateTime today = DateTime.now();
 
   @override
@@ -130,8 +130,7 @@ class _HomeScreenState extends State<HomeScreen> {
                   active: true,
                   snoozeMinutes: snoozeMinutes,
                 );
-                setState(() => notes.add(note));
-                await DbService().saveNotes(notes);
+                await context.read<NoteProvider>().addNote(note);
 
                 if (alarmTime != null) {
                   final id = DateTime.now().millisecondsSinceEpoch % 100000;
@@ -171,6 +170,7 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   List<Note> notesForDay(DateTime day) {
+    final notes = context.read<NoteProvider>().notes;
     return notes
         .where((n) =>
             n.alarmTime != null &&
@@ -258,6 +258,7 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   Widget _buildNotesList() {
+    final notes = context.watch<NoteProvider>().notes;
     if (notes.isEmpty) return const Center(child: Text('Chưa có ghi chú nào'));
     return ListView.builder(
       itemCount: notes.length,
@@ -279,7 +280,8 @@ class _HomeScreenState extends State<HomeScreen> {
             },
             trailing: IconButton(
               icon: const Icon(Icons.delete),
-              onPressed: () => setState(() => notes.removeAt(index)),
+              onPressed: () =>
+                  context.read<NoteProvider>().removeNoteAt(index),
             ),
           ),
         );

--- a/lib/screens/note_detail_screen.dart
+++ b/lib/screens/note_detail_screen.dart
@@ -1,5 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:provider/provider.dart';
+
 import '../models/note.dart';
+import '../providers/note_provider.dart';
+import '../services/notification_service.dart';
 import '../services/tts_service.dart';
 import 'chat_screen.dart';
 
@@ -15,12 +20,18 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
   late final TextEditingController _titleCtrl;
   late final TextEditingController _contentCtrl;
   final List<String> _attachments = [];
+  DateTime? _alarmTime;
+  RepeatInterval? _repeat;
+  int _snoozeMinutes = 5;
 
   @override
   void initState() {
     super.initState();
     _titleCtrl = TextEditingController(text: widget.note.title);
     _contentCtrl = TextEditingController(text: widget.note.content);
+    _alarmTime = widget.note.alarmTime;
+    _repeat = widget.note.daily ? RepeatInterval.daily : null;
+    _snoozeMinutes = widget.note.snoozeMinutes;
   }
 
   @override
@@ -45,18 +56,47 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
         TextField(
           controller: _titleCtrl,
           decoration: const InputDecoration(labelText: 'Tiêu đề'),
-          readOnly: true,
         ),
         TextField(
           controller: _contentCtrl,
           decoration: const InputDecoration(labelText: 'Nội dung'),
-          readOnly: true,
         ),
-        if (widget.note.alarmTime != null)
-          Text(
-            'Thời gian: ${widget.note.alarmTime}',
-            style: const TextStyle(fontSize: 16),
-          ),
+        const SizedBox(height: 12),
+        ElevatedButton(
+          onPressed: _pickAlarmTime,
+          child: Text(
+              _alarmTime != null ? 'Thời gian: $_alarmTime' : 'Chọn thời gian nhắc'),
+        ),
+        const SizedBox(height: 12),
+        DropdownButton<RepeatInterval?>(
+          value: _repeat,
+          items: const [
+            DropdownMenuItem(value: null, child: Text('Không lặp')),
+            DropdownMenuItem(
+                value: RepeatInterval.hourly, child: Text('Hằng giờ')),
+            DropdownMenuItem(
+                value: RepeatInterval.daily, child: Text('Hằng ngày')),
+          ],
+          onChanged: (val) => setState(() => _repeat = val),
+        ),
+        Row(
+          children: [
+            const Text('Snooze:'),
+            const SizedBox(width: 8),
+            DropdownButton<int>(
+              value: _snoozeMinutes,
+              items: const [
+                DropdownMenuItem(value: 5, child: Text('5')),
+                DropdownMenuItem(value: 10, child: Text('10')),
+                DropdownMenuItem(value: 15, child: Text('15')),
+              ],
+              onChanged: (v) =>
+                  setState(() => _snoozeMinutes = v ?? _snoozeMinutes),
+            ),
+          ],
+        ),
+        const SizedBox(height: 10),
+        ElevatedButton(onPressed: _save, child: const Text('Lưu')),
         const SizedBox(height: 10),
         ElevatedButton(
           onPressed: () => TTSService().speak(_contentCtrl.text),
@@ -70,5 +110,77 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
         Expanded(child: ChatScreen(initialMessage: _contentCtrl.text)),
       ],
     );
+  }
+
+  Future<void> _pickAlarmTime() async {
+    final now = DateTime.now();
+    final picked = await showDatePicker(
+      context: context,
+      firstDate: now,
+      lastDate: DateTime(now.year + 2),
+      initialDate: _alarmTime ?? now,
+    );
+    if (picked != null) {
+      final time = await showTimePicker(
+        context: context,
+        initialTime:
+            _alarmTime != null ? TimeOfDay.fromDateTime(_alarmTime!) : TimeOfDay.now(),
+      );
+      if (time != null) {
+        setState(() {
+          _alarmTime = DateTime(
+            picked.year,
+            picked.month,
+            picked.day,
+            time.hour,
+            time.minute,
+          );
+        });
+      }
+    }
+  }
+
+  Future<void> _save() async {
+    final updated = Note(
+      id: widget.note.id,
+      title: _titleCtrl.text,
+      content: _contentCtrl.text,
+      alarmTime: _alarmTime,
+      daily: _repeat == RepeatInterval.daily,
+      active: true,
+      snoozeMinutes: _snoozeMinutes,
+    );
+    await context.read<NoteProvider>().updateNote(updated);
+
+    if (_alarmTime != null) {
+      final id = int.tryParse(updated.id) ??
+          DateTime.now().millisecondsSinceEpoch % 100000;
+      final service = NotificationService();
+      if (_repeat == RepeatInterval.daily) {
+        await service.scheduleDailyAtTime(
+          id: id,
+          title: updated.title,
+          body: updated.content,
+          time: Time(_alarmTime!.hour, _alarmTime!.minute),
+        );
+      } else if (_repeat != null) {
+        await service.scheduleRecurring(
+          id: id,
+          title: updated.title,
+          body: updated.content,
+          repeatInterval: _repeat!,
+        );
+      } else {
+        await service.scheduleNotification(
+          id: id,
+          title: updated.title,
+          body: updated.content,
+          scheduledDate: _alarmTime!,
+        );
+      }
+    }
+
+    if (!mounted) return;
+    Navigator.pop(context);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   audioplayers: ^6.5.0
   intl: ^0.18.1
   flutter_tts: ^4.2.3
+  provider: ^6.1.2
 
 dev_dependencies:
   flutter_test:

--- a/test/home_screen_test.dart
+++ b/test/home_screen_test.dart
@@ -1,10 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:notes_reminder_app/providers/note_provider.dart';
 import 'package:notes_reminder_app/screens/home_screen.dart';
 
 void main() {
   testWidgets('add and delete notes', (tester) async {
-    await tester.pumpWidget(MaterialApp(home: HomeScreen(onThemeChanged: (_) {})));
+    await tester.pumpWidget(
+      ChangeNotifierProvider(
+        create: (_) => NoteProvider(),
+        child: MaterialApp(home: HomeScreen(onThemeChanged: (_) {})),
+      ),
+    );
 
     expect(find.text('Chưa có ghi chú nào'), findsOneWidget);
 

--- a/test/note_detail_screen_test.dart
+++ b/test/note_detail_screen_test.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
 import 'package:notes_reminder_app/models/note.dart';
+import 'package:notes_reminder_app/providers/note_provider.dart';
 import 'package:notes_reminder_app/screens/note_detail_screen.dart';
 
 void main() {
@@ -15,9 +17,14 @@ void main() {
       return null;
     });
 
-    await tester.pumpWidget(const MaterialApp(home: NoteDetailScreen(note: note)));
+    await tester.pumpWidget(
+      ChangeNotifierProvider(
+        create: (_) => NoteProvider(),
+        child: const MaterialApp(home: NoteDetailScreen(note: note)),
+      ),
+    );
 
-    expect(find.text('Nội dung: content'), findsOneWidget);
+    expect(find.text('content'), findsOneWidget);
 
     await tester.tap(find.text('Đọc Note'));
     await tester.pump();

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:notes_reminder_app/main.dart';
+import 'package:notes_reminder_app/providers/note_provider.dart';
 
 void main() {
   testWidgets('renders home screen title', (WidgetTester tester) async {
-    await tester.pumpWidget(MyApp(themeColor: Colors.blue));
+    await tester.pumpWidget(
+      MyApp(themeColor: Colors.blue, noteProvider: NoteProvider()),
+    );
 
     expect(find.text('Notes & Reminders'), findsOneWidget);
   });


### PR DESCRIPTION
## Summary
- add NoteProvider for persistent state management
- allow editing notes with scheduling and snooze options
- wire app and home screen to NoteProvider and notifications

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9dc6747608333bd96f1ee05ce9bd2