### PR TITLE
Validate note fields before saving

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3,6 +3,7 @@
   "addNoteReminder": "Add note / reminder",
   "titleLabel": "Title",
   "contentLabel": "Content",
+  "fieldRequired": "This field cannot be empty",
   "selectReminderTime": "Select reminder time",
   "cancel": "Cancel",
   "save": "Save",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -3,6 +3,7 @@
   "addNoteReminder": "Thêm ghi chú / nhắc lịch",
   "titleLabel": "Tiêu đề",
   "contentLabel": "Nội dung",
+  "fieldRequired": "Không được để trống",
   "selectReminderTime": "Chọn thời gian nhắc",
   "cancel": "Hủy",
   "save": "Lưu",


### PR DESCRIPTION
## Summary
- require non-empty title and content when adding a note
- disable Save button until inputs are valid and show localized error messages

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9b8803a4833391fdcc20ea77bec7