### PR TITLE
Localize authentication prompt

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -57,6 +57,7 @@
   "addTag": "Add tag",
   "requireAuth": "Require authentication",
   "lockNote": "Lock note",
+  "authReason": "Please authenticate to continue",
   "voiceToNote": "Voice To Note",
   "stop": "Stop",
   "speak": "Speak",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -57,6 +57,7 @@
   "addTag": "Thêm tag",
   "requireAuth": "Yêu cầu xác thực",
   "lockNote": "Khóa ghi chú",
+  "authReason": "Vui lòng xác thực để tiếp tục",
   "voiceToNote": "Giọng nói thành ghi chú",
   "stop": "Dừng",
   "speak": "Nói",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,7 +22,9 @@ void main() async {
   final settings = SettingsService();
   final requireAuth = await settings.loadRequireAuth();
   if (requireAuth) {
-    final ok = await AuthService().authenticate();
+    final locale = WidgetsBinding.instance.platformDispatcher.locale;
+    final l10n = await AppLocalizations.delegate.load(locale);
+    final ok = await AuthService().authenticate(l10n);
     if (!ok) {
       return;
     }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -222,7 +222,8 @@ class _HomeScreenState extends State<HomeScreen> {
             ),
             onTap: () async {
               if (note.locked) {
-                final ok = await AuthService().authenticate();
+                final ok = await AuthService()
+                    .authenticate(AppLocalizations.of(context)!);
                 if (!ok) return;
               }
               Navigator.push(

--- a/lib/screens/note_list_for_day_screen.dart
+++ b/lib/screens/note_list_for_day_screen.dart
@@ -77,7 +77,8 @@ class NoteListForDayScreen extends StatelessWidget {
               isThreeLine: timeStr != null || note.tags.isNotEmpty,
               onTap: () async {
                 if (note.locked) {
-                  final ok = await AuthService().authenticate();
+                  final ok = await AuthService()
+                      .authenticate(AppLocalizations.of(context)!);
                   if (!ok) return;
                 }
                 Navigator.push(

--- a/lib/screens/note_search_delegate.dart
+++ b/lib/screens/note_search_delegate.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import '../models/note.dart';
 import 'note_detail_screen.dart';
 import '../services/auth_service.dart';
@@ -48,7 +49,8 @@ class NoteSearchDelegate extends SearchDelegate {
                 subtitle: Text(n.content),
                 onTap: () async {
                   if (n.locked) {
-                    final ok = await AuthService().authenticate();
+                    final ok = await AuthService()
+                        .authenticate(AppLocalizations.of(context)!);
                     if (!ok) return;
                   }
                   Navigator.push(

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,13 +1,14 @@
 import 'package:local_auth/local_auth.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class AuthService {
   final LocalAuthentication _auth;
   AuthService({LocalAuthentication? auth}) : _auth = auth ?? LocalAuthentication();
 
-  Future<bool> authenticate() async {
+  Future<bool> authenticate(AppLocalizations l10n) async {
     try {
       return await _auth.authenticate(
-        localizedReason: 'Please authenticate to continue',
+        localizedReason: l10n.authReason,
         options: const AuthenticationOptions(stickyAuth: true),
       );
     } catch (_) {


### PR DESCRIPTION
## Summary
- Localize biometric auth reason using `AppLocalizations`
- Add `authReason` key to English and Vietnamese ARB files
- Pass `AppLocalizations` into `AuthService.authenticate`

## Testing
- `flutter gen-l10n` *(fails: command not found)*
- `dart format lib/services/auth_service.dart ...` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ba8322d9088333ba97ca731424ee65