### PR TITLE
Add recurring and daily notification scheduling

### DIFF
--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -77,7 +77,11 @@ class NotificationService {
       priority: Priority.high,
     );
 
-    const details = NotificationDetails(android: androidDetails);
+    const iosDetails = DarwinNotificationDetails();
+    const details = NotificationDetails(
+      android: androidDetails,
+      iOS: iosDetails,
+    );
 
     await _fln.periodicallyShow(
       id,
@@ -103,7 +107,11 @@ class NotificationService {
       priority: Priority.high,
     );
 
-    const details = NotificationDetails(android: androidDetails);
+    const iosDetails = DarwinNotificationDetails();
+    const details = NotificationDetails(
+      android: androidDetails,
+      iOS: iosDetails,
+    );
 
     final scheduledDate = _nextInstanceOfTime(time);
 

--- a/test/notification_service_test.dart
+++ b/test/notification_service_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:notes_reminder_app/services/notification_service.dart';
 
 void main() {
@@ -34,5 +35,27 @@ void main() {
       scheduledDate: DateTime.now().add(const Duration(minutes: 1)),
     );
     expect(log.any((c) => c.method == 'zonedSchedule'), isTrue);
+  });
+
+  test('scheduleDailyAtTime schedules daily notification', () async {
+    final service = NotificationService();
+    await service.scheduleDailyAtTime(
+      id: 2,
+      title: 't',
+      body: 'b',
+      time: const Time(10, 0, 0),
+    );
+    expect(log.any((c) => c.method == 'zonedSchedule'), isTrue);
+  });
+
+  test('scheduleRecurring schedules recurring notification', () async {
+    final service = NotificationService();
+    await service.scheduleRecurring(
+      id: 3,
+      title: 't',
+      body: 'b',
+      repeatInterval: RepeatInterval.daily,
+    );
+    expect(log.any((c) => c.method == 'periodicallyShow'), isTrue);
   });
 }


### PR DESCRIPTION
## Summary
- implement daily and recurring scheduling methods in notification service using flutter_local_notifications
- include iOS notification details
- test daily and recurring notification scheduling

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f11a42848333a9bd8750cefa2119