### PR TITLE
test: remove drag interaction in note detail attachment delete

### DIFF
--- a/test/note_detail_screen_test.dart
+++ b/test/note_detail_screen_test.dart
@@ -59,9 +59,11 @@ void main() {
     );
 
     expect(find.text('a.txt'), findsOneWidget);
+    await tester.tap(find.byIcon(Icons.delete));
 
-    await tester.drag(find.byType(Dismissible).first, const Offset(-500, 0));
-    await tester.pumpAndSettle();
+    while (find.text('a.txt').evaluate().isNotEmpty) {
+      await tester.pumpAndSettle();
+    }
 
     expect(find.text('a.txt'), findsNothing);
 


### PR DESCRIPTION
## Summary
- replace drag on attachment with tapping delete icon in note detail test
- wait for attachment to disappear before asserting absence

## Testing
- `flutter test test/note_detail_screen_test.dart` *(fails: Because every version of vosk_flutter depends on http ^0.13.5 and notes_reminder_app depends on http ^1.2.2, version solving failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9031b1c483338094ed7886a1df34