### PR TITLE
Use timestamp-based notification IDs

### DIFF
--- a/lib/providers/note_provider.dart
+++ b/lib/providers/note_provider.dart
@@ -78,7 +78,7 @@ class NoteProvider extends ChangeNotifier {
   }) async {
     final noteId = const Uuid().v4();
     final notificationId =
-        alarmTime != null ? const Uuid().v4().hashCode : null;
+        alarmTime != null ? DateTime.now().millisecondsSinceEpoch : null;
 
     final note = Note(
       id: noteId,

--- a/lib/screens/note_detail_screen.dart
+++ b/lib/screens/note_detail_screen.dart
@@ -8,7 +8,6 @@ import 'package:provider/provider.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:intl/intl.dart';
-import 'package:uuid/uuid.dart';
 
 import '../models/note.dart';
 import '../providers/note_provider.dart';
@@ -396,7 +395,7 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
 
     int? newId;
     if (_alarmTime != null) {
-      newId = const Uuid().v4().hashCode;
+      newId = DateTime.now().millisecondsSinceEpoch;
     }
 
     final updated = widget.note.copyWith(


### PR DESCRIPTION
## Summary
- generate notification IDs using `DateTime.now().millisecondsSinceEpoch` to avoid negative or colliding hashCodes
- update note detail screen to schedule/cancel notifications with the new ID generation

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9b85d9d4833391ebb77a2627bd41