### PR TITLE
Remove duplicate CalendarService declaration in NoteProvider

### DIFF
--- a/lib/providers/note_provider.dart
+++ b/lib/providers/note_provider.dart
@@ -16,7 +16,6 @@ class NoteProvider extends ChangeNotifier {
 
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
   final FirebaseAuth _auth = FirebaseAuth.instance;
-  final CalendarService _calendarService;
 
   List<Note> _notes = [];
   String _draft = '';


### PR DESCRIPTION
## Summary
- Remove duplicate `_calendarService` field from `NoteProvider`
- Keep constructor assignment to `_calendarService`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba771821e48333a8c38b430d7891e5