### PR TITLE
Handle initialization failures gracefully

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,11 +14,33 @@ import 'firebase_options.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await Firebase.initializeApp(
-    options: DefaultFirebaseOptions.currentPlatform,
-  );
-  await FirebaseAuth.instance.signInAnonymously();
-  await NotificationService().init();
+  try {
+    await Firebase.initializeApp(
+      options: DefaultFirebaseOptions.currentPlatform,
+    );
+  } catch (e) {
+    debugPrint('Firebase init failed: $e');
+    runApp(
+      const MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: Text('Failed to initialize app'),
+          ),
+        ),
+      ),
+    );
+    return;
+  }
+  try {
+    await FirebaseAuth.instance.signInAnonymously();
+  } catch (e) {
+    debugPrint('Anonymous sign-in failed: $e');
+  }
+  try {
+    await NotificationService().init();
+  } catch (e) {
+    debugPrint('Notification setup failed: $e');
+  }
   final settings = SettingsService();
   final requireAuth = await settings.loadRequireAuth();
   if (requireAuth) {


### PR DESCRIPTION
## Summary
- Add try/catch around Firebase init, anonymous sign-in, and notification setup
- Show fallback UI when initialization fails and log recoverable errors

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*
- `sudo apt-get install -y dart` *(fails: Unable to locate package dart)*


------
https://chatgpt.com/codex/tasks/task_e_68ba96e1d4e08333beea6e5e93fddc0b