### PR TITLE
Persist unsynced notes and auto sync on connectivity

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   firebase_core: ^4.1.0
   cloud_firestore: ^6.0.1
   firebase_auth: ^6.0.2
+  connectivity_plus: ^6.1.5
 
   google_sign_in: ^6.2.1
 


### PR DESCRIPTION
## Summary
- Persist unsynced note IDs in local storage using SharedPreferences
- Add connectivity listener and Firestore offline persistence to auto-sync notes when online
- Add connectivity_plus dependency

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bad6aeafac8333bc8315f0346be565