### PR TITLE
Use locale-aware alarm time format

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -201,7 +201,11 @@ class _HomeScreenState extends State<HomeScreen> {
             title: Text(note.title),
             subtitle: Text(
               note.alarmTime != null
-                  ? '${note.content}\n⏰ ${DateFormat('HH:mm dd/MM/yyyy').format(note.alarmTime!)}'
+                  ? '${note.content}\n⏰ ${DateFormat.yMd(
+                          Localizations.localeOf(context).toString(),
+                        )
+                          .add_Hm()
+                          .format(note.alarmTime!)}'
                   : note.content,
             ),
             onTap: () {


### PR DESCRIPTION
## Summary
- display alarm times in home screen using locale-specific formatting

## Testing
- `flutter test` *(command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7725dd748333a92cdf8bc9855a8d