### PR TITLE
feat: add tag selector for notes

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -29,5 +29,6 @@
   "addNoteTooltip": "Add note",
   "settingsTooltip": "Open settings",
   "delete": "Delete",
-  "timeLabel": "Time"
+  "timeLabel": "Time",
+  "tagsLabel": "Tags"
 }

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -29,5 +29,6 @@
   "addNoteTooltip": "Thêm ghi chú",
   "settingsTooltip": "Mở cài đặt",
   "delete": "Xóa",
-  "timeLabel": "Thời gian"
+  "timeLabel": "Thời gian",
+  "tagsLabel": "Tag"
 }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -8,6 +8,7 @@ import '../models/note.dart';
 import '../providers/note_provider.dart';
 import '../services/notification_service.dart';
 import '../services/settings_service.dart';
+import '../widgets/tag_selector.dart';
 import 'note_detail_screen.dart';
 import 'note_list_for_day_screen.dart';
 import 'settings_screen.dart';
@@ -50,6 +51,9 @@ class _HomeScreenState extends State<HomeScreen> {
     final titleCtrl = TextEditingController();
     final contentCtrl = TextEditingController(text: provider.draft);
     DateTime? alarmTime;
+    var tags = <String>[];
+    final availableTags =
+        provider.notes.expand((n) => n.tags).toSet().toList();
 
     showDialog(
       context: context,
@@ -70,6 +74,14 @@ class _HomeScreenState extends State<HomeScreen> {
                 decoration: InputDecoration(
                   labelText: AppLocalizations.of(context)!.contentLabel,
                 ),
+              ),
+              const SizedBox(height: 12),
+              TagSelector(
+                availableTags: availableTags,
+                selectedTags: tags,
+                onChanged: (v) => tags = v,
+                allowCreate: true,
+                label: AppLocalizations.of(context)!.tagsLabel,
               ),
               const SizedBox(height: 12),
               ElevatedButton(
@@ -115,6 +127,7 @@ class _HomeScreenState extends State<HomeScreen> {
                 title: titleCtrl.text,
                 content: contentCtrl.text,
                 alarmTime: alarmTime,
+                tags: tags,
                 locked: locked,
                 updatedAt: DateTime.now(),
               );

--- a/lib/screens/note_detail_screen.dart
+++ b/lib/screens/note_detail_screen.dart
@@ -10,6 +10,7 @@ import '../services/notification_service.dart';
 import '../services/tts_service.dart';
 import '../services/gemini_service.dart';
 import 'chat_screen.dart';
+import '../widgets/tag_selector.dart';
 
 
 class NoteDetailScreen extends StatefulWidget {
@@ -78,6 +79,19 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
           ),
           const Divider(),
           ..._attachments.map((a) => ListTile(title: Text(a.split('/').last))),
+          const SizedBox(height: 8),
+          TagSelector(
+            availableTags: context
+                .watch<NoteProvider>()
+                .notes
+                .expand((n) => n.tags)
+                .toSet()
+                .toList(),
+            selectedTags: _tags,
+            onChanged: (v) => setState(() => _tags = v),
+            allowCreate: true,
+            label: AppLocalizations.of(context)!.tagsLabel,
+          ),
           const Divider(),
           Expanded(child: ChatScreen(initialMessage: _contentCtrl.text)),
         ],


### PR DESCRIPTION
## Summary
- allow tagging when creating notes
- support editing tags in note detail
- add localization for tags label

## Testing
- `flutter format lib/screens/home_screen.dart lib/screens/note_detail_screen.dart lib/l10n/app_vi.arb lib/l10n/app_en.arb` (command not found: flutter)
- `flutter gen-l10n` (command not found: flutter)
- `flutter test` (command not found: flutter)


------
https://chatgpt.com/codex/tasks/task_e_68ba4224ff4883339b31b90642dc635d