### PR TITLE
Fix duplicate locked variable in note dialog

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -57,8 +57,6 @@ class _HomeScreenState extends State<HomeScreen> {
     final availableTags =
         provider.notes.expand((n) => n.tags).toSet().toList();
 
-    bool locked = false;
-
     showDialog(
       context: context,
       builder: (_) => StatefulBuilder(


### PR DESCRIPTION
## Summary
- remove redundant `locked` state variable in HomeScreen's `_addNote`

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4d8251f48333a646cdf422a8d2c4