### PR TITLE
Handle note creation failures with feedback

### DIFF
--- a/lib/providers/note_provider.dart
+++ b/lib/providers/note_provider.dart
@@ -68,7 +68,7 @@ class NoteProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> createNote({
+  Future<bool> createNote({
     required String title,
     required String content,
     required AppLocalizations l10n,
@@ -105,6 +105,8 @@ class NoteProvider extends ChangeNotifier {
         l10n: l10n,
       );
     }
+
+    return ok;
   }
   
   Future<bool> addNote(Note note) async {

--- a/lib/widgets/add_note_dialog.dart
+++ b/lib/widgets/add_note_dialog.dart
@@ -140,7 +140,7 @@ class _AddNoteDialogState extends State<AddNoteDialog> {
                   if (!(_formKey.currentState?.validate() ?? false)) {
                     return;
                   }
-                  await provider.createNote(
+                  final ok = await provider.createNote(
                     title: _titleCtrl.text,
                     content: _contentCtrl.text,
                     tags: _tags,
@@ -148,9 +148,19 @@ class _AddNoteDialogState extends State<AddNoteDialog> {
                     alarmTime: _alarmTime,
                     l10n: l10n,
                   );
-                  provider.setDraft('');
                   if (!mounted) return;
-                  Navigator.pop(context);
+                  if (ok) {
+                    provider.setDraft('');
+                    Navigator.pop(context);
+                  } else {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: Text(
+                          l10n.errorWithMessage(l10n.networkError),
+                        ),
+                      ),
+                    );
+                  }
                 }
               : null,
           child: Text(l10n.save),


### PR DESCRIPTION
## Summary
- Make `createNote` return a boolean success flag
- Preserve draft and show error snackbar when note creation fails

## Testing
- ⚠️ `flutter test` *(command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68baa420d7248333813043ece88997e9