### PR TITLE
Use random IDs for scheduled notifications

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:intl/intl.dart';
@@ -131,9 +133,8 @@ class _HomeScreenState extends State<HomeScreen> {
             ElevatedButton(
               onPressed: () async {
                 final noteId = const Uuid().v4();
-                final notificationId = alarmTime != null
-                    ? DateTime.now().millisecondsSinceEpoch % 100000
-                    : null;
+                final notificationId =
+                    alarmTime != null ? Random().nextInt(1 << 31) : null;
 
                 final note = Note(
                   id: noteId,

--- a/lib/screens/note_detail_screen.dart
+++ b/lib/screens/note_detail_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -341,10 +343,7 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
 
     int? newId;
     if (_alarmTime != null) {
-      newId =
-          oldId ??
-          int.tryParse(widget.note.id) ??
-          DateTime.now().millisecondsSinceEpoch % 100000;
+      newId = Random().nextInt(1 << 31);
     }
 
     final updated = widget.note.copyWith(


### PR DESCRIPTION
## Summary
- Generate notification IDs with `Random().nextInt(1 << 31)` when adding or saving notes
- Pass generated IDs to notification scheduling and cancellation

## Testing
- `dart format lib/screens/home_screen.dart lib/screens/note_detail_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7d380d388333b709dab399bda786