### PR TITLE
Add locked flag to note creation dialog

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -56,6 +56,8 @@ class _HomeScreenState extends State<HomeScreen> {
     final availableTags =
         provider.notes.expand((n) => n.tags).toSet().toList();
 
+    bool locked = false;
+
     showDialog(
       context: context,
       builder: (_) => StatefulBuilder(


### PR DESCRIPTION
## Summary
- declare and manage a `locked` flag in the add note dialog so notes can be marked as locked

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba494764b0833380aa2dff9c4c5c05