### PR TITLE
Localize repeat and attachment labels

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -31,6 +31,19 @@
   "delete": "Delete",
   "timeLabel": "Time",
 
+  "repeatLabel": "Repeat:",
+  "repeatNone": "None",
+  "repeatEveryMinute": "Every minute",
+  "repeatHourly": "Hourly",
+  "repeatDaily": "Daily",
+  "repeatWeekly": "Weekly",
+  "snoozeLabel": "Snooze: {minutes} min",
+  "snoozeLabel@placeholders": {
+    "minutes": {}
+  },
+  "imageLabel": "Image",
+  "audioLabel": "Audio",
+
   "tagsLabel": "Tags",
   "addTag": "Add tag",
   "requireAuth": "Require authentication",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -31,6 +31,19 @@
   "delete": "Xóa",
   "timeLabel": "Thời gian",
 
+  "repeatLabel": "Lặp lại:",
+  "repeatNone": "Không",
+  "repeatEveryMinute": "Mỗi phút",
+  "repeatHourly": "Hàng giờ",
+  "repeatDaily": "Hàng ngày",
+  "repeatWeekly": "Hàng tuần",
+  "snoozeLabel": "Báo lại: {minutes} phút",
+  "snoozeLabel@placeholders": {
+    "minutes": {}
+  },
+  "imageLabel": "Ảnh",
+  "audioLabel": "Âm thanh",
+
   "tagsLabel": "Tag",
   "addTag": "Thêm tag",
   "requireAuth": "Yêu cầu xác thực",

--- a/lib/screens/note_detail_screen.dart
+++ b/lib/screens/note_detail_screen.dart
@@ -112,38 +112,38 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
             const SizedBox(height: 12),
             Row(
               children: [
-                const Text('Repeat:'),
+                Text(AppLocalizations.of(context)!.repeatLabel),
                 const SizedBox(width: 8),
                 DropdownButton<RepeatInterval?>(
                   value: _repeat,
                   onChanged: (value) => setState(() => _repeat = value),
-                  items: const [
+                  items: [
                     DropdownMenuItem<RepeatInterval?> (
                       value: null,
-                      child: Text('None'),
+                      child: Text(AppLocalizations.of(context)!.repeatNone),
                     ),
                     DropdownMenuItem<RepeatInterval?> (
                       value: RepeatInterval.everyMinute,
-                      child: Text('Every minute'),
+                      child: Text(AppLocalizations.of(context)!.repeatEveryMinute),
                     ),
                     DropdownMenuItem<RepeatInterval?> (
                       value: RepeatInterval.hourly,
-                      child: Text('Hourly'),
+                      child: Text(AppLocalizations.of(context)!.repeatHourly),
                     ),
                     DropdownMenuItem<RepeatInterval?> (
                       value: RepeatInterval.daily,
-                      child: Text('Daily'),
+                      child: Text(AppLocalizations.of(context)!.repeatDaily),
                     ),
                     DropdownMenuItem<RepeatInterval?> (
                       value: RepeatInterval.weekly,
-                      child: Text('Weekly'),
+                      child: Text(AppLocalizations.of(context)!.repeatWeekly),
                     ),
                   ],
                 ),
               ],
             ),
             const SizedBox(height: 12),
-            Text('Snooze: $_snoozeMinutes min'),
+            Text(AppLocalizations.of(context)!.snoozeLabel(_snoozeMinutes)),
             Slider(
               value: _snoozeMinutes.toDouble(),
               min: 1,
@@ -166,13 +166,13 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
                 ElevatedButton.icon(
                   onPressed: _pickImage,
                   icon: const Icon(Icons.image),
-                  label: const Text('Image'),
+                  label: Text(AppLocalizations.of(context)!.imageLabel),
                 ),
                 const SizedBox(width: 8),
                 ElevatedButton.icon(
                   onPressed: _pickAudio,
                   icon: const Icon(Icons.audiotrack),
-                  label: const Text('Audio'),
+                  label: Text(AppLocalizations.of(context)!.audioLabel),
                 ),
               ],
             ),


### PR DESCRIPTION
## Summary
- Localize repeat interval dropdown, snooze display, and image/audio attachment buttons.
- Add English and Vietnamese translations for new repeat, snooze, and attachment labels.

## Testing
- `flutter gen-l10n` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4f9b28448333bd5bdc8412b2092d