### PR TITLE
Handle deleted notes from Firestore

### DIFF
--- a/lib/providers/note_provider.dart
+++ b/lib/providers/note_provider.dart
@@ -40,6 +40,7 @@ class NoteProvider extends ChangeNotifier {
           .collection('notes')
           .where('userId', isEqualTo: user.uid)
           .get();
+      final remoteIds = snapshot.docs.map((d) => d.id).toList();
       final remoteNotes = await Future.wait(
         snapshot.docs.map((d) => _repository.decryptNote(d.data())),
       );
@@ -58,6 +59,7 @@ class NoteProvider extends ChangeNotifier {
           }
         }
       }
+      map.removeWhere((key, _) => !remoteIds.contains(key));
       _notes = map.values.toList();
       await _repository.saveNotes(_notes);
     }


### PR DESCRIPTION
## Summary
- Sync notes with Firestore by tracking remote IDs and removing local notes missing remotely

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ba90336b98833390016ed3cccdf289