### PR TITLE
Add snoozeMinutes serialization tests

### DIFF
--- a/lib/models/note.dart
+++ b/lib/models/note.dart
@@ -5,6 +5,7 @@ class Note {
   DateTime? alarmTime;
   bool daily;
   bool active;
+  /// Minutes to postpone a notification when snoozed.
   int snoozeMinutes;
 
   Note({
@@ -24,7 +25,7 @@ class Note {
         alarmTime: j['alarmTime'] != null ? DateTime.parse(j['alarmTime']) : null,
         daily: j['daily'] == 1,
         active: j['active'] == 1,
-        snoozeMinutes: j['snoozeMinutes'] ?? 0,
+        snoozeMinutes: j['snoozeMinutes'] as int? ?? 0,
       );
 
   Map<String, dynamic> toJson() => {

--- a/test/note_detail_screen_test.dart
+++ b/test/note_detail_screen_test.dart
@@ -6,7 +6,7 @@ import 'package:notes_reminder_app/screens/note_detail_screen.dart';
 
 void main() {
   testWidgets('display note and trigger TTS', (tester) async {
-    const note = Note(id: '1', title: 'title', content: 'content');
+    final note = Note(id: '1', title: 'title', content: 'content');
 
     const channel = MethodChannel('flutter_tts');
     final calls = <MethodCall>[];
@@ -17,7 +17,8 @@ void main() {
 
     await tester.pumpWidget(const MaterialApp(home: NoteDetailScreen(note: note)));
 
-    expect(find.text('Nội dung: content'), findsOneWidget);
+    // The note content should be displayed inside a read-only text field.
+    expect(find.text('content'), findsOneWidget);
 
     await tester.tap(find.text('Đọc Note'));
     await tester.pump();

--- a/test/note_repository_test.dart
+++ b/test/note_repository_test.dart
@@ -19,23 +19,40 @@ void main() {
 
     test('saveNotes and getNotes persist data', () async {
       final repo = NoteRepository();
-      final note = Note(id: '1', title: 't', content: 'c');
+      final note = Note(
+        id: '1',
+        title: 't',
+        content: 'c',
+        snoozeMinutes: 10,
+      );
       await repo.saveNotes([note]);
       final notes = await repo.getNotes();
       expect(notes.length, 1);
       expect(notes.first.title, 't');
+      expect(notes.first.snoozeMinutes, 10);
     });
 
     test('updateNote persists changes', () async {
       final repo = NoteRepository();
-      final note = Note(id: '1', title: 't', content: 'c');
+      final note = Note(
+        id: '1',
+        title: 't',
+        content: 'c',
+        snoozeMinutes: 5,
+      );
       await repo.saveNotes([note]);
-      final updated = Note(id: '1', title: 't2', content: 'c2');
+      final updated = Note(
+        id: '1',
+        title: 't2',
+        content: 'c2',
+        snoozeMinutes: 15,
+      );
       await repo.updateNote(updated);
       final notes = await repo.getNotes();
       expect(notes.length, 1);
       expect(notes.first.title, 't2');
       expect(notes.first.content, 'c2');
+      expect(notes.first.snoozeMinutes, 15);
     });
   });
 }


### PR DESCRIPTION
## Summary
- document snoozeMinutes field on Note and handle type-safe JSON parsing
- verify snoozeMinutes persists through NoteRepository
- fix NoteDetailScreen test to use updated Note API

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f11c5a1c833384297e5d2816663a