### PR TITLE
Implement note update persistence and private loadNotes

### DIFF
--- a/lib/providers/note_provider.dart
+++ b/lib/providers/note_provider.dart
@@ -19,6 +19,15 @@ class NoteProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  Future<void> updateNote(Note note) async {
+    final index = _notes.indexWhere((n) => n.id == note.id);
+    if (index != -1) {
+      _notes[index] = note;
+      await _repository.updateNote(note);
+      notifyListeners();
+    }
+  }
+
   Future<void> addNote(Note note) async {
     _notes.add(note);
     await _repository.saveNotes(_notes);

--- a/lib/services/db_service.dart
+++ b/lib/services/db_service.dart
@@ -18,4 +18,13 @@ class DbService {
     final raw = jsonEncode(notes.map((e) => e.toJson()).toList());
     await sp.setString(_kNotes, raw);
   }
+
+  Future<void> updateNote(Note note) async {
+    final notes = await getNotes();
+    final index = notes.indexWhere((n) => n.id == note.id);
+    if (index != -1) {
+      notes[index] = note;
+      await saveNotes(notes);
+    }
+  }
 }

--- a/lib/services/note_repository.dart
+++ b/lib/services/note_repository.dart
@@ -13,4 +13,8 @@ class NoteRepository {
   Future<void> saveNotes(List<Note> notes) {
     return _dbService.saveNotes(notes);
   }
+
+  Future<void> updateNote(Note note) {
+    return _dbService.updateNote(note);
+  }
 }

--- a/test/note_repository_test.dart
+++ b/test/note_repository_test.dart
@@ -25,5 +25,17 @@ void main() {
       expect(notes.length, 1);
       expect(notes.first.title, 't');
     });
+
+    test('updateNote persists changes', () async {
+      final repo = NoteRepository();
+      final note = Note(id: '1', title: 't', content: 'c');
+      await repo.saveNotes([note]);
+      final updated = Note(id: '1', title: 't2', content: 'c2');
+      await repo.updateNote(updated);
+      final notes = await repo.getNotes();
+      expect(notes.length, 1);
+      expect(notes.first.title, 't2');
+      expect(notes.first.content, 'c2');
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Make `NoteProvider` constructor load notes and expose notes via getter
- Add `updateNote` method that persists through repository
- Extend repository and DB service with single-note update support
- Test repository update behavior

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e0262704833396c4f22fe165c7db