### PR TITLE
Add search functionality to HomeScreen

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -12,6 +12,7 @@ import '../services/settings_service.dart';
 import '../widgets/tag_selector.dart';
 import 'note_detail_screen.dart';
 import 'note_list_for_day_screen.dart';
+import 'note_search_delegate.dart';
 import 'settings_screen.dart';
 import 'voice_to_note_screen.dart';
 
@@ -232,6 +233,14 @@ class _HomeScreenState extends State<HomeScreen> {
       appBar: AppBar(
         title: Text(AppLocalizations.of(context)!.appTitle),
         actions: [
+          IconButton(
+            icon: const Icon(Icons.search),
+            onPressed: () => showSearch(
+              context: context,
+              delegate:
+                  NoteSearchDelegate(context.read<NoteProvider>().notes),
+            ),
+          ),
           IconButton(
             icon: const Icon(Icons.mic),
             onPressed: () async {


### PR DESCRIPTION
## Summary
- add search icon to HomeScreen AppBar for quick note lookup
- integrate NoteSearchDelegate to search provider notes

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6c281c208333952ee268cc28c183