### PR TITLE
feat: add create note API

### DIFF
--- a/test/note_provider_test.dart
+++ b/test/note_provider_test.dart
@@ -5,16 +5,19 @@ import 'package:notes_reminder_app/providers/note_provider.dart';
 import 'package:notes_reminder_app/services/note_repository.dart';
 import 'package:notes_reminder_app/services/calendar_service.dart';
 import 'package:notes_reminder_app/services/notification_service.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class MockRepo extends Mock implements NoteRepository {}
 class MockCalendar extends Mock implements CalendarService {}
 class MockNotification extends Mock implements NotificationService {}
+class FakeL10n extends Fake implements AppLocalizations {}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUpAll(() {
     registerFallbackValue<List<Note>>([]);
+    registerFallbackValue(DateTime(0));
   });
 
   test('removeNoteAt cancels notification and deletes event', () async {
@@ -49,5 +52,60 @@ void main() {
     verify(() => notification.cancel(123)).called(1);
     verify(() => calendar.deleteEvent('e1')).called(1);
     verify(() => repo.saveNotes([])).called(1);
+  });
+
+  test('createNote schedules notification', () async {
+    final repo = MockRepo();
+    final calendar = MockCalendar();
+    final notification = MockNotification();
+    final l10n = FakeL10n();
+    when(() => repo.saveNotes(any())).thenAnswer((_) async {});
+    when(
+      () => notification.scheduleNotification(
+        id: any(named: 'id'),
+        title: any(named: 'title'),
+        body: any(named: 'body'),
+        scheduledDate: any(named: 'scheduledDate'),
+        l10n: l10n,
+      ),
+    ).thenAnswer((_) async {});
+    when(
+      () => calendar.createEvent(
+        title: any(named: 'title'),
+        description: any(named: 'description'),
+        start: any(named: 'start'),
+      ),
+    ).thenAnswer((_) async => 'e1');
+
+    final provider = NoteProvider(
+      repository: repo,
+      calendarService: calendar,
+      notificationService: notification,
+    );
+
+    final ok = await provider.createNote(
+      title: 't',
+      content: 'c',
+      alarmTime: DateTime(2025, 1, 1),
+      l10n: l10n,
+    );
+
+    expect(ok, isTrue);
+    expect(provider.notes.length, 1);
+    final note = provider.notes.first;
+    expect(note.notificationId, isNotNull);
+    expect(note.notificationId! > 0, isTrue);
+    verify(() => repo.saveNotes(any())).called(1);
+    final captured = verify(
+      () => notification.scheduleNotification(
+        id: captureAny(named: 'id'),
+        title: 't',
+        body: 'c',
+        scheduledDate: any(named: 'scheduledDate'),
+        l10n: l10n,
+      ),
+    ).captured;
+    expect(captured.first, isA<int>());
+    expect(captured.first > 0, isTrue);
   });
 }


### PR DESCRIPTION
## Summary
- add note creation method that schedules positive notification and saves to Firestore
- test note creation scheduling

## Testing
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68badb627ddc83339078fc446c5532fa