### PR TITLE
Handle update failure when saving notes

### DIFF
--- a/lib/screens/note_detail_screen.dart
+++ b/lib/screens/note_detail_screen.dart
@@ -414,7 +414,18 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
       actionItems: actionItems,
       dates: dates,
     );
-    await context.read<NoteProvider>().updateNote(updated);
+    final ok = await context.read<NoteProvider>().updateNote(updated);
+
+    if (!ok) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(l10n.errorWithMessage('Failed to save note')),
+        ),
+      );
+      Navigator.pop(context);
+      return;
+    }
 
     if (_alarmTime != null && newId != null) {
       if (_repeat == RepeatInterval.daily) {


### PR DESCRIPTION
## Summary
- Save the result of updating a note and show a SnackBar when the update fails before closing the screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68baa9e645cc8333be461bc3105e6810