### PR TITLE
chore: remove gemini service import

### DIFF
--- a/lib/screens/note_detail_screen.dart
+++ b/lib/screens/note_detail_screen.dart
@@ -8,7 +8,6 @@ import '../models/note.dart';
 import '../providers/note_provider.dart';
 import '../services/notification_service.dart';
 import '../services/tts_service.dart';
-import '../services/gemini_service.dart';
 import 'chat_screen.dart';
 import 'package:intl/intl.dart';
 import '../widgets/tag_selector.dart';


### PR DESCRIPTION
## Summary
- remove unused Gemini service import from note detail screen

## Testing
- `FLUTTER_SUPPRESS_ANALYTICS=true /tmp/flutter-sdk/bin/flutter analyze`
- `FLUTTER_SUPPRESS_ANALYTICS=true /tmp/flutter-sdk/bin/flutter analyze --no-pub`

------
https://chatgpt.com/codex/tasks/task_e_68ba5a117cb88333b2ea488cd2e60bee