### PR TITLE
Add API-based TTS playback

### DIFF
--- a/lib/services/tts_service.dart
+++ b/lib/services/tts_service.dart
@@ -1,9 +1,14 @@
+import 'dart:convert';
+import 'dart:io';
 import 'dart:ui';
 
+import 'package:audioplayers/audioplayers.dart';
 import 'package:flutter_tts/flutter_tts.dart';
+import 'package:http/http.dart' as http;
 
 class TTSService {
   final FlutterTts _tts = FlutterTts();
+  final AudioPlayer _player = AudioPlayer();
 
   String _ttsCodeForLocale(Locale locale) {
     const mapping = {
@@ -18,5 +23,29 @@ class TTSService {
     await _tts.setLanguage(_ttsCodeForLocale(loc));
     await _tts.setPitch(1.0);
     await _tts.speak(text);
+  }
+
+  Future<void> speakWithApi(String text) async {
+    final apiKey =
+        Platform.environment['TTS_API_KEY'] ?? const String.fromEnvironment('TTS_API_KEY');
+    if (apiKey.isEmpty) {
+      throw Exception('Missing TTS_API_KEY');
+    }
+
+    final url = Uri.parse('https://api.elevenlabs.io/v1/text-to-speech/en-US');
+    final response = await http.post(
+      url,
+      headers: {
+        'Content-Type': 'application/json',
+        'xi-api-key': apiKey,
+      },
+      body: jsonEncode({'text': text}),
+    );
+
+    if (response.statusCode != 200) {
+      throw Exception('TTS API error: ${response.statusCode}');
+    }
+
+    await _player.play(BytesSource(response.bodyBytes));
   }
 }


### PR DESCRIPTION
## Summary
- use HTTP client to request TTS audio from API and play via AudioPlayer

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba648b205c833385e3e9a33c29bfce