### PR TITLE
Add auth switch to settings

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -31,8 +31,8 @@
   "delete": "Delete",
   "timeLabel": "Time",
 
-  "tagsLabel": "Tags"
-
+  "tagsLabel": "Tags",
+  "requireAuth": "Require authentication",
   "lockNote": "Lock note"
 
 }

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -31,8 +31,8 @@
   "delete": "Xóa",
   "timeLabel": "Thời gian",
 
-  "tagsLabel": "Tag"
-
+  "tagsLabel": "Tag",
+  "requireAuth": "Yêu cầu xác thực",
   "lockNote": "Khóa ghi chú"
 
 }

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -22,6 +22,16 @@ class _SettingsScreenState extends State<SettingsScreen> {
   final SettingsService _settings = SettingsService();
   bool _requireAuth = false;
 
+  @override
+  void initState() {
+    super.initState();
+    _settings.loadRequireAuth().then((v) {
+      if (mounted) {
+        setState(() => _requireAuth = v);
+      }
+    });
+  }
+
   Future<void> _pickColor() async {
     final colors = [
       Colors.blue,
@@ -145,6 +155,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
           ListTile(
             title: Text(AppLocalizations.of(context)!.fontSize),
             onTap: _changeFontScale,
+          ),
+          SwitchListTile(
+            title: Text(AppLocalizations.of(context)!.requireAuth),
+            value: _requireAuth,
+            onChanged: _toggleAuth,
           ),
         ],
       ),


### PR DESCRIPTION
## Summary
- add require authentication toggle to settings
- load saved auth preference on startup
- localize new require authentication label

## Testing
- `flutter test` *(fails: command not found: flutter)*


------
https://chatgpt.com/codex/tasks/task_e_68ba494b6dc4833389911ebe8cf05f73