### PR TITLE
Add local authentication for locked notes

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'screens/home_screen.dart';
 import 'services/notification_service.dart';
 import 'services/settings_service.dart';
+import 'services/auth_service.dart';
 import 'package:provider/provider.dart';
 import 'providers/note_provider.dart';
 import 'firebase_options.dart';
@@ -19,6 +20,13 @@ void main() async {
   await FirebaseAuth.instance.signInAnonymously();
   await NotificationService().init();
   final settings = SettingsService();
+  final requireAuth = await settings.loadRequireAuth();
+  if (requireAuth) {
+    final ok = await AuthService().authenticate();
+    if (!ok) {
+      return;
+    }
+  }
   final themeColor = await settings.loadThemeColor();
   final fontScale = await settings.loadFontScale();
   runApp(

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -11,6 +11,7 @@ import '../models/note.dart';
 import '../providers/note_provider.dart';
 import '../services/notification_service.dart';
 import '../services/settings_service.dart';
+import '../services/auth_service.dart';
 import '../widgets/tag_selector.dart';
 import 'note_detail_screen.dart';
 import 'note_list_for_day_screen.dart';
@@ -209,7 +210,11 @@ class _HomeScreenState extends State<HomeScreen> {
                           .format(note.alarmTime!)}'
                   : note.content,
             ),
-            onTap: () {
+            onTap: () async {
+              if (note.locked) {
+                final ok = await AuthService().authenticate();
+                if (!ok) return;
+              }
               Navigator.push(
                 context,
                 MaterialPageRoute(builder: (_) => NoteDetailScreen(note: note)),

--- a/lib/screens/note_list_for_day_screen.dart
+++ b/lib/screens/note_list_for_day_screen.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import '../models/note.dart';
 import '../providers/note_provider.dart';
 import 'note_detail_screen.dart';
+import '../services/auth_service.dart';
 
 class NoteListForDayScreen extends StatelessWidget {
   final DateTime date;
@@ -74,7 +75,11 @@ class NoteListForDayScreen extends StatelessWidget {
                 ],
               ),
               isThreeLine: timeStr != null || note.tags.isNotEmpty,
-              onTap: () {
+              onTap: () async {
+                if (note.locked) {
+                  final ok = await AuthService().authenticate();
+                  if (!ok) return;
+                }
                 Navigator.push(
                   context,
                   MaterialPageRoute(

--- a/lib/screens/note_search_delegate.dart
+++ b/lib/screens/note_search_delegate.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/note.dart';
 import 'note_detail_screen.dart';
+import '../services/auth_service.dart';
 
 class NoteSearchDelegate extends SearchDelegate {
   final List<Note> notes;
@@ -45,7 +46,11 @@ class NoteSearchDelegate extends SearchDelegate {
           .map((n) => ListTile(
                 title: Text(n.title),
                 subtitle: Text(n.content),
-                onTap: () {
+                onTap: () async {
+                  if (n.locked) {
+                    final ok = await AuthService().authenticate();
+                    if (!ok) return;
+                  }
                   Navigator.push(
                     context,
                     MaterialPageRoute(

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,0 +1,17 @@
+import 'package:local_auth/local_auth.dart';
+
+class AuthService {
+  final LocalAuthentication _auth;
+  AuthService({LocalAuthentication? auth}) : _auth = auth ?? LocalAuthentication();
+
+  Future<bool> authenticate() async {
+    try {
+      return await _auth.authenticate(
+        localizedReason: 'Please authenticate to continue',
+        options: const AuthenticationOptions(stickyAuth: true),
+      );
+    } catch (_) {
+      return false;
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,8 @@ dependencies:
   speech_to_text: ^7.3.0
   vosk_flutter: ^0.3.48
 
+  local_auth: ^2.1.7
+
   encrypt: ^5.0.1
   flutter_secure_storage: ^9.0.0
   file_picker: ^6.1.1


### PR DESCRIPTION
## Summary
- add `local_auth` dependency and authentication service
- require auth on app start when enabled in settings
- authenticate before opening locked notes

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7fdd1fd08333822ff3b7750bb334