### PR TITLE
Cancel notifications and calendar events when removing note

### DIFF
--- a/lib/providers/note_provider.dart
+++ b/lib/providers/note_provider.dart
@@ -7,6 +7,7 @@ import 'package:flutter/foundation.dart';
 import '../models/note.dart';
 import '../services/note_repository.dart';
 import '../services/calendar_service.dart';
+import '../services/notification_service.dart';
 
 class NoteProvider extends ChangeNotifier {
   final NoteRepository _repository;
@@ -91,8 +92,16 @@ class NoteProvider extends ChangeNotifier {
 
 
   Future<void> removeNoteAt(int index) async {
+    final note = _notes[index];
 
-    final note = _notes.removeAt(index);
+    if (note.notificationId != null) {
+      await NotificationService().cancel(note.notificationId!);
+    }
+    if (note.eventId != null) {
+      await _calendarService.deleteEvent(note.eventId!);
+    }
+
+    _notes.removeAt(index);
 
     await _repository.saveNotes(_notes);
     notifyListeners();


### PR DESCRIPTION
## Summary
- cancel any scheduled notification before removing a note
- delete associated calendar event when a note is removed

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6c2764408333842e8061b69e17ce