### PR TITLE
Localize voice to note screen

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -34,6 +34,13 @@
   "tagsLabel": "Tags",
   "addTag": "Add tag",
   "requireAuth": "Require authentication",
-  "lockNote": "Lock note"
-
+  "lockNote": "Lock note",
+  "voiceToNote": "Voice To Note",
+  "stop": "Stop",
+  "speak": "Speak",
+  "convertToNote": "Convert to note",
+  "convertSpeechPrompt": "Convert the following speech into a note: {recognized}",
+  "convertSpeechPrompt@placeholders": {
+    "recognized": {}
+  }
 }

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -34,6 +34,13 @@
   "tagsLabel": "Tag",
   "addTag": "Thêm tag",
   "requireAuth": "Yêu cầu xác thực",
-  "lockNote": "Khóa ghi chú"
-
+  "lockNote": "Khóa ghi chú",
+  "voiceToNote": "Giọng nói thành ghi chú",
+  "stop": "Dừng",
+  "speak": "Nói",
+  "convertToNote": "Chuyển thành ghi chú",
+  "convertSpeechPrompt": "Chuyển đoạn nói sau thành ghi chú: {recognized}",
+  "convertSpeechPrompt@placeholders": {
+    "recognized": {}
+  }
 }

--- a/lib/screens/voice_to_note_screen.dart
+++ b/lib/screens/voice_to_note_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 import 'package:speech_to_text/speech_to_text.dart' as stt;
 
@@ -36,8 +37,9 @@ class _VoiceToNoteScreenState extends State<VoiceToNoteScreen> {
   Future<void> _convertToNote() async {
     if (_recognized.isEmpty) return;
     setState(() => _isProcessing = true);
-    final reply = await GeminiService()
-        .chat('Chuyển đoạn nói sau thành ghi chú: $_recognized');
+    final prompt = AppLocalizations.of(context)!
+        .convertSpeechPrompt(_recognized);
+    final reply = await GeminiService().chat(prompt);
     if (!mounted) return;
     context.read<NoteProvider>().setDraft(reply);
     setState(() => _isProcessing = false);
@@ -53,7 +55,8 @@ class _VoiceToNoteScreenState extends State<VoiceToNoteScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Voice To Note')),
+      appBar: AppBar(
+          title: Text(AppLocalizations.of(context)!.voiceToNote)),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(
@@ -66,12 +69,15 @@ class _VoiceToNoteScreenState extends State<VoiceToNoteScreen> {
               children: [
                 ElevatedButton(
                   onPressed: _toggleListening,
-                  child: Text(_isListening ? 'Dừng' : 'Nói'),
+                  child: Text(_isListening
+                      ? AppLocalizations.of(context)!.stop
+                      : AppLocalizations.of(context)!.speak),
                 ),
                 const SizedBox(width: 8),
                 ElevatedButton(
                   onPressed: _isProcessing ? null : _convertToNote,
-                  child: const Text('Chuyển thành ghi chú'),
+                  child:
+                      Text(AppLocalizations.of(context)!.convertToNote),
                 ),
               ],
             )


### PR DESCRIPTION
## Summary
- replace hardcoded text in voice-to-note UI with localization keys
- add English & Vietnamese translations
- localize Gemini prompt for speech conversion

## Testing
- `flutter --version` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4fa2e2488333a9d0ddb3cb69b15d