### PR TITLE
Add undo snackbar for note deletion

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -37,6 +37,9 @@
   "delete": "Delete",
   "timeLabel": "Time",
 
+  "noteDeleted": "Note deleted",
+  "undo": "Undo",
+
   "repeatLabel": "Repeat:",
   "repeatNone": "None",
   "repeatEveryMinute": "Every minute",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -37,6 +37,9 @@
   "delete": "Xóa",
   "timeLabel": "Thời gian",
 
+  "noteDeleted": "Đã xóa ghi chú",
+  "undo": "Hoàn tác",
+
   "repeatLabel": "Lặp lại:",
   "repeatNone": "Không",
   "repeatEveryMinute": "Mỗi phút",

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -218,7 +218,22 @@ class _HomeScreenState extends State<HomeScreen> {
             trailing: IconButton(
               icon: const Icon(Icons.delete),
               tooltip: AppLocalizations.of(context)!.delete,
-              onPressed: () => context.read<NoteProvider>().removeNoteAt(index),
+              onPressed: () {
+                final note = context.read<NoteProvider>().notes[index];
+                context.read<NoteProvider>().removeNoteAt(index);
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(
+                    content: Text(
+                      AppLocalizations.of(context)!.noteDeleted,
+                    ),
+                    action: SnackBarAction(
+                      label: AppLocalizations.of(context)!.undo,
+                      onPressed: () =>
+                          context.read<NoteProvider>().addNote(note),
+                    ),
+                  ),
+                );
+              },
             ),
           ),
         );


### PR DESCRIPTION
## Summary
- show a SnackBar with undo when deleting a note
- add `noteDeleted` and `undo` localization keys

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7fdf5c4483339e9a7643609c81fd