### PR TITLE
Localize SnackBar messages

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -82,6 +82,8 @@
   "aiSuggestionsTitle": "AI Suggestions",
   "summaryLabel": "Summary",
   "actionItemsLabel": "Action items",
-  "datesLabel": "Dates"
+  "datesLabel": "Dates",
+  "authFailedMessage": "Anonymous sign-in failed. Limited functionality.",
+  "notificationFailedMessage": "Notification setup failed."
 
 }

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -82,6 +82,8 @@
   "aiSuggestionsTitle": "Gợi ý AI",
   "summaryLabel": "Tóm tắt",
   "actionItemsLabel": "Cần làm",
-  "datesLabel": "Ngày"
+  "datesLabel": "Ngày",
+  "authFailedMessage": "Đăng nhập ẩn danh thất bại. Chức năng bị hạn chế.",
+  "notificationFailedMessage": "Thiết lập thông báo thất bại."
 
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -99,17 +99,18 @@ class _MyAppState extends State<MyApp> {
     _themeColor = widget.themeColor;
     _fontScale = widget.fontScale;
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      final l10n = AppLocalizations.of(context)!;
       if (widget.authFailed) {
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Anonymous sign-in failed. Limited functionality.'),
+          SnackBar(
+            content: Text(l10n.authFailedMessage),
           ),
         );
       }
       if (widget.notificationFailed) {
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Notification setup failed.'),
+          SnackBar(
+            content: Text(l10n.notificationFailedMessage),
           ),
         );
       }


### PR DESCRIPTION
## Summary
- Replace hard-coded SnackBar strings with localized messages
- Add English and Vietnamese translations for auth and notification errors

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68baa41ed8ac83339e18b37ccf380726