### PR TITLE
Fix addNote remote save to include eventId

### DIFF
--- a/lib/providers/note_provider.dart
+++ b/lib/providers/note_provider.dart
@@ -80,9 +80,9 @@ class NoteProvider extends ChangeNotifier {
     notifyListeners();
     if (Firebase.apps.isNotEmpty) {
       final user = _auth.currentUser ?? await _auth.signInAnonymously();
-      final data = await _repository.encryptNote(note);
+      final data = await _repository.encryptNote(toSave);
       data['userId'] = user.uid;
-      await _firestore.collection('notes').doc(note.id).set(data);
+      await _firestore.collection('notes').doc(toSave.id).set(data);
     }
   }
 


### PR DESCRIPTION
## Summary
- Use computed `toSave` note when encrypting and uploading to Firestore

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba772d23cc8333a8026c6d676660e4