### PR TITLE
Refactor day note list to use provider

### DIFF
--- a/lib/providers/note_provider.dart
+++ b/lib/providers/note_provider.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/note.dart';
+import '../services/note_repository.dart';
+
+class NoteProvider extends ChangeNotifier {
+  final NoteRepository _repository;
+  List<Note> _notes = [];
+
+  List<Note> get notes => _notes;
+
+  NoteProvider({NoteRepository? repository})
+      : _repository = repository ?? NoteRepository();
+
+  Future<void> loadNotes() async {
+    _notes = await _repository.getNotes();
+    notifyListeners();
+  }
+
+  Future<void> addNote(Note note) async {
+    _notes.add(note);
+    await _repository.saveNotes(_notes);
+    notifyListeners();
+  }
+
+  Future<void> removeNoteAt(int index) async {
+    _notes.removeAt(index);
+    await _repository.saveNotes(_notes);
+    notifyListeners();
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -218,11 +218,10 @@ class _HomeScreenState extends State<HomeScreen> {
                 final hasNotes = notesForDay(d).isNotEmpty;
                 return GestureDetector(
                   onTap: () {
-                    final dayNotes = notesForDay(d);
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (_) => NoteListForDayScreen(date: d, notes: dayNotes),
+                        builder: (_) => NoteListForDayScreen(date: d),
                       ),
                     );
                   },

--- a/lib/screens/note_list_for_day_screen.dart
+++ b/lib/screens/note_list_for_day_screen.dart
@@ -1,23 +1,36 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
 
 import '../models/note.dart';
+import '../providers/note_provider.dart';
 import 'note_detail_screen.dart';
 
 class NoteListForDayScreen extends StatelessWidget {
   final DateTime date;
-  final List<Note> notes;
 
   const NoteListForDayScreen({
     super.key,
     required this.date,
-    required this.notes,
   });
 
   @override
   Widget build(BuildContext context) {
+    final notes = context.watch<NoteProvider>().notes;
+    final dayNotes = notes
+        .where((n) =>
+            n.alarmTime != null &&
+            n.alarmTime!.year == date.year &&
+            n.alarmTime!.month == date.month &&
+            n.alarmTime!.day == date.day)
+        .toList()
+      ..sort((a, b) {
+        final at = a.alarmTime?.millisecondsSinceEpoch ?? 0;
+        final bt = b.alarmTime?.millisecondsSinceEpoch ?? 0;
+        return at.compareTo(bt);
+      });
     final title = 'Lịch ngày ${DateFormat('dd/MM/yyyy').format(date)}';
-    if (notes.isEmpty) {
+    if (dayNotes.isEmpty) {
       return Scaffold(
         appBar: AppBar(title: Text(title)),
         body: const Center(
@@ -25,18 +38,12 @@ class NoteListForDayScreen extends StatelessWidget {
         ),
       );
     }
-    final sorted = [...notes]
-      ..sort((a, b) {
-        final at = a.alarmTime?.millisecondsSinceEpoch ?? 0;
-        final bt = b.alarmTime?.millisecondsSinceEpoch ?? 0;
-        return at.compareTo(bt);
-      });
     return Scaffold(
       appBar: AppBar(title: Text(title)),
       body: ListView.builder(
-        itemCount: sorted.length,
+        itemCount: dayNotes.length,
         itemBuilder: (context, index) {
-          final note = sorted[index];
+          final note = dayNotes[index];
           final timeStr = note.alarmTime != null
               ? DateFormat('HH:mm').format(note.alarmTime!)
               : null;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   shared_preferences: ^2.3.2
   audioplayers: ^6.5.0
   intl: ^0.18.1
+  provider: ^6.1.2
   flutter_tts: ^4.2.3
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- Use NoteProvider to filter and sort notes for a day
- Wire day note screen to provider and add provider dependency

## Testing
- `dart format lib/screens/note_list_for_day_screen.dart lib/screens/home_screen.dart lib/providers/note_provider.dart pubspec.yaml` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9dc6989488333a326780f90a06ca1