### PR TITLE
Open chat via button

### DIFF
--- a/lib/screens/note_detail_screen.dart
+++ b/lib/screens/note_detail_screen.dart
@@ -199,9 +199,18 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
               (a) => ListTile(title: Text(a.split('/').last)),
             ),
             const SizedBox(height: 12),
-            SizedBox(
-              height: 300,
-              child: ChatScreen(initialMessage: _contentCtrl.text),
+            ElevatedButton.icon(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) =>
+                        ChatScreen(initialMessage: _contentCtrl.text),
+                  ),
+                );
+              },
+              icon: const Icon(Icons.chat),
+              label: Text(AppLocalizations.of(context)!.chatAI),
             ),
           ],
         ),


### PR DESCRIPTION
## Summary
- Replace embedded ChatScreen with button that opens ChatScreen via Navigator.push
- Keep ChatScreen as independent screen with its own scaffold

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba611b533083339badaffff07f8b82