### PR TITLE
Clean up codex placeholders in lib sources

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
- codex/enable-flutter_localizations-and-update-ui
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
@@ -14,7 +13,6 @@ void main() async {
   await NotificationService().init();
   final settings = SettingsService();
   final themeColor = await settings.loadThemeColor();
- codex/enable-flutter_localizations-and-update-ui
   final fontScale = await settings.loadFontScale();
   runApp(MyApp(themeColor: themeColor, fontScale: fontScale));
 
@@ -22,7 +20,6 @@ void main() async {
 
 class MyApp extends StatefulWidget {
   final Color themeColor;
- codex/enable-flutter_localizations-and-update-ui
   final double fontScale;
   const MyApp({super.key, required this.themeColor, required this.fontScale});
 
@@ -54,7 +51,6 @@ class _MyAppState extends State<MyApp> {
 
   @override
   Widget build(BuildContext context) {
- codex/enable-flutter_localizations-and-update-ui
     return MaterialApp(
       onGenerateTitle: (context) => AppLocalizations.of(context)!.appTitle,
       localizationsDelegates: const [

--- a/lib/models/note.dart
+++ b/lib/models/note.dart
@@ -5,7 +5,6 @@ class Note {
   DateTime? remindAt;
   bool daily;
   bool active;
- codex/add-tag-chips-to-note-list
   List<String> tags;
 
 
@@ -16,7 +15,6 @@ class Note {
     this.remindAt,
     this.daily = false,
     this.active = false,
- codex/add-tag-chips-to-note-list
     this.tags = const [],
 
   });
@@ -26,12 +24,9 @@ class Note {
         id: j['id'],
         title: j['title'],
         content: j['content'],
-codex/implement-note-repository-and-provider
         alarmTime: j['alarmTime'] != null ? DateTime.parse(j['alarmTime']) : null,
- codex/expand-note-model-with-new-fields
         daily: j['daily'] ?? false,
         active: j['active'] ?? false,
- codex/add-tag-chips-to-note-list
         tags: (j['tags'] as List<dynamic>? ?? []).cast<String>(),
 
       );
@@ -40,11 +35,9 @@ codex/implement-note-repository-and-provider
         'id': id,
         'title': title,
         'content': content,
- codex/update-homescreenstate-to-manage-notes
         'remindAt': remindAt?.toIso8601String(),
         'daily': daily,
         'active': active,
- codex/add-tag-chips-to-note-list
         'tags': tags,
 
       };

--- a/lib/providers/note_provider.dart
+++ b/lib/providers/note_provider.dart
@@ -1,4 +1,3 @@
- codex/convert-notedetailscreen-to-statefulwidget
 
 import 'package:flutter/foundation.dart';
 
@@ -9,7 +8,6 @@ class NoteProvider extends ChangeNotifier {
   final NoteRepository _repository;
   List<Note> _notes = [];
 
- codex/convert-notedetailscreen-to-statefulwidget
   NoteProvider({NoteRepository? repository})
       : _repository = repository ?? NoteRepository();
 
@@ -27,7 +25,6 @@ class NoteProvider extends ChangeNotifier {
     notifyListeners();
   }
 
- codex/convert-notedetailscreen-to-statefulwidget
   Future<void> updateNote(Note note) async {
     final index = _notes.indexWhere((n) => n.id == note.id);
     if (index != -1) {
@@ -44,5 +41,4 @@ class NoteProvider extends ChangeNotifier {
     notifyListeners();
   }
 }
- codex/convert-notedetailscreen-to-statefulwidget
 

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,11 +1,8 @@
 import 'package:flutter/material.dart';
- codex/enable-flutter_localizations-and-update-ui
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'package:intl/intl.dart';
- codex/expand-note-model-with-new-fields
 import 'package:lottie/lottie.dart';
- codex/convert-notedetailscreen-to-statefulwidget
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:provider/provider.dart';
 
@@ -39,7 +36,6 @@ class _HomeScreenState extends State<HomeScreen> {
   static const _platform = MethodChannel('notes_reminder_app/actions');
 
   String _mascotPath = 'assets/lottie/mascot.json';
- codex/convert-notedetailscreen-to-statefulwidget
 
   DateTime today = DateTime.now();
   final _db = DbService();
@@ -49,7 +45,6 @@ class _HomeScreenState extends State<HomeScreen> {
   void initState() {
     super.initState();
     _loadMascot();
- codex/implement-secure-storage-and-authentication
     _loadNotes();
 
   }
@@ -69,12 +64,10 @@ class _HomeScreenState extends State<HomeScreen> {
     final titleCtrl = TextEditingController();
     final contentCtrl = TextEditingController(text: provider.draft);
     DateTime? alarmTime;
- codex/implement-secure-storage-and-authentication
     bool locked = false;
 
     showDialog(
       context: context,
- codex/enable-flutter_localizations-and-update-ui
       builder: (_) => AlertDialog(
         title: Text(AppLocalizations.of(context)!.addNoteReminder),
         content: SingleChildScrollView(
@@ -105,7 +98,6 @@ class _HomeScreenState extends State<HomeScreen> {
                       lastDate: DateTime(now.year + 2),
                       initialDate: now,
                     );
- codex/implement-secure-storage-and-authentication
                     if (picked != null) {
                       final time = await showTimePicker(
                         context: context,
@@ -120,7 +112,6 @@ class _HomeScreenState extends State<HomeScreen> {
                         );
                       }
                     }
- codex/enable-flutter_localizations-and-update-ui
                   }
                 },
                 child: Text(AppLocalizations.of(context)!.selectReminderTime),
@@ -128,7 +119,6 @@ class _HomeScreenState extends State<HomeScreen> {
             ],
 
           ),
- codex/refactor-note-id-and-alarm-time-formatting
         ),
         actions: [
           TextButton(
@@ -153,7 +143,6 @@ class _HomeScreenState extends State<HomeScreen> {
                   scheduledDate: alarmTime!,
 
                 );
- codex/enable-flutter_localizations-and-update-ui
               }
               if (!mounted) return;
               Navigator.pop(context); // FIX Lỗi 1: auto đóng dialog
@@ -166,7 +155,6 @@ class _HomeScreenState extends State<HomeScreen> {
     );
   }
 
- codex/convert-notedetailscreen-to-statefulwidget
   List<Note> notesForDay(DateTime day) {
     final notes = context.read<NoteProvider>().notes;
     return notes
@@ -179,7 +167,6 @@ class _HomeScreenState extends State<HomeScreen> {
         .toList();
   }
 
- codex/add-ask-ai-button-to-notedetailscreen
   @override
   Widget build(BuildContext context) {
     final weekDays = List.generate(7, (i) => today.add(Duration(days: i)));
@@ -269,9 +256,7 @@ class _HomeScreenState extends State<HomeScreen> {
     );
   }
 
- codex/convert-notedetailscreen-to-statefulwidget
   Widget _buildNotesList() {
- codex/enable-flutter_localizations-and-update-ui
     if (notes.isEmpty)
       return Center(child: Text(AppLocalizations.of(context)!.noNotes));
 
@@ -283,10 +268,8 @@ class _HomeScreenState extends State<HomeScreen> {
           child: ListTile(
             leading: note.locked ? const Icon(Icons.lock) : null,
             title: Text(note.title),
- codex/expand-note-model-with-new-fields
 
             subtitle: Text(note.alarmTime != null
- codex/refactor-note-id-and-alarm-time-formatting
                 ? '${note.content}\n⏰ ${DateFormat('HH:mm dd/MM/yyyy').format(note.alarmTime!)}'
                 : note.content),
             onTap: () {
@@ -300,7 +283,6 @@ class _HomeScreenState extends State<HomeScreen> {
             },
             trailing: IconButton(
               icon: const Icon(Icons.delete),
- codex/enable-flutter_localizations-and-update-ui
               tooltip: AppLocalizations.of(context)!.delete,
               onPressed: () => setState(() => notes.removeAt(index)),
 

--- a/lib/screens/note_detail_screen.dart
+++ b/lib/screens/note_detail_screen.dart
@@ -1,15 +1,12 @@
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
- codex/enable-flutter_localizations-and-update-ui
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import '../models/note.dart';
 import '../providers/note_provider.dart';
- codex/convert-notedetailscreen-to-statefulwidget
 import '../services/notification_service.dart';
 
 import '../services/tts_service.dart';
- codex/add-ask-ai-button-to-notedetailscreen
 import '../services/gemini_service.dart';
 
 
@@ -22,7 +19,6 @@ class NoteDetailScreen extends StatefulWidget {
 }
 
 class _NoteDetailScreenState extends State<NoteDetailScreen> {
- codex/convert-notedetailscreen-to-statefulwidget
   late final TextEditingController _titleCtrl;
   late final TextEditingController _contentCtrl;
   final List<String> _attachments = [];
@@ -36,7 +32,6 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
     super.initState();
     _titleCtrl = TextEditingController(text: widget.note.title);
     _contentCtrl = TextEditingController(text: widget.note.content);
- codex/convert-notedetailscreen-to-statefulwidget
     _alarmTime = widget.note.alarmTime;
     _repeat = widget.note.daily ? RepeatInterval.daily : null;
     _snoozeMinutes = widget.note.snoozeMinutes;
@@ -74,7 +69,6 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
   Widget build(BuildContext context) {
     final provider = context.watch<NoteProvider>();
     return Scaffold(
- codex/enable-flutter_localizations-and-update-ui
       appBar: AppBar(title: Text(note.title)),
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/screens/note_list_for_day_screen.dart
+++ b/lib/screens/note_list_for_day_screen.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:intl/intl.dart';
- codex/verify-imports-and-clean-up-code
 import 'package:provider/provider.dart';
 
 import '../models/note.dart';
@@ -9,7 +8,6 @@ import '../providers/note_provider.dart';
 
 import 'note_detail_screen.dart';
 import '../models/note.dart';
- codex/expand-note-model-with-new-fields
 
 
 class NoteListForDayScreen extends StatelessWidget {
@@ -22,7 +20,6 @@ class NoteListForDayScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
- codex/enable-flutter_localizations-and-update-ui
     final title = AppLocalizations.of(context)!
         .scheduleForDate(DateFormat('dd/MM/yyyy').format(date));
     if (notes.isEmpty) {
@@ -34,7 +31,6 @@ class NoteListForDayScreen extends StatelessWidget {
         ),
       );
     }
- codex/verify-imports-and-clean-up-code
 
     return Scaffold(
       appBar: AppBar(title: Text(title)),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -15,7 +15,6 @@ class SettingsScreen extends StatefulWidget {
   State<SettingsScreen> createState() => _SettingsScreenState();
 }
 
- codex/enable-flutter_localizations-and-update-ui
     void _pickColor() async {
       final colors = [Colors.blue, Colors.green, Colors.red, Colors.purple, Colors.orange, Colors.teal];
       await showDialog(
@@ -94,7 +93,6 @@ class SettingsScreen extends StatefulWidget {
     );
   }
 
- codex/implement-secure-storage-and-authentication
   void _toggleAuth(bool v) {
     setState(() => _requireAuth = v);
     _settings.saveRequireAuth(v);
@@ -114,7 +112,6 @@ class SettingsScreen extends StatefulWidget {
             title: Text(AppLocalizations.of(context)!.changeMascot),
             onTap: _pickMascot,
           ),
- codex/enable-flutter_localizations-and-update-ui
           ListTile(
             title: Text(AppLocalizations.of(context)!.fontSize),
             onTap: () async {

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 class SettingsService {
   static const _kThemeColor = 'theme_color';
   static const _kMascotPath = 'mascot_path';
- codex/enable-flutter_localizations-and-update-ui
   static const _kFontScale = 'font_scale';
 
 
@@ -29,7 +28,6 @@ class SettingsService {
     return sp.getString(_kMascotPath) ?? 'assets/lottie/mascot.json';
   }
 
- codex/enable-flutter_localizations-and-update-ui
   Future<void> saveFontScale(double scale) async {
     final sp = await SharedPreferences.getInstance();
     await sp.setDouble(_kFontScale, scale);


### PR DESCRIPTION
## Summary
- remove leftover `codex/` markers from Dart files in `lib`

## Testing
- `flutter analyze` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ba20396c748333b1b7e346c6ba0a68