### PR TITLE
Load locale-specific Vosk models

### DIFF
--- a/assets/models/vosk-model-small-en-us-0.15/README.txt
+++ b/assets/models/vosk-model-small-en-us-0.15/README.txt
@@ -1,2 +1,0 @@
-This directory should contain the Vosk model files for offline recognition.
-Due to network restrictions, download the 'vosk-model-small-en-us-0.15' model separately from https://alphacephei.com/vosk/models and extract its contents here.

--- a/assets/models/vosk-model-small-en/README.txt
+++ b/assets/models/vosk-model-small-en/README.txt
@@ -1,0 +1,1 @@
+Placeholder for English Vosk model

--- a/assets/models/vosk-model-small-vi/README.txt
+++ b/assets/models/vosk-model-small-vi/README.txt
@@ -1,0 +1,1 @@
+Placeholder for Vietnamese Vosk model

--- a/lib/screens/voice_to_note_screen.dart
+++ b/lib/screens/voice_to_note_screen.dart
@@ -35,8 +35,14 @@ class _VoiceToNoteScreenState extends State<VoiceToNoteScreen> {
 
   Future<void> _startOffline() async {
     if (_voskRecognizer == null) {
+      final locale = Localizations.localeOf(context);
+      final code = {
+            'vi': 'vi',
+            'en': 'en',
+          }[locale.languageCode] ??
+          'en';
       final model = await widget.vosk
-          .createModel('assets/models/vosk-model-small-en-us-0.15');
+          .createModel('assets/models/vosk-model-small-$code');
       _voskRecognizer = await widget.vosk.createRecognizer(model: model);
       _voskService = await widget.vosk.initSpeechService(_voskRecognizer!);
       _voskService!.onResult().listen((event) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,4 +47,5 @@ flutter:
     - assets/lottie/mascot2.json
     - assets/lottie/mascot3.json
     - assets/models/
-    - assets/models/vosk-model-small-en-us-0.15/
+    - assets/models/vosk-model-small-en/
+    - assets/models/vosk-model-small-vi/


### PR DESCRIPTION
## Summary
- Choose Vosk model based on the app's current locale when starting offline recognition.
- Add English and Vietnamese Vosk model placeholders and expose them via `pubspec.yaml`.

## Testing
- `flutter pub get` *(fails: command not found)*
- `apt-get update` *(fails: 403 from proxy)*
- `apt-get install -y flutter` *(fails: package not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7fe0f820833388394bc067f1ea77