### PR TITLE
Dispose controllers in note detail screen

### DIFF
--- a/lib/screens/note_detail_screen.dart
+++ b/lib/screens/note_detail_screen.dart
@@ -46,6 +46,13 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
     _tags = List.from(widget.note.tags);
   }
 
+  @override
+  void dispose() {
+    _titleCtrl.dispose();
+    _contentCtrl.dispose();
+    super.dispose();
+  }
+
   Future<void> _pickImage() async {
     final picker = ImagePicker();
     final file = await picker.pickImage(source: ImageSource.gallery);


### PR DESCRIPTION
## Summary
- properly dispose NoteDetailScreen text controllers

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba56e659048333ae2a170ad9d79a57