### PR TITLE
Use per-note IV for encryption

### DIFF
--- a/test/note_repository_test.dart
+++ b/test/note_repository_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
@@ -28,6 +30,12 @@ void main() {
         snoozeMinutes: 10,
       );
       await repo.saveNotes([note]);
+      final sp = await SharedPreferences.getInstance();
+      final raw = sp.getString('notes_v1');
+      final stored =
+          (jsonDecode(raw!) as List).cast<Map<String, dynamic>>().first;
+      expect(stored['iv'], isNotEmpty);
+      expect(stored['content'], isNot('c'));
       final notes = await repo.getNotes();
       expect(notes.length, 1);
       expect(notes.first.title, 't');


### PR DESCRIPTION
## Summary
- generate a unique IV for each note and persist it alongside the ciphertext
- read IV from storage when decrypting notes
- adjust tests to verify IV is stored with encrypted content

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ba3200e28083339b476ec5942d25da