### PR TITLE
Refactor note provider access and remove merge artifacts

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -169,7 +169,8 @@ class _HomeScreenState extends State<HomeScreen> {
     );
   }
 
-  List<Note> notesForDay(DateTime day, List<Note> notes) {
+  List<Note> notesForDay(DateTime day) {
+    final notes = context.read<NoteProvider>().notes;
     return notes
         .where((n) =>
             n.alarmTime != null &&
@@ -215,10 +216,10 @@ class _HomeScreenState extends State<HomeScreen> {
               itemCount: weekDays.length,
               itemBuilder: (context, i) {
                 final d = weekDays[i];
-                final hasNotes = notesForDay(d, notes).isNotEmpty;
+                final hasNotes = notesForDay(d).isNotEmpty;
                 return GestureDetector(
                   onTap: () {
-                    final dayNotes = notesForDay(d, notes);
+                    final dayNotes = notesForDay(d);
                     Navigator.push(
                       context,
                       MaterialPageRoute(
@@ -247,7 +248,7 @@ class _HomeScreenState extends State<HomeScreen> {
             ),
           ),
           const SizedBox(height: 8),
-          Expanded(child: _buildNotesList(notes)),
+          Expanded(child: _buildNotesList()),
         ],
       ),
       floatingActionButton: FloatingActionButton(
@@ -257,7 +258,8 @@ class _HomeScreenState extends State<HomeScreen> {
     );
   }
 
-  Widget _buildNotesList(List<Note> notes) {
+  Widget _buildNotesList() {
+    final notes = context.watch<NoteProvider>().notes;
     if (notes.isEmpty) {
       return const Center(child: Text('Chưa có ghi chú nào'));
     }


### PR DESCRIPTION
## Summary
- clean up HomeScreen merge remnants
- refactor `notesForDay` and `_buildNotesList` to use Provider's `read` and `watch`

## Testing
- `flutter format lib/screens/home_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9eca6a7788333a637c0976e4252b3