### PR TITLE
Refactor HomeScreen to use NoteProvider

### DIFF
--- a/lib/providers/note_provider.dart
+++ b/lib/providers/note_provider.dart
@@ -7,11 +7,13 @@ import '../services/note_repository.dart';
 class NoteProvider extends ChangeNotifier {
   final NoteRepository _repository;
   List<Note> _notes = [];
+  String _draft = '';
 
   NoteProvider({NoteRepository? repository})
       : _repository = repository ?? NoteRepository();
 
   List<Note> get notes => List.unmodifiable(_notes);
+  String get draft => _draft;
 
 
   Future<void> loadNotes() async {
@@ -38,6 +40,11 @@ class NoteProvider extends ChangeNotifier {
   Future<void> removeNoteAt(int index) async {
     _notes.removeAt(index);
     await _repository.saveNotes(_notes);
+    notifyListeners();
+  }
+
+  void setDraft(String value) {
+    _draft = value;
     notifyListeners();
   }
 }


### PR DESCRIPTION
## Summary
- Clean up HomeScreen imports and state handling
- Use NoteProvider for loading, adding, and deleting notes
- Add draft support to NoteProvider for VoiceToNote integration

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba31fddf3c8333b441107de8b55f3b