### PR TITLE
Localize Gemini service messages

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -55,5 +55,11 @@
   "convertSpeechPrompt": "Convert the following speech into a note: {recognized}",
   "convertSpeechPrompt@placeholders": {
     "recognized": {}
+  },
+  "geminiApiKeyNotConfigured": "Gemini API key is not configured.",
+  "noResponse": "No response",
+  "geminiError": "Gemini error: {error}",
+  "geminiError@placeholders": {
+    "error": {}
   }
 }

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -55,5 +55,11 @@
   "convertSpeechPrompt": "Chuyển đoạn nói sau thành ghi chú: {recognized}",
   "convertSpeechPrompt@placeholders": {
     "recognized": {}
+  },
+  "geminiApiKeyNotConfigured": "Chưa cấu hình khóa Gemini API.",
+  "noResponse": "Không có phản hồi",
+  "geminiError": "Lỗi Gemini: {error}",
+  "geminiError@placeholders": {
+    "error": {}
   }
 }

--- a/lib/screens/chat_screen.dart
+++ b/lib/screens/chat_screen.dart
@@ -35,7 +35,8 @@ class _ChatScreenState extends State<ChatScreen> {
     setState(() => _isLoading = true);
 
     try {
-      final reply = await _geminiService.chat(userText);
+      final reply =
+          await _geminiService.chat(userText, AppLocalizations.of(context)!);
       setState(() => _messages.add(Message(reply, false)));
     } catch (e) {
       setState(() =>

--- a/lib/services/gemini_service.dart
+++ b/lib/services/gemini_service.dart
@@ -1,12 +1,13 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class GeminiService {
   static const _apiKey = String.fromEnvironment('GEMINI_API_KEY', defaultValue: '');
   static const _model = 'gemini-1.5-flash-latest';
 
-  Future<String> chat(String userText) async {
-    if (_apiKey.isEmpty) return 'Gemini API key chưa được cấu hình.';
+  Future<String> chat(String userText, AppLocalizations l10n) async {
+    if (_apiKey.isEmpty) return l10n.geminiApiKeyNotConfigured;
 
     final uri = Uri.parse(
       'https://generativelanguage.googleapis.com/v1beta/models/$_model:generateContent?key=$_apiKey',
@@ -26,9 +27,9 @@ class GeminiService {
     if (res.statusCode == 200) {
       final data = jsonDecode(res.body);
       final text = (data['candidates']?[0]?['content']?['parts']?[0]?['text'] ?? '').toString();
-      return text.isEmpty ? 'No response' : text;
+      return text.isEmpty ? l10n.noResponse : text;
     } else {
-      return 'Gemini error: ${res.statusCode} ${res.body}';
+      return l10n.geminiError('${res.statusCode} ${res.body}');
     }
   }
 }


### PR DESCRIPTION
## Summary
- localize Gemini service responses with `AppLocalizations`
- add English and Vietnamese strings for Gemini messages
- update chat screen to provide localization when calling service

## Testing
- ⚠️ `flutter test` *(missing: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5a102aa88333b883ea48d7d964f2