### PR TITLE
Dispose controllers after closing add note dialog

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -158,7 +158,10 @@ class _HomeScreenState extends State<HomeScreen> {
           ],
         ),
       ),
-    );
+    ).whenComplete(() {
+      titleCtrl.dispose();
+      contentCtrl.dispose();
+    });
   }
 
   List<Note> _notesForDay(DateTime day, List<Note> notes) {


### PR DESCRIPTION
## Summary
- Dispose `titleCtrl` and `contentCtrl` when the add-note dialog closes to free resources.

## Testing
- `dart format lib/screens/home_screen.dart` (fails: command not found)
- `flutter test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68ba5a1743648333ab77516a7e3d8966