### PR TITLE
fix: remove duplicate shared_preferences import

### DIFF
--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -1,4 +1,3 @@
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -36,6 +35,5 @@ class SettingsService {
   Future<double> loadFontScale() async {
     final sp = await SharedPreferences.getInstance();
     return sp.getDouble(_kFontScale) ?? 1.0;
-
   }
 }


### PR DESCRIPTION
## Summary
- remove duplicate shared_preferences import from settings_service
- tidy formatting in settings_service

## Testing
- `dart format lib/services/settings_service.dart` *(fails: command not found: dart)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68ba31fe9c788333804a0bb415c9301f