### PR TITLE
Refactor SettingsService to reuse SharedPreferences

### DIFF
--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -2,49 +2,59 @@ import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class SettingsService {
+  SettingsService({SharedPreferences? sharedPreferences})
+      : _preferences = sharedPreferences;
+
   static const _kThemeColor = 'theme_color';
   static const _kMascotPath = 'mascot_path';
   static const _kFontScale = 'font_scale';
   static const _kRequireAuth = 'require_auth';
 
+  SharedPreferences? _preferences;
+
+  Future<SharedPreferences> get _sp async {
+    _preferences ??= await SharedPreferences.getInstance();
+    return _preferences!;
+  }
+
   Future<void> saveThemeColor(Color color) async {
-    final sp = await SharedPreferences.getInstance();
+    final sp = await _sp;
     await sp.setInt(_kThemeColor, color.value);
   }
 
   Future<Color> loadThemeColor() async {
-    final sp = await SharedPreferences.getInstance();
+    final sp = await _sp;
     final v = sp.getInt(_kThemeColor);
     return v != null ? Color(v) : Colors.blue;
   }
 
   Future<void> saveMascotPath(String path) async {
-    final sp = await SharedPreferences.getInstance();
+    final sp = await _sp;
     await sp.setString(_kMascotPath, path);
   }
 
   Future<String> loadMascotPath() async {
-    final sp = await SharedPreferences.getInstance();
+    final sp = await _sp;
     return sp.getString(_kMascotPath) ?? 'assets/lottie/mascot.json';
   }
 
   Future<void> saveFontScale(double scale) async {
-    final sp = await SharedPreferences.getInstance();
+    final sp = await _sp;
     await sp.setDouble(_kFontScale, scale);
   }
 
   Future<double> loadFontScale() async {
-    final sp = await SharedPreferences.getInstance();
+    final sp = await _sp;
     return sp.getDouble(_kFontScale) ?? 1.0;
   }
 
   Future<void> saveRequireAuth(bool value) async {
-    final sp = await SharedPreferences.getInstance();
+    final sp = await _sp;
     await sp.setBool(_kRequireAuth, value);
   }
 
   Future<bool> loadRequireAuth() async {
-    final sp = await SharedPreferences.getInstance();
+    final sp = await _sp;
     return sp.getBool(_kRequireAuth) ?? false;
   }
 }


### PR DESCRIPTION
## Summary
- Reuse a lazily loaded SharedPreferences instance across settings operations
- Allow injecting a custom SharedPreferences for easier testing

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba96e590a483339d5fc44ca61f3bf2