### PR TITLE
Add voice recognition and Gemini analysis tests

### DIFF
--- a/test/gemini_service_test.dart
+++ b/test/gemini_service_test.dart
@@ -1,0 +1,44 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:notes_reminder_app/services/gemini_service.dart';
+
+void main() {
+  test('analyzeNote parses valid response', () async {
+    final service = GeminiService();
+    final analysisJson = {
+      'summary': 'note summary',
+      'actionItems': ['task1'],
+      'suggestedTags': ['tag1', 'tag2'],
+      'dates': ['2024-01-01T00:00:00Z']
+    };
+    final apiResponse = {
+      'candidates': [
+        {
+          'content': {
+            'parts': [
+              {'text': jsonEncode(analysisJson)}
+            ]
+          }
+        }
+      ]
+    };
+
+    final client = MockClient((request) async {
+      expect(request.method, 'POST');
+      return http.Response(jsonEncode(apiResponse), 200,
+          headers: {'content-type': 'application/json'});
+    });
+
+    final result = await http.runWithClient(
+        () => service.analyzeNote('test note'), () => client);
+
+    expect(result, isNotNull);
+    expect(result!.summary, analysisJson['summary']);
+    expect(result.actionItems, analysisJson['actionItems']);
+    expect(result.suggestedTags, analysisJson['suggestedTags']);
+    expect(result.dates.first, DateTime.parse(analysisJson['dates']![0]));
+  });
+}

--- a/test/voice_to_note_screen_test.dart
+++ b/test/voice_to_note_screen_test.dart
@@ -75,6 +75,9 @@ void main() {
       await tester.pump();
 
       expect(find.text('offline'), findsOneWidget);
+      verify(() => voskPlugin.createModel(any())).called(1);
+      verify(() => voskPlugin.createRecognizer(model: model)).called(1);
+      verify(() => voskPlugin.initSpeechService(recognizer)).called(1);
       verify(() => service.start()).called(1);
       await controller.close();
     });


### PR DESCRIPTION
## Summary
- extend offline voice test to verify Vosk plugin interactions
- add mock HTTP test for `GeminiService.analyzeNote`

## Testing
- `flutter test --dart-define=GEMINI_API_KEY=test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7d3bd13083339ea34b313461b1d8