### PR TITLE
Add auth and calendar service tests with mocks

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,12 +35,14 @@ dependencies:
   firebase_core: ^4.1.0
   cloud_firestore: ^6.0.1
   firebase_auth: ^6.0.2
+  google_sign_in: ^6.2.1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^2.0.0
   mocktail: ^1.0.4
+  google_sign_in_platform_interface: ^2.4.0
 
 dependency_overrides:
   http: ^0.13.5

--- a/test/auth_service_test.dart
+++ b/test/auth_service_test.dart
@@ -1,0 +1,42 @@
+import 'dart:ui';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:local_auth/local_auth.dart';
+import 'package:notes_reminder_app/services/auth_service.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+class MockLocalAuth extends Mock implements LocalAuthentication {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late MockLocalAuth mock;
+  late AuthService service;
+  late AppLocalizations l10n;
+
+  setUp(() async {
+    mock = MockLocalAuth();
+    service = AuthService(auth: mock);
+    l10n = await AppLocalizations.delegate.load(const Locale('en'));
+  });
+
+  test('authenticate returns true on success', () async {
+    when(() => mock.authenticate(
+          localizedReason: any(named: 'localizedReason'),
+          options: any(named: 'options'),
+        )).thenAnswer((_) async => true);
+
+    final ok = await service.authenticate(l10n);
+    expect(ok, isTrue);
+  });
+
+  test('authenticate returns false on failure', () async {
+    when(() => mock.authenticate(
+          localizedReason: any(named: 'localizedReason'),
+          options: any(named: 'options'),
+        )).thenThrow(Exception('fail'));
+
+    final ok = await service.authenticate(l10n);
+    expect(ok, isFalse);
+  });
+}

--- a/test/calendar_service_test.dart
+++ b/test/calendar_service_test.dart
@@ -1,0 +1,160 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_sign_in_platform_interface/google_sign_in_platform_interface.dart';
+import 'package:notes_reminder_app/services/calendar_service.dart';
+
+class FakeSignInSuccess extends GoogleSignInPlatform {
+  @override
+  Future<void> init({
+    List<String>? scopes,
+    String? signInOption,
+    String? clientId,
+    bool? forceCodeForRefreshToken,
+    String? hostedDomain,
+  }) async {}
+
+  @override
+  Future<GoogleSignInUserData?> signInSilently() async =>
+      const GoogleSignInUserData(email: 'e', id: '1', displayName: 'd');
+
+  @override
+  Future<GoogleSignInUserData?> signIn() async =>
+      const GoogleSignInUserData(email: 'e', id: '1', displayName: 'd');
+
+  @override
+  Future<GoogleSignInTokenData> getTokens({
+    required String email,
+    bool? shouldRecoverAuth,
+  }) async =>
+      const GoogleSignInTokenData(accessToken: 'token', idToken: 'id');
+}
+
+class FakeSignInFail extends GoogleSignInPlatform {
+  @override
+  Future<void> init({
+    List<String>? scopes,
+    String? signInOption,
+    String? clientId,
+    bool? forceCodeForRefreshToken,
+    String? hostedDomain,
+  }) async {}
+
+  @override
+  Future<GoogleSignInUserData?> signInSilently() async => null;
+
+  @override
+  Future<GoogleSignInUserData?> signIn() async => null;
+
+  @override
+  Future<GoogleSignInTokenData> getTokens({
+    required String email,
+    bool? shouldRecoverAuth,
+  }) async =>
+      const GoogleSignInTokenData(accessToken: '', idToken: '');
+}
+
+class FakeHttpClient extends HttpClient {
+  @override
+  Future<HttpClientRequest> openUrl(String method, Uri url) async {
+    return FakeHttpClientRequest(method, url);
+  }
+
+  @override
+  void close({bool force = false}) {}
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class FakeHttpClientRequest implements HttpClientRequest {
+  final String method;
+  final Uri url;
+  @override
+  final HttpHeaders headers = HttpHeaders();
+  @override
+  bool followRedirects = true;
+  @override
+  int maxRedirects = 5;
+  @override
+  int contentLength = 0;
+
+  FakeHttpClientRequest(this.method, this.url);
+
+  @override
+  void add(List<int> data) {}
+
+  @override
+  Future<HttpClientResponse> close() async {
+    if (method == 'POST') {
+      return FakeHttpClientResponse(200, '{"id":"fake-id"}');
+    } else {
+      return FakeHttpClientResponse(200, '');
+    }
+  }
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class FakeHttpClientResponse extends Stream<List<int>>
+    implements HttpClientResponse {
+  final int _statusCode;
+  final List<int> _body;
+  FakeHttpClientResponse(this._statusCode, String body)
+      : _body = utf8.encode(body);
+
+  @override
+  int get statusCode => _statusCode;
+  @override
+  int get contentLength => _body.length;
+  @override
+  bool get isRedirect => false;
+  @override
+  bool get persistentConnection => false;
+  @override
+  String get reasonPhrase => '';
+  @override
+  HttpHeaders get headers => HttpHeaders();
+
+  @override
+  StreamSubscription<List<int>> listen(void Function(List<int>)? onData,
+      {Function? onError, void Function()? onDone, bool? cancelOnError}) {
+    return Stream<List<int>>.fromIterable([_body]).listen(onData,
+        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+  }
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('createEvent returns event id on success', () async {
+    final previous = GoogleSignInPlatform.instance;
+    GoogleSignInPlatform.instance = FakeSignInSuccess();
+    final id = await HttpOverrides.runZoned(() async {
+      return await CalendarService.instance.createEvent(
+        title: 't',
+        description: 'd',
+        start: DateTime(2024, 1, 1),
+      );
+    }, createHttpClient: (context) => FakeHttpClient());
+    expect(id, 'fake-id');
+    GoogleSignInPlatform.instance = previous;
+  });
+
+  test('createEvent returns null when sign in fails', () async {
+    final previous = GoogleSignInPlatform.instance;
+    GoogleSignInPlatform.instance = FakeSignInFail();
+    final id = await CalendarService.instance.createEvent(
+      title: 't',
+      description: 'd',
+      start: DateTime(2024, 1, 1),
+    );
+    expect(id, isNull);
+    GoogleSignInPlatform.instance = previous;
+  });
+}


### PR DESCRIPTION
## Summary
- add google sign-in dependency
- add tests for AuthService using mocked LocalAuthentication
- add tests for CalendarService using fake GoogleSignIn and HttpClient

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68baa9e849448333abe1737b33fb03bd