### PR TITLE
refactor: expand note model and persistence

### DIFF
--- a/lib/models/note.dart
+++ b/lib/models/note.dart
@@ -1,59 +1,92 @@
 class Note {
-
-
-
   final String id;
   final String title;
   final String content;
-  final DateTime? remindAt;
+  final DateTime? alarmTime;
   final bool daily;
   final bool active;
   final List<String> tags;
+  final List<String> attachments;
+  final bool locked;
   final int snoozeMinutes;
+  final DateTime? updatedAt;
 
   const Note({
     required this.id,
-
-
-
     required this.title,
     required this.content,
     this.alarmTime,
     this.daily = false,
     this.active = false,
-
     this.tags = const [],
+    this.attachments = const [],
+    this.locked = false,
     this.snoozeMinutes = 0,
+    this.updatedAt,
   });
 
-  factory Note.fromJson(Map<String, dynamic> j) => Note(
+  Note copyWith({
+    String? id,
+    String? title,
+    String? content,
+    DateTime? alarmTime,
+    bool? daily,
+    bool? active,
+    List<String>? tags,
+    List<String>? attachments,
+    bool? locked,
+    int? snoozeMinutes,
+    DateTime? updatedAt,
+  }) {
+    return Note(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      content: content ?? this.content,
+      alarmTime: alarmTime ?? this.alarmTime,
+      daily: daily ?? this.daily,
+      active: active ?? this.active,
+      tags: tags ?? this.tags,
+      attachments: attachments ?? this.attachments,
+      locked: locked ?? this.locked,
+      snoozeMinutes: snoozeMinutes ?? this.snoozeMinutes,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
 
-
-        id: j['id'] as String,
-        title: j['title'] as String,
-        content: j['content'] as String,
-        remindAt: j['remindAt'] != null
-            ? DateTime.parse(j['remindAt'])
-            : null,
-
-
-        daily: j['daily'] ?? false,
-        active: j['active'] ?? false,
-        tags: (j['tags'] as List<dynamic>? ?? []).cast<String>(),
-        snoozeMinutes: j['snoozeMinutes'] ?? 0,
-
-      );
+  factory Note.fromJson(Map<String, dynamic> json) {
+    return Note(
+      id: json['id'] as String,
+      title: json['title'] as String,
+      content: json['content'] as String,
+      alarmTime: json['alarmTime'] != null
+          ? DateTime.parse(json['alarmTime'])
+          : json['remindAt'] != null
+              ? DateTime.parse(json['remindAt'])
+              : null,
+      daily: json['daily'] ?? false,
+      active: json['active'] ?? false,
+      tags: (json['tags'] as List<dynamic>? ?? []).cast<String>(),
+      attachments:
+          (json['attachments'] as List<dynamic>? ?? []).cast<String>(),
+      locked: json['locked'] ?? false,
+      snoozeMinutes: json['snoozeMinutes'] ?? 0,
+      updatedAt: json['updatedAt'] != null
+          ? DateTime.parse(json['updatedAt'])
+          : null,
+    );
+  }
 
   Map<String, dynamic> toJson() => {
         'id': id,
         'title': title,
         'content': content,
-
-        'remindAt': remindAt?.toIso8601String(),
+        'alarmTime': alarmTime?.toIso8601String(),
         'daily': daily,
         'active': active,
         'tags': tags,
+        'attachments': attachments,
+        'locked': locked,
         'snoozeMinutes': snoozeMinutes,
+        'updatedAt': updatedAt?.toIso8601String(),
       };
 }
-

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -145,6 +145,8 @@ class _HomeScreenState extends State<HomeScreen> {
                 title: titleCtrl.text,
                 content: contentCtrl.text,
                 alarmTime: alarmTime,
+                locked: locked,
+                updatedAt: DateTime.now(),
               );
               setState(() => _notes.add(note));
 

--- a/lib/services/db_service.dart
+++ b/lib/services/db_service.dart
@@ -8,7 +8,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../models/note.dart';
 
 class DbService {
-  static const _kNotes = 'notes_v1';
+  static const _kNotes = 'notes_v2';
+  static const _kLegacyNotes = 'notes_v1';
   static const _kEncKey = 'enc_key';
 
   final _secure = const FlutterSecureStorage();
@@ -26,7 +27,8 @@ class DbService {
 
   Future<List<Note>> getNotes() async {
     final sp = await SharedPreferences.getInstance();
-    final raw = sp.getString(_kNotes);
+    var raw = sp.getString(_kNotes);
+    raw ??= sp.getString(_kLegacyNotes);
     if (raw == null) return [];
     final key = await _getKey();
     final iv = encrypt.IV.fromLength(16);

--- a/test/note_repository_test.dart
+++ b/test/note_repository_test.dart
@@ -25,6 +25,9 @@ void main() {
         id: '1',
         title: 't',
         content: 'c',
+        alarmTime: DateTime(2024, 1, 1),
+        attachments: ['a'],
+        locked: true,
         snoozeMinutes: 10,
       );
       await repo.saveNotes([note]);
@@ -32,6 +35,9 @@ void main() {
       expect(notes.length, 1);
       expect(notes.first.title, 't');
       expect(notes.first.snoozeMinutes, 10);
+      expect(notes.first.locked, true);
+      expect(notes.first.attachments, ['a']);
+      expect(notes.first.alarmTime, DateTime(2024, 1, 1));
     });
 
     test('updateNote persists changes', () async {
@@ -40,6 +46,7 @@ void main() {
         id: '1',
         title: 't',
         content: 'c',
+        attachments: ['a'],
         snoozeMinutes: 5,
       );
       await repo.saveNotes([note]);
@@ -47,6 +54,7 @@ void main() {
         id: '1',
         title: 't2',
         content: 'c2',
+        attachments: ['b'],
         snoozeMinutes: 15,
       );
       await repo.updateNote(updated);
@@ -55,6 +63,7 @@ void main() {
       expect(notes.first.title, 't2');
       expect(notes.first.content, 'c2');
       expect(notes.first.snoozeMinutes, 15);
+      expect(notes.first.attachments, ['b']);
     });
   });
 }


### PR DESCRIPTION
## Summary
- expand `Note` model with alarmTime field consistency, attachments, locked, updatedAt, and copyWith
- update note detail and home screens to use new immutable pattern
- bump DB service storage key and handle legacy data
- broaden repository tests for new note fields

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba31f8fdc88333a6cd4d350e845d01