### PR TITLE
feat: localize notification channel descriptions

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -60,6 +60,10 @@
   "scheduled": "Scheduled",
   "recurring": "Recurring",
   "daily": "Daily",
-  "snooze": "Snooze"
+  "snooze": "Snooze",
+  "scheduledDesc": "Scheduled notifications",
+  "recurringDesc": "Recurring notifications",
+  "dailyDesc": "Daily notifications",
+  "snoozeDesc": "Snoozed notifications"
 
 }

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -60,6 +60,10 @@
   "scheduled": "Lên lịch",
   "recurring": "Định kỳ",
   "daily": "Hàng ngày",
-  "snooze": "Báo lại"
+  "snooze": "Báo lại",
+  "scheduledDesc": "Thông báo đã lên lịch",
+  "recurringDesc": "Thông báo định kỳ",
+  "dailyDesc": "Thông báo hàng ngày",
+  "snoozeDesc": "Thông báo báo lại"
 
 }

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -47,7 +47,7 @@ class NotificationService {
     final androidDetails = AndroidNotificationDetails(
       'scheduled_channel',
       l10n.scheduled,
-      channelDescription: 'Scheduled notifications',
+      channelDescription: l10n.scheduledDesc,
       importance: Importance.max,
       priority: Priority.high,
     );
@@ -75,7 +75,7 @@ class NotificationService {
     final androidDetails = AndroidNotificationDetails(
       'recurring_channel',
       l10n.recurring,
-      channelDescription: 'Recurring notifications',
+      channelDescription: l10n.recurringDesc,
       importance: Importance.max,
       priority: Priority.high,
     );
@@ -106,7 +106,7 @@ class NotificationService {
     final androidDetails = AndroidNotificationDetails(
       'daily_channel',
       l10n.daily,
-      channelDescription: 'Daily notifications',
+      channelDescription: l10n.dailyDesc,
       importance: Importance.max,
       priority: Priority.high,
     );
@@ -165,7 +165,7 @@ class NotificationService {
     final androidDetails = AndroidNotificationDetails(
       'snooze_channel',
       l10n.snooze,
-      channelDescription: 'Snoozed notifications',
+      channelDescription: l10n.snoozeDesc,
       importance: Importance.max,
       priority: Priority.high,
     );


### PR DESCRIPTION
## Summary
- add localized channel descriptions for scheduled, recurring, daily, and snooze notifications
- use new l10n keys in `NotificationService`

## Testing
- `flutter gen-l10n` *(fails: Invalid ARB resource name "errorWithMessage@placeholders")*
- `flutter test` *(fails: version solving failed for intl)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5ef445f88333a10182bf4f89f7eb