### PR TITLE
Add delete option for attachments in note detail

### DIFF
--- a/lib/screens/note_detail_screen.dart
+++ b/lib/screens/note_detail_screen.dart
@@ -210,19 +210,45 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
               ],
             ),
             const SizedBox(height: 12),
-            ..._attachments.map(
-              (a) {
+            ..._attachments.asMap().entries.map(
+              (entry) {
+                final index = entry.key;
+                final a = entry.value;
                 final ext = a.split('.').last.toLowerCase();
                 if (['jpg', 'jpeg', 'png', 'gif', 'bmp'].contains(ext)) {
-                  return Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 4),
-                    child: Image.file(File(a)),
+                  return Stack(
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 4),
+                        child: Image.file(File(a)),
+                      ),
+                      Positioned(
+                        top: 0,
+                        right: 0,
+                        child: IconButton(
+                          icon: const Icon(Icons.close),
+                          onPressed: () =>
+                              setState(() => _attachments.removeAt(index)),
+                        ),
+                      ),
+                    ],
                   );
                 }
                 if (['mp3', 'wav'].contains(ext)) {
-                  return _AudioAttachment(path: a);
+                  return _AudioAttachment(
+                    path: a,
+                    onDelete: () =>
+                        setState(() => _attachments.removeAt(index)),
+                  );
                 }
-                return ListTile(title: Text(a.split('/').last));
+                return ListTile(
+                  title: Text(a.split('/').last),
+                  trailing: IconButton(
+                    icon: const Icon(Icons.delete),
+                    onPressed: () =>
+                        setState(() => _attachments.removeAt(index)),
+                  ),
+                );
               },
             ),
             const SizedBox(height: 12),
@@ -420,7 +446,8 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
 
 class _AudioAttachment extends StatefulWidget {
   final String path;
-  const _AudioAttachment({required this.path});
+  final VoidCallback? onDelete;
+  const _AudioAttachment({required this.path, this.onDelete});
 
   @override
   State<_AudioAttachment> createState() => _AudioAttachmentState();
@@ -449,9 +476,19 @@ class _AudioAttachmentState extends State<_AudioAttachment> {
   Widget build(BuildContext context) {
     return ListTile(
       title: Text(widget.path.split('/').last),
-      trailing: IconButton(
-        icon: Icon(_playing ? Icons.pause : Icons.play_arrow),
-        onPressed: _toggle,
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            icon: Icon(_playing ? Icons.pause : Icons.play_arrow),
+            onPressed: _toggle,
+          ),
+          if (widget.onDelete != null)
+            IconButton(
+              icon: const Icon(Icons.delete),
+              onPressed: widget.onDelete,
+            ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary
- enable removing attachments by wrapping each in a Stack/ListTile with delete button
- allow audio attachments to expose a delete button alongside playback controls

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68ba831911a483338a701ed9859cb6bc