### PR TITLE
Handle network failures for Gemini service

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -26,6 +26,7 @@
   "errorWithMessage@placeholders": {
     "error": {}
   },
+  "networkError": "Network error. Please try again.",
   "readNote": "Read Note",
   "scheduleForDate": "Schedule for {date}",
   "scheduleForDate@placeholders": {

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -26,6 +26,7 @@
   "errorWithMessage@placeholders": {
     "error": {}
   },
+  "networkError": "Lỗi mạng. Vui lòng thử lại.",
   "readNote": "Đọc Note",
   "scheduleForDate": "Lịch ngày {date}",
   "scheduleForDate@placeholders": {

--- a/lib/services/gemini_service.dart
+++ b/lib/services/gemini_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -18,18 +19,24 @@ class GeminiService {
       ]
     };
 
-    final res = await http.post(
-      uri,
-      headers: {'Content-Type': 'application/json'},
-      body: jsonEncode(body),
-    );
+    try {
+      final res = await http
+          .post(
+            uri,
+            headers: {'Content-Type': 'application/json'},
+            body: jsonEncode(body),
+          )
+          .timeout(const Duration(seconds: 10));
 
-    if (res.statusCode == 200) {
-      final data = jsonDecode(res.body);
-      final text = (data['candidates']?[0]?['content']?['parts']?[0]?['text'] ?? '').toString();
-      return text.isEmpty ? l10n.noResponse : text;
-    } else {
-      return l10n.geminiError('${res.statusCode} ${res.body}');
+      if (res.statusCode == 200) {
+        final data = jsonDecode(res.body);
+        final text = (data['candidates']?[0]?['content']?['parts']?[0]?['text'] ?? '').toString();
+        return text.isEmpty ? l10n.noResponse : text;
+      } else {
+        return l10n.geminiError('${res.statusCode} ${res.body}');
+      }
+    } catch (_) {
+      return l10n.errorWithMessage(l10n.networkError);
     }
   }
 
@@ -49,11 +56,18 @@ class GeminiService {
       ]
     };
 
-    final res = await http.post(
-      uri,
-      headers: {'Content-Type': 'application/json'},
-      body: jsonEncode(body),
-    );
+    http.Response res;
+    try {
+      res = await http
+          .post(
+            uri,
+            headers: {'Content-Type': 'application/json'},
+            body: jsonEncode(body),
+          )
+          .timeout(const Duration(seconds: 10));
+    } catch (_) {
+      return null;
+    }
 
     if (res.statusCode != 200) return null;
 


### PR DESCRIPTION
## Summary
- Add 10s timeout and network exception handling for Gemini API requests
- Localize network error message in English and Vietnamese

## Testing
- `dart format lib/services/gemini_service.dart lib/l10n/app_en.arb lib/l10n/app_vi.arb` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `flutter gen-l10n` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba96e3ffd08333ba13bdd451577eee