### PR TITLE
Localize read note button

### DIFF
--- a/lib/screens/note_detail_screen.dart
+++ b/lib/screens/note_detail_screen.dart
@@ -76,7 +76,7 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
         actions: [
           TextButton(
             onPressed: _readNote,
-            child: const Text('Đọc Note'),
+            child: Text(AppLocalizations.of(context)!.readNote),
           ),
           IconButton(
             icon: const Icon(Icons.save),


### PR DESCRIPTION
## Summary
- Use localized string for the note reading button

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68ba56e359a08333801635a1aaa0eedb