### PR TITLE
feat: localize all tags filter

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -54,6 +54,7 @@
   "audioLabel": "Audio",
 
   "tagsLabel": "Tags",
+  "allTags": "All tags",
   "addTag": "Add tag",
   "requireAuth": "Require authentication",
   "lockNote": "Lock note",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -54,6 +54,7 @@
   "audioLabel": "Âm thanh",
 
   "tagsLabel": "Tag",
+  "allTags": "Tất cả tag",
   "addTag": "Thêm tag",
   "requireAuth": "Yêu cầu xác thực",
   "lockNote": "Khóa ghi chú",

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -270,17 +270,23 @@ class _HomeScreenState extends State<HomeScreen> {
       appBar: AppBar(
         title: Text(AppLocalizations.of(context)!.appTitle),
         actions: [
-          PopupMenuButton<String>(
+          PopupMenuButton<String?>(
             icon: const Icon(Icons.label),
             onSelected: (value) {
               setState(() {
-                _selectedTag = value == 'All' ? null : value;
+                _selectedTag = value;
               });
             },
             itemBuilder: (context) => [
-              const PopupMenuItem(value: 'All', child: Text('All')),
+              PopupMenuItem<String?>(
+                value: null,
+                child: Text(AppLocalizations.of(context)!.allTags),
+              ),
               ...tags.map(
-                (t) => PopupMenuItem(value: t, child: Text(t)),
+                (t) => PopupMenuItem<String?>(
+                  value: t,
+                  child: Text(t),
+                ),
               ),
             ],
           ),


### PR DESCRIPTION
## Summary
- localize "All tags" option in tag filter popup
- allow null value and assign _selectedTag directly when choosing tags

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba831908dc8333bd7d4b8f22da15a8