### PR TITLE
Add TTS read button to note detail screen

### DIFF
--- a/lib/screens/note_detail_screen.dart
+++ b/lib/screens/note_detail_screen.dart
@@ -30,6 +30,7 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
   RepeatInterval? _repeat;
   int _snoozeMinutes = 5;
   late List<String> _tags;
+  final _ttsService = TTSService();
 
 
   @override
@@ -60,6 +61,10 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
     }
   }
 
+  Future<void> _readNote() async {
+    await _ttsService.speak(_contentCtrl.text);
+  }
+
   @override
   Widget build(BuildContext context) {
     final provider = context.watch<NoteProvider>();
@@ -69,6 +74,10 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
       appBar: AppBar(
         title: Text(widget.note.title),
         actions: [
+          TextButton(
+            onPressed: _readNote,
+            child: const Text('Đọc Note'),
+          ),
           IconButton(
             icon: const Icon(Icons.save),
             onPressed: _save,

--- a/test/note_detail_screen_test.dart
+++ b/test/note_detail_screen_test.dart
@@ -8,7 +8,7 @@ import 'package:notes_reminder_app/screens/note_detail_screen.dart';
 
 void main() {
   testWidgets('display note and trigger TTS', (tester) async {
-    final note = Note(id: '1', title: 'title', content: 'content');
+    const note = Note(id: '1', title: 'title', content: 'content');
 
     const channel = MethodChannel('flutter_tts');
     final calls = <MethodCall>[];
@@ -20,7 +20,7 @@ void main() {
     await tester.pumpWidget(
       ChangeNotifierProvider(
         create: (_) => NoteProvider(),
-        child: const MaterialApp(home: NoteDetailScreen(note: note)),
+        child: MaterialApp(home: NoteDetailScreen(note: note)),
       ),
     );
 


### PR DESCRIPTION
## Summary
- enable text-to-speech for notes with a "Đọc Note" button
- update note detail widget test for the TTS button

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4fa6f6e083338d6f12f1023d8532