### PR TITLE
Persist notes and schedule reminders

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,11 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
-import 'package:provider/provider.dart';
 import 'package:lottie/lottie.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 
 import '../models/note.dart';
-import '../providers/note_provider.dart';
 import '../services/db_service.dart';
 import '../services/notification_service.dart';
 import '../services/settings_service.dart';
@@ -24,11 +22,15 @@ class HomeScreen extends StatefulWidget {
 class _HomeScreenState extends State<HomeScreen> {
   String _mascotPath = 'assets/lottie/mascot.json';
   DateTime today = DateTime.now();
+  List<Note> notes = [];
 
   @override
   void initState() {
     super.initState();
     _loadMascot();
+    DbService().getNotes().then((loadedNotes) {
+      setState(() => notes = loadedNotes);
+    });
   }
 
   Future<void> _loadMascot() async {
@@ -37,7 +39,6 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   void _addNote() {
-    final notes = context.read<NoteProvider>().notes;
     final titleCtrl = TextEditingController();
     final contentCtrl = TextEditingController();
     DateTime? alarmTime;
@@ -173,7 +174,6 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   List<Note> notesForDay(DateTime day) {
-    final notes = context.read<NoteProvider>().notes;
     return notes
         .where((n) =>
             n.alarmTime != null &&
@@ -185,7 +185,6 @@ class _HomeScreenState extends State<HomeScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final notes = context.watch<NoteProvider>().notes;
     final weekDays = List.generate(7, (i) => today.add(Duration(days: i)));
 
     return Scaffold(
@@ -262,7 +261,6 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   Widget _buildNotesList() {
-    final notes = context.watch<NoteProvider>().notes;
     if (notes.isEmpty) {
       return const Center(child: Text('Chưa có ghi chú nào'));
     }
@@ -288,8 +286,10 @@ class _HomeScreenState extends State<HomeScreen> {
             },
             trailing: IconButton(
               icon: const Icon(Icons.delete),
-              onPressed: () =>
-                  context.read<NoteProvider>().removeNoteAt(index),
+              onPressed: () async {
+                setState(() => notes.removeAt(index));
+                await DbService().saveNotes(notes);
+              },
             ),
           ),
         );


### PR DESCRIPTION
## Summary
- load stored notes on startup and hold them in state
- save notes and schedule notifications when adding new notes
- persist note deletions immediately

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f7c13bb08333a530f83d8116b767