### PR TITLE
Localize notification channel titles

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -55,5 +55,9 @@
   "convertSpeechPrompt": "Convert the following speech into a note: {recognized}",
   "convertSpeechPrompt@placeholders": {
     "recognized": {}
-  }
+  },
+  "scheduled": "Scheduled",
+  "recurring": "Recurring",
+  "daily": "Daily",
+  "snooze": "Snooze"
 }

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -55,5 +55,9 @@
   "convertSpeechPrompt": "Chuyển đoạn nói sau thành ghi chú: {recognized}",
   "convertSpeechPrompt@placeholders": {
     "recognized": {}
-  }
+  },
+  "scheduled": "Lên lịch",
+  "recurring": "Định kỳ",
+  "daily": "Hàng ngày",
+  "snooze": "Báo lại"
 }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -148,6 +148,7 @@ class _HomeScreenState extends State<HomeScreen> {
                     title: note.title,
                     body: note.content,
                     scheduledDate: alarmTime!,
+                    l10n: AppLocalizations.of(context)!,
                   );
                 }
                 if (!mounted) return;

--- a/lib/screens/note_detail_screen.dart
+++ b/lib/screens/note_detail_screen.dart
@@ -260,6 +260,7 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
           title: updated.title,
           body: updated.content,
           time: Time(_alarmTime!.hour, _alarmTime!.minute),
+          l10n: AppLocalizations.of(context)!,
         );
       } else if (_repeat != null) {
         await service.scheduleRecurring(
@@ -267,6 +268,7 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
           title: updated.title,
           body: updated.content,
           repeatInterval: _repeat!,
+          l10n: AppLocalizations.of(context)!,
         );
       } else {
         await service.scheduleNotification(
@@ -274,6 +276,7 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
           title: updated.title,
           body: updated.content,
           scheduledDate: _alarmTime!,
+          l10n: AppLocalizations.of(context)!,
         );
       }
     }

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:timezone/data/latest.dart' as tzdata;
 import 'package:timezone/timezone.dart' as tz;
 
@@ -41,16 +42,17 @@ class NotificationService {
     required String title,
     required String body,
     required DateTime scheduledDate,
+    required AppLocalizations l10n,
   }) async {
-    const androidDetails = AndroidNotificationDetails(
+    final androidDetails = AndroidNotificationDetails(
       'scheduled_channel',
-      'Scheduled',
+      l10n.scheduled,
       channelDescription: 'Scheduled notifications',
       importance: Importance.max,
       priority: Priority.high,
     );
 
-    const details = NotificationDetails(android: androidDetails);
+    final details = NotificationDetails(android: androidDetails);
 
     await _fln.zonedSchedule(
       id,
@@ -68,17 +70,18 @@ class NotificationService {
     required String title,
     required String body,
     required RepeatInterval repeatInterval,
+    required AppLocalizations l10n,
   }) async {
-    const androidDetails = AndroidNotificationDetails(
+    final androidDetails = AndroidNotificationDetails(
       'recurring_channel',
-      'Recurring',
+      l10n.recurring,
       channelDescription: 'Recurring notifications',
       importance: Importance.max,
       priority: Priority.high,
     );
 
     const iosDetails = DarwinNotificationDetails();
-    const details = NotificationDetails(
+    final details = NotificationDetails(
       android: androidDetails,
       iOS: iosDetails,
     );
@@ -98,17 +101,18 @@ class NotificationService {
     required String title,
     required String body,
     required Time time,
+    required AppLocalizations l10n,
   }) async {
-    const androidDetails = AndroidNotificationDetails(
+    final androidDetails = AndroidNotificationDetails(
       'daily_channel',
-      'Daily',
+      l10n.daily,
       channelDescription: 'Daily notifications',
       importance: Importance.max,
       priority: Priority.high,
     );
 
     const iosDetails = DarwinNotificationDetails();
-    const details = NotificationDetails(
+    final details = NotificationDetails(
       android: androidDetails,
       iOS: iosDetails,
     );
@@ -151,21 +155,22 @@ class NotificationService {
     required String title,
     required String body,
     required int minutes,
+    required AppLocalizations l10n,
   }) async {
     await _fln.cancel(id);
 
     final scheduledDate =
         tz.TZDateTime.now(tz.local).add(Duration(minutes: minutes));
 
-    const androidDetails = AndroidNotificationDetails(
+    final androidDetails = AndroidNotificationDetails(
       'snooze_channel',
-      'Snooze',
+      l10n.snooze,
       channelDescription: 'Snoozed notifications',
       importance: Importance.max,
       priority: Priority.high,
     );
 
-    const details = NotificationDetails(android: androidDetails);
+    final details = NotificationDetails(android: androidDetails);
 
     await _fln.zonedSchedule(
       id,

--- a/test/notification_service_test.dart
+++ b/test/notification_service_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'dart:ui';
 import 'package:notes_reminder_app/services/notification_service.dart';
 
 void main() {
@@ -27,34 +29,40 @@ void main() {
   });
 
   test('scheduleNotification schedules notification', () async {
+    final l10n = await AppLocalizations.delegate.load(const Locale('en'));
     final service = NotificationService();
     await service.scheduleNotification(
       id: 1,
       title: 't',
       body: 'b',
       scheduledDate: DateTime.now().add(const Duration(minutes: 1)),
+      l10n: l10n,
     );
     expect(log.any((c) => c.method == 'zonedSchedule'), isTrue);
   });
 
   test('scheduleDailyAtTime schedules daily notification', () async {
+    final l10n = await AppLocalizations.delegate.load(const Locale('en'));
     final service = NotificationService();
     await service.scheduleDailyAtTime(
       id: 2,
       title: 't',
       body: 'b',
       time: const Time(10, 0, 0),
+      l10n: l10n,
     );
     expect(log.any((c) => c.method == 'zonedSchedule'), isTrue);
   });
 
   test('scheduleRecurring schedules recurring notification', () async {
+    final l10n = await AppLocalizations.delegate.load(const Locale('en'));
     final service = NotificationService();
     await service.scheduleRecurring(
       id: 3,
       title: 't',
       body: 'b',
       repeatInterval: RepeatInterval.daily,
+      l10n: l10n,
     );
     expect(log.any((c) => c.method == 'periodicallyShow'), isTrue);
   });


### PR DESCRIPTION
## Summary
- add localized strings for notification channels
- use AppLocalizations to name scheduled, recurring, daily, and snooze channels
- pass localization to notification service callers

## Testing
- `dart format lib/services/notification_service.dart lib/screens/home_screen.dart lib/screens/note_detail_screen.dart test/notification_service_test.dart` *(command not found)*
- `flutter test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5a124c108333bd02ba832f57c3ee