### PR TITLE
Dispose controller in TagSelector

### DIFF
--- a/lib/widgets/tag_selector.dart
+++ b/lib/widgets/tag_selector.dart
@@ -73,5 +73,11 @@ class _TagSelectorState extends State<TagSelector> {
       ],
     );
   }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
 }
 


### PR DESCRIPTION
## Summary
- ensure TagSelector's TextEditingController is properly disposed

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba56eeb4388333a825f2f9043d3d5a