### PR TITLE
Add repeat interval and snooze controls to note detail screen

### DIFF
--- a/lib/models/note.dart
+++ b/lib/models/note.dart
@@ -1,8 +1,11 @@
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
 class Note {
   final String id;
   final String title;
   final String content;
   final DateTime? alarmTime;
+  final RepeatInterval? repeatInterval;
   final bool daily;
   final bool active;
   final List<String> tags;
@@ -16,6 +19,7 @@ class Note {
     required this.title,
     required this.content,
     this.alarmTime,
+    this.repeatInterval,
     this.daily = false,
     this.active = false,
     this.tags = const [],
@@ -30,6 +34,7 @@ class Note {
     String? title,
     String? content,
     DateTime? alarmTime,
+    RepeatInterval? repeatInterval,
     bool? daily,
     bool? active,
     List<String>? tags,
@@ -43,6 +48,7 @@ class Note {
       title: title ?? this.title,
       content: content ?? this.content,
       alarmTime: alarmTime ?? this.alarmTime,
+      repeatInterval: repeatInterval ?? this.repeatInterval,
       daily: daily ?? this.daily,
       active: active ?? this.active,
       tags: tags ?? this.tags,
@@ -63,6 +69,8 @@ class Note {
           : json['remindAt'] != null
               ? DateTime.parse(json['remindAt'])
               : null,
+      repeatInterval:
+          _repeatIntervalFromString(json['repeatInterval'] as String?),
       daily: json['daily'] ?? false,
       active: json['active'] ?? false,
       tags: (json['tags'] as List<dynamic>? ?? []).cast<String>(),
@@ -81,6 +89,7 @@ class Note {
         'title': title,
         'content': content,
         'alarmTime': alarmTime?.toIso8601String(),
+        'repeatInterval': repeatInterval?.toString().split('.').last,
         'daily': daily,
         'active': active,
         'tags': tags,
@@ -89,4 +98,12 @@ class Note {
         'snoozeMinutes': snoozeMinutes,
         'updatedAt': updatedAt?.toIso8601String(),
       };
+}
+
+RepeatInterval? _repeatIntervalFromString(String? value) {
+  if (value == null) return null;
+  for (final r in RepeatInterval.values) {
+    if (r.toString().split('.').last == value) return r;
+  }
+  return null;
 }

--- a/lib/screens/note_detail_screen.dart
+++ b/lib/screens/note_detail_screen.dart
@@ -38,7 +38,8 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
     _titleCtrl = TextEditingController(text: widget.note.title);
     _contentCtrl = TextEditingController(text: widget.note.content);
     _alarmTime = widget.note.alarmTime;
-    _repeat = widget.note.daily ? RepeatInterval.daily : null;
+    _repeat =
+        widget.note.repeatInterval ?? (widget.note.daily ? RepeatInterval.daily : null);
     _snoozeMinutes = widget.note.snoozeMinutes;
     _attachments = List.from(widget.note.attachments);
     _tags = List.from(widget.note.tags);
@@ -107,6 +108,49 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
                     child: Text(DateFormat('HH:mm dd/MM/yyyy').format(_alarmTime!)),
                   ),
               ],
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                const Text('Repeat:'),
+                const SizedBox(width: 8),
+                DropdownButton<RepeatInterval?>(
+                  value: _repeat,
+                  onChanged: (value) => setState(() => _repeat = value),
+                  items: const [
+                    DropdownMenuItem<RepeatInterval?> (
+                      value: null,
+                      child: Text('None'),
+                    ),
+                    DropdownMenuItem<RepeatInterval?> (
+                      value: RepeatInterval.everyMinute,
+                      child: Text('Every minute'),
+                    ),
+                    DropdownMenuItem<RepeatInterval?> (
+                      value: RepeatInterval.hourly,
+                      child: Text('Hourly'),
+                    ),
+                    DropdownMenuItem<RepeatInterval?> (
+                      value: RepeatInterval.daily,
+                      child: Text('Daily'),
+                    ),
+                    DropdownMenuItem<RepeatInterval?> (
+                      value: RepeatInterval.weekly,
+                      child: Text('Weekly'),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Text('Snooze: $_snoozeMinutes min'),
+            Slider(
+              value: _snoozeMinutes.toDouble(),
+              min: 1,
+              max: 60,
+              divisions: 59,
+              label: _snoozeMinutes.toString(),
+              onChanged: (v) => setState(() => _snoozeMinutes = v.round()),
             ),
             const SizedBox(height: 12),
             TagSelector(
@@ -182,6 +226,7 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
       tags: _tags,
       attachments: _attachments,
       alarmTime: _alarmTime,
+      repeatInterval: _repeat,
       daily: _repeat == RepeatInterval.daily,
       active: true,
       snoozeMinutes: _snoozeMinutes,


### PR DESCRIPTION
## Summary
- add repeat interval dropdown and snooze slider to NoteDetailScreen
- store selected repeat interval in Note model
- persist snooze duration and repeat settings when saving notes

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4d848d1c8333ac68f8add2ec3bc4