### PR TITLE
Reuse stored notification ID when scheduling notifications

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -151,11 +151,8 @@ class _HomeScreenState extends State<HomeScreen> {
                 provider.setDraft('');
 
                 if (alarmTime != null) {
-                  final notificationId =
-                      DateTime.now().millisecondsSinceEpoch % 100000;
-
                   await NotificationService().scheduleNotification(
-                    id: notificationId,
+                    id: note.notificationId!,
                     title: note.title,
                     body: note.content,
                     scheduledDate: alarmTime!,


### PR DESCRIPTION
## Summary
- Generate and store a unique notification ID before creating a note
- Reuse the note's notificationId when scheduling notifications to avoid mismatches

## Testing
- ⚠️ `dart format lib/screens/home_screen.dart` (command not found: dart)
- ⚠️ `flutter test` (command not found: flutter)


------
https://chatgpt.com/codex/tasks/task_e_68ba6c24c2a88333af6cf87baae789bd