### PR TITLE
Add tests for tag filtering and attachment deletion

### DIFF
--- a/lib/screens/note_detail_screen.dart
+++ b/lib/screens/note_detail_screen.dart
@@ -22,8 +22,11 @@ import '../services/gemini_service.dart';
 class NoteDetailScreen extends StatefulWidget {
   final Note note;
   final TTSService ttsService;
-  const NoteDetailScreen({super.key, required this.note, TTSService? ttsService})
-      : ttsService = ttsService ?? TTSService();
+  const NoteDetailScreen({
+    super.key,
+    required this.note,
+    TTSService? ttsService,
+  }) : ttsService = ttsService ?? TTSService();
 
   @override
   State<NoteDetailScreen> createState() => _NoteDetailScreenState();
@@ -133,9 +136,9 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
                   Padding(
                     padding: const EdgeInsets.only(left: 8),
                     child: Text(
-                      DateFormat.yMd(Localizations.localeOf(context).toString())
-                          .add_Hm()
-                          .format(_alarmTime!),
+                      DateFormat.yMd(
+                        Localizations.localeOf(context).toString(),
+                      ).add_Hm().format(_alarmTime!),
                     ),
                   ),
               ],
@@ -210,21 +213,32 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
               ],
             ),
             const SizedBox(height: 12),
-            ..._attachments.map(
-              (a) {
-                final ext = a.split('.').last.toLowerCase();
-                if (['jpg', 'jpeg', 'png', 'gif', 'bmp'].contains(ext)) {
-                  return Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 4),
-                    child: Image.file(File(a)),
-                  );
-                }
-                if (['mp3', 'wav'].contains(ext)) {
-                  return _AudioAttachment(path: a);
-                }
-                return ListTile(title: Text(a.split('/').last));
-              },
-            ),
+            ..._attachments.map((a) {
+              final ext = a.split('.').last.toLowerCase();
+              Widget child;
+              if (['jpg', 'jpeg', 'png', 'gif', 'bmp'].contains(ext)) {
+                child = Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 4),
+                  child: Image.file(File(a)),
+                );
+              } else if (['mp3', 'wav'].contains(ext)) {
+                child = _AudioAttachment(path: a);
+              } else {
+                child = ListTile(title: Text(a.split('/').last));
+              }
+              return Dismissible(
+                key: ValueKey(a),
+                direction: DismissDirection.endToStart,
+                onDismissed: (_) => setState(() => _attachments.remove(a)),
+                background: Container(
+                  color: Colors.red,
+                  alignment: Alignment.centerRight,
+                  padding: const EdgeInsets.only(right: 16),
+                  child: const Icon(Icons.delete, color: Colors.white),
+                ),
+                child: child,
+              );
+            }),
             const SizedBox(height: 12),
             ElevatedButton.icon(
               onPressed: () {
@@ -285,14 +299,17 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
 
     if (analysis != null) {
       final summaryCtrl = TextEditingController(text: analysis.summary);
-      final actionCtrl =
-          TextEditingController(text: analysis.actionItems.join('\n'));
-      final tagsCtrl =
-          TextEditingController(text: analysis.suggestedTags.join(', '));
+      final actionCtrl = TextEditingController(
+        text: analysis.actionItems.join('\n'),
+      );
+      final tagsCtrl = TextEditingController(
+        text: analysis.suggestedTags.join(', '),
+      );
       final datesCtrl = TextEditingController(
-          text: analysis.dates
-              .map((d) => DateFormat('yyyy-MM-dd').format(d))
-              .join(', '));
+        text: analysis.dates
+            .map((d) => DateFormat('yyyy-MM-dd').format(d))
+            .join(', '),
+      );
 
       final accepted = await showDialog<bool>(
         context: context,
@@ -308,8 +325,7 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
                 ),
                 TextField(
                   controller: actionCtrl,
-                  decoration:
-                      InputDecoration(labelText: l10n.actionItemsLabel),
+                  decoration: InputDecoration(labelText: l10n.actionItemsLabel),
                   maxLines: null,
                 ),
                 TextField(

--- a/test/home_screen_test.dart
+++ b/test/home_screen_test.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:notes_reminder_app/providers/note_provider.dart';
 import 'package:notes_reminder_app/screens/home_screen.dart';
+import 'package:notes_reminder_app/models/note.dart';
 
 void main() {
   testWidgets('add and delete notes', (tester) async {
@@ -15,10 +16,7 @@ void main() {
           locale: const Locale('vi'),
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
-          home: HomeScreen(
-            onThemeChanged: (_) {},
-            onFontScaleChanged: (_) {},
-          ),
+          home: HomeScreen(onThemeChanged: (_) {}, onFontScaleChanged: (_) {}),
         ),
       ),
     );
@@ -40,5 +38,63 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text(l10n.noNotes), findsOneWidget);
+  });
+
+  testWidgets('filter notes by tag', (tester) async {
+    final provider = NoteProvider();
+    await tester.pumpWidget(
+      ChangeNotifierProvider.value(
+        value: provider,
+        child: MaterialApp(
+          locale: const Locale('vi'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: HomeScreen(onThemeChanged: (_) {}, onFontScaleChanged: (_) {}),
+        ),
+      ),
+    );
+
+    await provider.addNote(
+      const Note(
+        id: '1',
+        title: 'n1',
+        content: 'c1',
+        summary: '',
+        actionItems: [],
+        dates: [],
+        tags: ['work'],
+      ),
+    );
+    await provider.addNote(
+      const Note(
+        id: '2',
+        title: 'n2',
+        content: 'c2',
+        summary: '',
+        actionItems: [],
+        dates: [],
+        tags: ['home'],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('n1'), findsOneWidget);
+    expect(find.text('n2'), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.label));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('work').last);
+    await tester.pumpAndSettle();
+
+    expect(find.text('n1'), findsOneWidget);
+    expect(find.text('n2'), findsNothing);
+
+    await tester.tap(find.byIcon(Icons.label));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('All').last);
+    await tester.pumpAndSettle();
+
+    expect(find.text('n1'), findsOneWidget);
+    expect(find.text('n2'), findsOneWidget);
   });
 }

--- a/test/note_detail_screen_test.dart
+++ b/test/note_detail_screen_test.dart
@@ -7,7 +7,6 @@ import 'package:notes_reminder_app/providers/note_provider.dart';
 import 'package:notes_reminder_app/screens/note_detail_screen.dart';
 
 void main() {
-
   testWidgets('display note details', (tester) async {
     final note = Note(
       id: '1',
@@ -28,10 +27,47 @@ void main() {
           supportedLocales: AppLocalizations.supportedLocales,
           home: NoteDetailScreen(note: note),
         ),
-
       ),
     );
 
     expect(find.text('content'), findsOneWidget);
+  });
+
+  testWidgets('remove attachment updates UI and data', (tester) async {
+    final provider = NoteProvider();
+    const note = Note(
+      id: '1',
+      title: 'title',
+      content: 'content',
+      summary: '',
+      actionItems: [],
+      dates: [],
+      attachments: ['a.txt'],
+    );
+    await provider.addNote(note);
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider.value(
+        value: provider,
+        child: MaterialApp(
+          locale: const Locale('vi'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: NoteDetailScreen(note: note),
+        ),
+      ),
+    );
+
+    expect(find.text('a.txt'), findsOneWidget);
+
+    await tester.drag(find.byType(Dismissible).first, const Offset(-500, 0));
+    await tester.pumpAndSettle();
+
+    expect(find.text('a.txt'), findsNothing);
+
+    await tester.tap(find.byIcon(Icons.save));
+    await tester.pumpAndSettle();
+
+    expect(provider.notes.first.attachments, isEmpty);
   });
 }


### PR DESCRIPTION
## Summary
- add dismissible attachments to NoteDetailScreen
- test tag filtering on HomeScreen
- test removing attachments in NoteDetailScreen

## Testing
- `flutter test` *(fails: Because every version of vosk_flutter depends on http ^0.13.5 and notes_reminder_app depends on http ^1.2.2, vosk_flutter is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ba8317fc148333b7bae8377f5c8aea