### PR TITLE
Use locale-aware weekday format

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -302,7 +302,7 @@ class _HomeScreenState extends State<HomeScreen> {
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
-                        Text(DateFormat('E').format(d)),
+                        Text(DateFormat.E(Localizations.localeOf(context).toString()).format(d)),
                         Text('${d.day}'),
                       ],
                     ),


### PR DESCRIPTION
## Summary
- ensure weekday abbreviations honor the current locale

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ba7d31572c8333b081f7ded8fe70cb