### PR TITLE
Use locale-based TTS language

### DIFF
--- a/lib/screens/note_detail_screen.dart
+++ b/lib/screens/note_detail_screen.dart
@@ -69,7 +69,10 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
   }
 
   Future<void> _readNote() async {
-    await _ttsService.speak(_contentCtrl.text);
+    await _ttsService.speak(
+      _contentCtrl.text,
+      locale: Localizations.localeOf(context),
+    );
   }
 
   @override

--- a/lib/services/tts_service.dart
+++ b/lib/services/tts_service.dart
@@ -1,10 +1,21 @@
+import 'dart:ui';
+
 import 'package:flutter_tts/flutter_tts.dart';
 
 class TTSService {
   final FlutterTts _tts = FlutterTts();
 
-  Future<void> speak(String text) async {
-    await _tts.setLanguage("vi-VN");
+  String _ttsCodeForLocale(Locale locale) {
+    const mapping = {
+      'en': 'en-US',
+      'vi': 'vi-VN',
+    };
+    return mapping[locale.languageCode] ?? locale.toLanguageTag();
+  }
+
+  Future<void> speak(String text, {Locale? locale}) async {
+    final loc = locale ?? PlatformDispatcher.instance.locale;
+    await _tts.setLanguage(_ttsCodeForLocale(loc));
     await _tts.setPitch(1.0);
     await _tts.speak(text);
   }


### PR DESCRIPTION
## Summary
- map app locale to TTS language codes
- allow overriding locale for speech
- have NoteDetailScreen pass its locale to TTS

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5a107c7483339ab5a39207bca292