### PR TITLE
Set locale for widget test

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,15 +1,21 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:notes_reminder_app/main.dart';
 import 'package:notes_reminder_app/providers/note_provider.dart';
 import 'package:provider/provider.dart';
 
 void main() {
   testWidgets('renders home screen title', (WidgetTester tester) async {
-    runApp(
-      ChangeNotifierProvider(
-        create: (_) => NoteProvider(),
-        child: MyApp(themeColor: Colors.blue, fontScale: 1.0),
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('vi'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: ChangeNotifierProvider(
+          create: (_) => NoteProvider(),
+          child: MyApp(themeColor: Colors.blue, fontScale: 1.0),
+        ),
       ),
     );
     await tester.pumpAndSettle();


### PR DESCRIPTION
## Summary
- ensure widget test uses Vietnamese locale by wrapping `MyApp` in a `MaterialApp` with localization delegates

## Testing
- `flutter test test/widget_test.dart` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68ba69575fd08333a4cfe862c41bfe39