### PR TITLE
Add speech and Google service dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,6 +32,12 @@ dependencies:
   cloud_firestore: ^6.0.1
   firebase_auth: ^6.0.2
 
+  speech_to_text: ^x.y.z
+  vosk_flutter: ^x.y.z
+  google_sign_in: ^x.y.z
+  googleapis: ^x.y.z
+  image_picker: ^x.y.z
+
 
 
 


### PR DESCRIPTION
## Summary
- add speech_to_text, vosk_flutter, google_sign_in, googleapis, image_picker dependencies

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6c291e288333b22d32ee3e507992