### PR TITLE
Add tests for note removal, search, speech and speech synthesis

### DIFF
--- a/lib/screens/note_detail_screen.dart
+++ b/lib/screens/note_detail_screen.dart
@@ -15,7 +15,9 @@ import '../services/gemini_service.dart';
 
 class NoteDetailScreen extends StatefulWidget {
   final Note note;
-  const NoteDetailScreen({super.key, required this.note});
+  final TTSService ttsService;
+  const NoteDetailScreen({super.key, required this.note, TTSService? ttsService})
+      : ttsService = ttsService ?? TTSService();
 
   @override
   State<NoteDetailScreen> createState() => _NoteDetailScreenState();
@@ -29,11 +31,12 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
   RepeatInterval? _repeat;
   int _snoozeMinutes = 5;
   late List<String> _tags;
-  final _ttsService = TTSService();
+  late final TTSService _ttsService;
 
   @override
   void initState() {
     super.initState();
+    _ttsService = widget.ttsService;
     _titleCtrl = TextEditingController(text: widget.note.title);
     _contentCtrl = TextEditingController(text: widget.note.content);
     _alarmTime = widget.note.alarmTime;

--- a/lib/services/tts_service.dart
+++ b/lib/services/tts_service.dart
@@ -7,8 +7,12 @@ import 'package:flutter_tts/flutter_tts.dart';
 import 'package:http/http.dart' as http;
 
 class TTSService {
-  final FlutterTts _tts = FlutterTts();
-  final AudioPlayer _player = AudioPlayer();
+  final FlutterTts _tts;
+  final AudioPlayer _player;
+
+  TTSService({FlutterTts? tts, AudioPlayer? player})
+      : _tts = tts ?? FlutterTts(),
+        _player = player ?? AudioPlayer();
 
   String _ttsCodeForLocale(Locale locale) {
     const mapping = {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,8 @@ dependencies:
   provider: ^6.1.2
   flutter_tts: ^4.2.3
   uuid: ^4.5.1
+  speech_to_text: ^7.3.0
+  vosk_flutter: ^0.3.48
 
   encrypt: ^5.0.1
   flutter_secure_storage: ^9.0.0
@@ -40,6 +42,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^2.0.0
+  mocktail: ^1.0.4
 
 flutter:
   generate: true

--- a/test/note_detail_tts_test.dart
+++ b/test/note_detail_tts_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:provider/provider.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:notes_reminder_app/models/note.dart';
+import 'package:notes_reminder_app/providers/note_provider.dart';
+import 'package:notes_reminder_app/screens/note_detail_screen.dart';
+import 'package:notes_reminder_app/services/tts_service.dart';
+
+class MockTTS extends Mock implements TTSService {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    registerFallbackValue(const Locale('en'));
+  });
+
+  testWidgets('read note triggers TTS', (tester) async {
+    final tts = MockTTS();
+    when(() => tts.speak(any(), locale: any(named: 'locale'))).thenAnswer((_) async {});
+
+    final note = const Note(
+      id: '1',
+      title: 't',
+      content: 'content',
+      summary: '',
+      actionItems: const [],
+      dates: const [],
+    );
+
+    await tester.pumpWidget(ChangeNotifierProvider(
+      create: (_) => NoteProvider(),
+      child: MaterialApp(
+        locale: const Locale('en'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: NoteDetailScreen(note: note, ttsService: tts),
+      ),
+    ));
+
+    final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+    await tester.tap(find.text(l10n.readNote));
+    await tester.pump();
+
+    verify(() => tts.speak('content', locale: any(named: 'locale'))).called(1);
+  });
+}

--- a/test/note_provider_test.dart
+++ b/test/note_provider_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:notes_reminder_app/models/note.dart';
+import 'package:notes_reminder_app/providers/note_provider.dart';
+import 'package:notes_reminder_app/services/note_repository.dart';
+import 'package:notes_reminder_app/services/calendar_service.dart';
+import 'package:notes_reminder_app/services/notification_service.dart';
+
+class MockRepo extends Mock implements NoteRepository {}
+class MockCalendar extends Mock implements CalendarService {}
+class MockNotification extends Mock implements NotificationService {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    registerFallbackValue<List<Note>>([]);
+  });
+
+  test('removeNoteAt cancels notification and deletes event', () async {
+    final repo = MockRepo();
+    final calendar = MockCalendar();
+    final notification = MockNotification();
+    when(() => repo.getNotes()).thenAnswer((_) async => [
+          const Note(
+            id: '1',
+            title: 't',
+            content: 'c',
+            summary: '',
+            actionItems: const [],
+            dates: const [],
+            notificationId: 123,
+            eventId: 'e1',
+          )
+        ]);
+    when(() => repo.saveNotes(any())).thenAnswer((_) async {});
+    when(() => calendar.deleteEvent(any())).thenAnswer((_) async {});
+    when(() => notification.cancel(any())).thenAnswer((_) async {});
+
+    final provider = NoteProvider(
+      repository: repo,
+      calendarService: calendar,
+      notificationService: notification,
+    );
+
+    await provider.loadNotes();
+    await provider.removeNoteAt(0);
+
+    verify(() => notification.cancel(123)).called(1);
+    verify(() => calendar.deleteEvent('e1')).called(1);
+    verify(() => repo.saveNotes([])).called(1);
+  });
+}

--- a/test/note_search_delegate_test.dart
+++ b/test/note_search_delegate_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:notes_reminder_app/models/note.dart';
+import 'package:notes_reminder_app/screens/note_search_delegate.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+void main() {
+  testWidgets('NoteSearchDelegate displays results', (tester) async {
+    final notes = [
+      const Note(
+        id: '1',
+        title: 'apple',
+        content: 'fruit',
+        summary: '',
+        actionItems: const [],
+        dates: const [],
+      )
+    ];
+
+    await tester.pumpWidget(MaterialApp(
+      locale: const Locale('en'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Builder(
+        builder: (context) => TextButton(
+          onPressed: () {
+            showSearch(context: context, delegate: NoteSearchDelegate(notes));
+          },
+          child: const Text('search'),
+        ),
+      ),
+    ));
+
+    await tester.tap(find.text('search'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), 'apple');
+    await tester.pumpAndSettle();
+
+    expect(find.text('apple'), findsOneWidget);
+  });
+}

--- a/test/voice_to_note_screen_test.dart
+++ b/test/voice_to_note_screen_test.dart
@@ -1,0 +1,82 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:speech_to_text/speech_to_text.dart' as stt;
+import 'package:vosk_flutter/vosk_flutter.dart' as vosk;
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:notes_reminder_app/screens/voice_to_note_screen.dart';
+
+class MockSpeechToText extends Mock implements stt.SpeechToText {}
+class MockVosk extends Mock implements vosk.VoskFlutterPlugin {}
+class MockSpeechService extends Mock implements vosk.SpeechService {}
+class MockRecognizer extends Mock implements vosk.Recognizer {}
+class MockModel extends Mock implements vosk.Model {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('VoiceToNoteScreen STT', () {
+    testWidgets('online mode uses SpeechToText', (tester) async {
+      final speech = MockSpeechToText();
+      when(() => speech.initialize()).thenAnswer((_) async => true);
+      when(() => speech.listen(onResult: any(named: 'onResult'))).thenAnswer((invocation) {
+        final callback = invocation.namedArguments[#onResult] as void Function(stt.SpeechRecognitionResult);
+        callback(stt.SpeechRecognitionResult([
+          stt.SpeechRecognitionWords('hello', null, 1.0)
+        ], true));
+      });
+      when(() => speech.stop()).thenAnswer((_) async {});
+
+      await tester.pumpWidget(MaterialApp(
+        locale: const Locale('en'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: VoiceToNoteScreen(speech: speech),
+      ));
+
+      final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+      await tester.tap(find.text(l10n.speak));
+      await tester.pump();
+
+      expect(find.text('hello'), findsOneWidget);
+      verify(() => speech.listen(onResult: any(named: 'onResult'))).called(1);
+    });
+
+    testWidgets('offline mode uses Vosk', (tester) async {
+      final speech = MockSpeechToText();
+      when(() => speech.stop()).thenAnswer((_) async {});
+      final voskPlugin = MockVosk();
+      final service = MockSpeechService();
+      final recognizer = MockRecognizer();
+      final model = MockModel();
+      when(() => voskPlugin.createModel(any())).thenAnswer((_) async => model);
+      when(() => voskPlugin.createRecognizer(model: model)).thenAnswer((_) async => recognizer);
+      when(() => voskPlugin.initSpeechService(recognizer)).thenAnswer((_) async => service);
+      final controller = StreamController<String>();
+      when(() => service.onResult()).thenAnswer((_) => controller.stream);
+      when(() => service.start()).thenAnswer((_) async {});
+      when(() => service.stop()).thenAnswer((_) async {});
+
+      await tester.pumpWidget(MaterialApp(
+        locale: const Locale('en'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: VoiceToNoteScreen(speech: speech, vosk: voskPlugin),
+      ));
+
+      await tester.tap(find.byType(Switch));
+      await tester.pumpAndSettle();
+      final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+      await tester.tap(find.text(l10n.speak));
+      await tester.pump();
+
+      controller.add('{"text": "offline"}');
+      await tester.pump();
+
+      expect(find.text('offline'), findsOneWidget);
+      verify(() => service.start()).called(1);
+      await controller.close();
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- ensure removing notes cancels notifications and calendar events
- test note search results via NoteSearchDelegate
- cover speech-to-text offline/online and note reading with TTS

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(partial success; some 403/503 errors)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6c29ce8c8333a6922a99bda37d45