### PR TITLE
Handle initialization failures for auth and notifications

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,12 +18,23 @@ import 'firebase_options.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  bool authFailed = false;
+  bool notificationFailed = false;
 
-  await Firebase.initializeApp(
-    options: DefaultFirebaseOptions.currentPlatform,
-  );
-  await FirebaseAuth.instance.signInAnonymously();
-  await NotificationService().init();
+  try {
+    await Firebase.initializeApp(
+      options: DefaultFirebaseOptions.currentPlatform,
+    );
+    await FirebaseAuth.instance.signInAnonymously();
+  } catch (e) {
+    authFailed = true;
+  }
+
+  try {
+    await NotificationService().init();
+  } catch (e) {
+    notificationFailed = true;
+  }
 
   final settings = SettingsService();
   final requireAuth = await settings.loadRequireAuth();


### PR DESCRIPTION
## Summary
- Guard Firebase initialization and anonymous sign-in with try/catch to flag authentication errors.
- Protect notification setup with error handling and surface failures via state flags.
- Pass initialization error flags into the app to trigger user-facing SnackBars.

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68badb5bc2e08333854b6cac2ec7f14a