### PR TITLE
feat: localize date and time formatting

### DIFF
--- a/lib/screens/note_detail_screen.dart
+++ b/lib/screens/note_detail_screen.dart
@@ -122,7 +122,9 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
                   Padding(
                     padding: const EdgeInsets.only(left: 8),
                     child: Text(
-                      DateFormat('HH:mm dd/MM/yyyy').format(_alarmTime!),
+                      DateFormat.yMd(Localizations.localeOf(context).toString())
+                          .add_Hm()
+                          .format(_alarmTime!),
                     ),
                   ),
               ],

--- a/lib/screens/note_list_for_day_screen.dart
+++ b/lib/screens/note_list_for_day_screen.dart
@@ -27,8 +27,9 @@ class NoteListForDayScreen extends StatelessWidget {
         .toList();
 
 
-    final title = AppLocalizations.of(context)!
-        .scheduleForDate(DateFormat('dd/MM/yyyy').format(date));
+    final title = AppLocalizations.of(context)!.scheduleForDate(
+      DateFormat.yMd(Localizations.localeOf(context).toString()).format(date),
+    );
     if (dayNotes.isEmpty) {
 
       return Scaffold(
@@ -46,7 +47,8 @@ class NoteListForDayScreen extends StatelessWidget {
         itemBuilder: (context, index) {
           final note = dayNotes[index];
           final timeStr = note.alarmTime != null
-              ? DateFormat('HH:mm').format(note.alarmTime!)
+              ? DateFormat.Hm(Localizations.localeOf(context).toString())
+                  .format(note.alarmTime!)
               : null;
           return Card(
             child: ListTile(


### PR DESCRIPTION
## Summary
- localize reminder time formatting in note detail screen
- use locale-aware date/time formats in daily note list

## Testing
- `dart format lib/screens/note_detail_screen.dart lib/screens/note_list_for_day_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7acf205083339526296e937b41e8