### PR TITLE
Display selected reminder time

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -109,18 +109,27 @@ class _HomeScreenState extends State<HomeScreen> {
                         initialTime: TimeOfDay.now(),
                       );
                       if (time != null) {
-                        alarmTime = DateTime(
-                          picked.year,
-                          picked.month,
-                          picked.day,
-                          time.hour,
-                          time.minute,
-                        );
+                        setState(() {
+                          alarmTime = DateTime(
+                            picked.year,
+                            picked.month,
+                            picked.day,
+                            time.hour,
+                            time.minute,
+                          );
+                        });
                       }
                     }
                   },
                   child: Text(AppLocalizations.of(context)!.selectReminderTime),
                 ),
+                if (alarmTime != null)
+                  Text(
+                    DateFormat.yMd(
+                            Localizations.localeOf(context).toString())
+                        .add_Hm()
+                        .format(alarmTime!),
+                  ),
               ],
             ),
           ),


### PR DESCRIPTION
## Summary
- update `_addNote` to call `setState` when a reminder time is chosen
- show formatted reminder time below the selection button

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7fda1f088333a91cf96b25d29ff4