### PR TITLE
Pass localization to Gemini chat in voice note conversion

### DIFF
--- a/lib/screens/voice_to_note_screen.dart
+++ b/lib/screens/voice_to_note_screen.dart
@@ -39,7 +39,8 @@ class _VoiceToNoteScreenState extends State<VoiceToNoteScreen> {
     setState(() => _isProcessing = true);
     final prompt = AppLocalizations.of(context)!
         .convertSpeechPrompt(_recognized);
-    final reply = await GeminiService().chat(prompt);
+    final l10n = AppLocalizations.of(context)!;
+    final reply = await GeminiService().chat(prompt, l10n);
     if (!mounted) return;
     context.read<NoteProvider>().setDraft(reply);
     setState(() => _isProcessing = false);


### PR DESCRIPTION
## Summary
- Retrieve localization context and pass it to `GeminiService.chat` when converting speech to a note.

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5eeec254833386a5077555750c88