### PR TITLE
feat: add notes backup and restore

### DIFF
--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -3,6 +3,9 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:lottie/lottie.dart';
 
 import '../services/settings_service.dart';
+import '../services/note_repository.dart';
+import 'package:provider/provider.dart';
+import '../providers/note_provider.dart';
 
 class SettingsScreen extends StatefulWidget {
   final Function(Color) onThemeChanged;
@@ -20,6 +23,7 @@ class SettingsScreen extends StatefulWidget {
 
 class _SettingsScreenState extends State<SettingsScreen> {
   final SettingsService _settings = SettingsService();
+  final NoteRepository _noteRepository = NoteRepository();
   bool _requireAuth = false;
 
   @override
@@ -136,6 +140,23 @@ class _SettingsScreenState extends State<SettingsScreen> {
     _settings.saveRequireAuth(v);
   }
 
+  Future<void> _exportNotes() async {
+    await _noteRepository.exportNotes();
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Notes exported')),
+    );
+  }
+
+  Future<void> _importNotes() async {
+    await _noteRepository.importNotes();
+    if (!mounted) return;
+    await context.read<NoteProvider>().loadNotes();
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Notes imported')),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -155,6 +176,14 @@ class _SettingsScreenState extends State<SettingsScreen> {
           ListTile(
             title: Text(AppLocalizations.of(context)!.fontSize),
             onTap: _changeFontScale,
+          ),
+          ListTile(
+            title: const Text('Export notes'),
+            onTap: _exportNotes,
+          ),
+          ListTile(
+            title: const Text('Import notes'),
+            onTap: _importNotes,
           ),
           SwitchListTile(
             title: Text(AppLocalizations.of(context)!.requireAuth),

--- a/lib/services/backup_service.dart
+++ b/lib/services/backup_service.dart
@@ -1,0 +1,36 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+
+import '../models/note.dart';
+
+class BackupService {
+  Future<void> exportNotes(List<Note> notes) async {
+    final path = await FilePicker.platform.saveFile(
+      dialogTitle: 'Export Notes',
+      fileName: 'notes_backup.json',
+      type: FileType.custom,
+      allowedExtensions: ['json'],
+    );
+    if (path == null) return;
+    final file = File(path);
+    final data = jsonEncode(notes.map((n) => n.toJson()).toList());
+    await file.writeAsString(data);
+  }
+
+  Future<List<Note>> importNotes() async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['json'],
+    );
+    if (result == null || result.files.single.path == null) return [];
+    final file = File(result.files.single.path!);
+    final content = await file.readAsString();
+    final list = jsonDecode(content) as List<dynamic>;
+    return list
+        .map((e) => Note.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+}
+

--- a/lib/services/note_repository.dart
+++ b/lib/services/note_repository.dart
@@ -1,10 +1,14 @@
 import '../models/note.dart';
 import 'db_service.dart';
+import 'backup_service.dart';
 
 class NoteRepository {
   final DbService _dbService;
+  final BackupService _backupService;
 
-  NoteRepository({DbService? dbService}) : _dbService = dbService ?? DbService();
+  NoteRepository({DbService? dbService, BackupService? backupService})
+      : _dbService = dbService ?? DbService(),
+        _backupService = backupService ?? BackupService();
 
   Future<List<Note>> getNotes() {
     return _dbService.getNotes();
@@ -26,6 +30,19 @@ class NoteRepository {
 
   Future<Note> decryptNote(Map<String, dynamic> data) {
     return _dbService.decryptNote(data);
+  }
+
+  Future<void> exportNotes() async {
+    final notes = await _dbService.getNotes();
+    await _backupService.exportNotes(notes);
+  }
+
+  Future<List<Note>> importNotes() async {
+    final notes = await _backupService.importNotes();
+    if (notes.isNotEmpty) {
+      await _dbService.saveNotes(notes);
+    }
+    return notes;
   }
 
 }


### PR DESCRIPTION
## Summary
- add BackupService to handle JSON export and import
- wire NoteRepository to export/import notes using BackupService
- expose backup and restore options in settings UI

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bad6ac0ad48333873eabf999df8d97