### PR TITLE
Use uuid for note IDs

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:intl/intl.dart';
 import 'package:lottie/lottie.dart';
 import 'package:provider/provider.dart';
+import 'package:uuid/uuid.dart';
 
 import '../models/note.dart';
 import '../providers/note_provider.dart';
@@ -130,9 +131,9 @@ class _HomeScreenState extends State<HomeScreen> {
             ),
             ElevatedButton(
               onPressed: () async {
-                final nowId = DateTime.now().millisecondsSinceEpoch;
+                final noteId = const Uuid().v4();
                 final note = Note(
-                  id: nowId.toString(),
+                  id: noteId,
                   title: titleCtrl.text,
                   content: contentCtrl.text,
                   alarmTime: alarmTime,
@@ -143,8 +144,10 @@ class _HomeScreenState extends State<HomeScreen> {
                 await provider.addNote(note);
                 provider.setDraft('');
                 if (alarmTime != null) {
+                  final notificationId =
+                      DateTime.now().millisecondsSinceEpoch % 100000;
                   await NotificationService().scheduleNotification(
-                    id: nowId % 100000,
+                    id: notificationId,
                     title: note.title,
                     body: note.content,
                     scheduledDate: alarmTime!,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -558,7 +558,7 @@ packages:
     source: hosted
     version: "1.4.0"
   uuid:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: uuid
       sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   intl: ^0.18.1
   provider: ^6.1.2
   flutter_tts: ^4.2.3
+  uuid: ^4.5.1
 
   encrypt: ^5.0.1
   flutter_secure_storage: ^9.0.0

--- a/test/note_repository_test.dart
+++ b/test/note_repository_test.dart
@@ -5,6 +5,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:notes_reminder_app/services/note_repository.dart';
 import 'package:notes_reminder_app/models/note.dart';
+import 'package:uuid/uuid.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -23,8 +24,9 @@ void main() {
 
     test('saveNotes and getNotes persist data', () async {
       final repo = NoteRepository();
+      final id = const Uuid().v4();
       final note = Note(
-        id: '1',
+        id: id,
         title: 't',
         content: 'c',
         alarmTime: DateTime(2024, 1, 1),
@@ -50,8 +52,9 @@ void main() {
 
     test('updateNote persists changes', () async {
       final repo = NoteRepository();
+      final id = const Uuid().v4();
       final note = Note(
-        id: '1',
+        id: id,
         title: 't',
         content: 'c',
         attachments: ['a'],
@@ -59,7 +62,7 @@ void main() {
       );
       await repo.saveNotes([note]);
       final updated = Note(
-        id: '1',
+        id: id,
         title: 't2',
         content: 'c2',
         attachments: ['b'],


### PR DESCRIPTION
## Summary
- add uuid package
- assign uuid v4 IDs to new notes
- update repository tests for new ID format

## Testing
- `flutter pub get` *(command not found: flutter)*
- `dart pub get` *(command not found: dart)*
- `flutter test` *(command not found: flutter)*
- `dart test` *(command not found: dart)*


------
https://chatgpt.com/codex/tasks/task_e_68ba611daa948333822a982b5caea267