### PR TITLE
Add Gemini localization strings

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -16,6 +16,12 @@
   "chatAI": "Chat AI",
   "enterMessage": "Enter message...",
   "send": "Send",
+  "geminiApiKeyNotConfigured": "Gemini API key is not configured.",
+  "noResponse": "No response.",
+  "geminiError": "Gemini error: {error}",
+  "geminiError@placeholders": {
+    "error": {}
+  },
   "errorWithMessage": "Error: {error}",
   "errorWithMessage@placeholders": {
     "error": {}

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -16,6 +16,12 @@
   "chatAI": "Chat AI",
   "enterMessage": "Nhập tin nhắn...",
   "send": "Gửi",
+  "geminiApiKeyNotConfigured": "Chưa cấu hình khóa API Gemini.",
+  "noResponse": "Không có phản hồi.",
+  "geminiError": "Lỗi Gemini: {error}",
+  "geminiError@placeholders": {
+    "error": {}
+  },
   "errorWithMessage": "Lỗi: {error}",
   "errorWithMessage@placeholders": {
     "error": {}


### PR DESCRIPTION
## Summary
- add Gemini-related localization strings for API key, error, and no response messages in English and Vietnamese

## Testing
- `flutter gen-l10n` (fails: command not found)
- `flutter test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68ba5ef5bd8483339174147bf9fbec74