### PR TITLE
Improve note model and auto id generation

### DIFF
--- a/lib/models/note.dart
+++ b/lib/models/note.dart
@@ -9,22 +9,22 @@ class Note {
   int snoozeMinutes;
 
   Note({
-    required this.id,
+    String? id,
     required this.title,
     required this.content,
     this.alarmTime,
     this.daily = false,
     this.active = false,
     this.snoozeMinutes = 0,
-  });
+  }) : id = id ?? DateTime.now().millisecondsSinceEpoch.toString();
 
   factory Note.fromJson(Map<String, dynamic> j) => Note(
         id: j['id'],
         title: j['title'],
         content: j['content'],
         alarmTime: j['alarmTime'] != null ? DateTime.parse(j['alarmTime']) : null,
-        daily: j['daily'] == 1,
-        active: j['active'] == 1,
+        daily: j['daily'] == 1 || j['daily'] == true,
+        active: j['active'] == 1 || j['active'] == true,
         snoozeMinutes: j['snoozeMinutes'] as int? ?? 0,
       );
 

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -124,7 +124,6 @@ class _HomeScreenState extends State<HomeScreen> {
             ElevatedButton(
               onPressed: () async {
                 final note = Note(
-                  id: DateTime.now().millisecondsSinceEpoch.toString(),
                   title: titleCtrl.text,
                   content: contentCtrl.text,
                   alarmTime: alarmTime,


### PR DESCRIPTION
## Summary
- Refactored `Note` model to auto-generate IDs and cover all fields
- Updated note creation screen to rely on model ID generation

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f7bd47a08333a526a9db34253987