### PR TITLE
Handle audio playback errors

### DIFF
--- a/lib/screens/note_detail_screen.dart
+++ b/lib/screens/note_detail_screen.dart
@@ -469,12 +469,23 @@ class _AudioAttachmentState extends State<_AudioAttachment> {
   }
 
   Future<void> _toggle() async {
-    if (_playing) {
-      await _player.pause();
-    } else {
-      await _player.play(DeviceFileSource(widget.path));
+    try {
+      if (_playing) {
+        await _player.pause();
+      } else {
+        await _player.play(DeviceFileSource(widget.path));
+      }
+      if (!mounted) return;
+      setState(() => _playing = !_playing);
+    } catch (e) {
+      if (!mounted) return;
+      final l10n = AppLocalizations.of(context)!;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(l10n.errorWithMessage(e.toString())),
+        ),
+      );
     }
-    setState(() => _playing = !_playing);
   }
 
   @override


### PR DESCRIPTION
## Summary
- wrap audio play/pause calls in try/catch
- show SnackBar when playback fails and keep state consistent

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68baa9e8e8dc83339e729a79e5e5e918