### PR TITLE
chore: add file_picker dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
 
   encrypt: ^5.0.1
   flutter_secure_storage: ^9.0.0
+  file_picker: ^6.1.1
 
 
 


### PR DESCRIPTION
## Summary
- add file_picker dependency to pubspec

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba320315b0833398947bae88873bcf