### PR TITLE
Remove placeholder dependency declarations

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,20 +29,9 @@ dependencies:
   flutter_secure_storage: ^9.0.0
   file_picker: ^6.1.1
 
-
   firebase_core: ^4.1.0
   cloud_firestore: ^6.0.1
   firebase_auth: ^6.0.2
-
-  speech_to_text: ^x.y.z
-  vosk_flutter: ^x.y.z
-  google_sign_in: ^x.y.z
-  googleapis: ^x.y.z
-  image_picker: ^x.y.z
-
-
-
-
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- remove placeholder dependency lines (speech_to_text, vosk_flutter, google_sign_in, googleapis, image_picker) from `pubspec.yaml`
- keep existing dependencies with actual versions

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba772087508333821bda8dc2841365