### PR TITLE
Refactor NoteProvider and expose loadNotes

### DIFF
--- a/lib/providers/note_provider.dart
+++ b/lib/providers/note_provider.dart
@@ -9,12 +9,12 @@ class NoteProvider extends ChangeNotifier {
 
   NoteProvider({NoteRepository? repository})
       : _repository = repository ?? NoteRepository() {
-    _loadNotes();
+    loadNotes();
   }
 
   List<Note> get notes => _notes;
 
-  Future<void> _loadNotes() async {
+  Future<void> loadNotes() async {
     _notes = await _repository.getNotes();
     notifyListeners();
   }


### PR DESCRIPTION
## Summary
- remove leftover merge structure from `note_provider.dart` and expose a public `loadNotes`
- ensure provider still persists notes via `NoteRepository`

## Testing
- `dart format lib/providers/note_provider.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9eca547188333a9579182267b35b0