### PR TITLE
Format alarm display and expose note metadata

### DIFF
--- a/lib/screens/note_detail_screen.dart
+++ b/lib/screens/note_detail_screen.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
 import '../models/note.dart';
 import '../services/tts_service.dart';
 import 'chat_screen.dart';
@@ -54,9 +56,13 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
         ),
         if (widget.note.alarmTime != null)
           Text(
-            'Thời gian: ${widget.note.alarmTime}',
+            'Thời gian: '
+            '${DateFormat.yMd().add_Hm().format(widget.note.alarmTime!)}',
             style: const TextStyle(fontSize: 16),
           ),
+        Text('Kích hoạt: ${widget.note.active ? 'Có' : 'Không'}'),
+        if (widget.note.snoozeMinutes > 0)
+          Text('Hoãn: ${widget.note.snoozeMinutes} phút'),
         const SizedBox(height: 10),
         ElevatedButton(
           onPressed: () => TTSService().speak(_contentCtrl.text),


### PR DESCRIPTION
## Summary
- tidy imports and add intl for formatting
- show formatted alarm time, active flag, and snooze duration in note details
- keep text-to-speech integration and chat navigation

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f7c1ff3c8333a97dcaf52452cec9