### PR TITLE
Localize tag labels and add addTag localization

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -32,6 +32,7 @@
   "timeLabel": "Time",
 
   "tagsLabel": "Tags",
+  "addTag": "Add tag",
   "requireAuth": "Require authentication",
   "lockNote": "Lock note"
 

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -32,6 +32,7 @@
   "timeLabel": "Thời gian",
 
   "tagsLabel": "Tag",
+  "addTag": "Thêm tag",
   "requireAuth": "Yêu cầu xác thực",
   "lockNote": "Khóa ghi chú"
 

--- a/lib/screens/note_detail_screen.dart
+++ b/lib/screens/note_detail_screen.dart
@@ -114,7 +114,7 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
               selectedTags: _tags,
               allowCreate: true,
               onChanged: (v) => setState(() => _tags = v),
-              label: 'Tags',
+              label: AppLocalizations.of(context)!.tagsLabel,
             ),
             const SizedBox(height: 12),
             Row(

--- a/lib/widgets/tag_selector.dart
+++ b/lib/widgets/tag_selector.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class TagSelector extends StatefulWidget {
   final List<String> availableTags;
@@ -64,7 +65,9 @@ class _TagSelectorState extends State<TagSelector> {
         if (widget.allowCreate)
           TextField(
             controller: _ctrl,
-            decoration: const InputDecoration(labelText: 'Thêm tag'),
+            decoration: InputDecoration(
+              labelText: AppLocalizations.of(context)!.addTag,
+            ),
             onSubmitted: _addTag,
           ),
       ],


### PR DESCRIPTION
## Summary
- Localize tags label in note detail screen
- Use localized "Add tag" label in tag selector
- Add English and Vietnamese translations for new label

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4d88441883338b5f214e50ee6237