### PR TITLE
Fix remote note sync to use updated note

### DIFF
--- a/lib/providers/note_provider.dart
+++ b/lib/providers/note_provider.dart
@@ -116,9 +116,9 @@ class NoteProvider extends ChangeNotifier {
       notifyListeners();
       if (Firebase.apps.isNotEmpty) {
         final user = _auth.currentUser ?? await _auth.signInAnonymously();
-        final data = await _repository.encryptNote(note);
+        final data = await _repository.encryptNote(updated);
         data['userId'] = user.uid;
-        await _firestore.collection('notes').doc(note.id).set(data);
+        await _firestore.collection('notes').doc(updated.id).set(data);
       }
     }
   }


### PR DESCRIPTION
## Summary
- ensure updateNote encrypts and uploads the updated note

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7ad5414c8333ade871b418289374