### PR TITLE
Add Gemini-powered note analysis suggestions

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -70,6 +70,10 @@
   "scheduledDesc": "Scheduled notifications",
   "recurringDesc": "Recurring notifications",
   "dailyDesc": "Daily notifications",
-  "snoozeDesc": "Snoozed notifications"
+  "snoozeDesc": "Snoozed notifications",
+  "aiSuggestionsTitle": "AI Suggestions",
+  "summaryLabel": "Summary",
+  "actionItemsLabel": "Action items",
+  "datesLabel": "Dates"
 
 }

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -70,6 +70,10 @@
   "scheduledDesc": "Thông báo đã lên lịch",
   "recurringDesc": "Thông báo định kỳ",
   "dailyDesc": "Thông báo hàng ngày",
-  "snoozeDesc": "Thông báo báo lại"
+  "snoozeDesc": "Thông báo báo lại",
+  "aiSuggestionsTitle": "Gợi ý AI",
+  "summaryLabel": "Tóm tắt",
+  "actionItemsLabel": "Cần làm",
+  "datesLabel": "Ngày"
 
 }

--- a/lib/models/note.dart
+++ b/lib/models/note.dart
@@ -14,6 +14,9 @@ class Note {
   final int snoozeMinutes;
   final DateTime? updatedAt;
   final int? notificationId;
+  final String summary;
+  final List<String> actionItems;
+  final List<DateTime> dates;
 
   const Note({
     required this.id,
@@ -29,6 +32,9 @@ class Note {
     this.snoozeMinutes = 0,
     this.updatedAt,
     this.notificationId,
+    this.summary = '',
+    this.actionItems = const [],
+    this.dates = const [],
   });
 
   Note copyWith({
@@ -45,6 +51,9 @@ class Note {
     int? snoozeMinutes,
     DateTime? updatedAt,
     Object? notificationId = _notificationIdSentinel,
+    String? summary,
+    List<String>? actionItems,
+    List<DateTime>? dates,
   }) {
     return Note(
       id: id ?? this.id,
@@ -62,6 +71,9 @@ class Note {
       notificationId: notificationId == _notificationIdSentinel
           ? this.notificationId
           : notificationId as int?,
+      summary: summary ?? this.summary,
+      actionItems: actionItems ?? this.actionItems,
+      dates: dates ?? this.dates,
     );
   }
 
@@ -88,6 +100,12 @@ class Note {
           ? DateTime.parse(json['updatedAt'])
           : null,
       notificationId: json['notificationId'] as int?,
+      summary: json['summary'] as String? ?? '',
+      actionItems: (json['actionItems'] as List<dynamic>? ?? []).cast<String>(),
+      dates: (json['dates'] as List<dynamic>? ?? [])
+          .map((d) => DateTime.tryParse(d as String))
+          .whereType<DateTime>()
+          .toList(),
     );
   }
 
@@ -105,6 +123,9 @@ class Note {
     'snoozeMinutes': snoozeMinutes,
     'updatedAt': updatedAt?.toIso8601String(),
     'notificationId': notificationId,
+    'summary': summary,
+    'actionItems': actionItems,
+    'dates': dates.map((d) => d.toIso8601String()).toList(),
   };
 }
 


### PR DESCRIPTION
## Summary
- add GeminiService.analyzeNote to extract summary, action items, tags, and dates
- show editable AI suggestions before saving notes and store results
- localize new suggestion fields

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68ba648cb6c883339d72a034a53b71da