### PR TITLE
Add localized error handling to backup service

### DIFF
--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -141,7 +141,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
   }
 
   Future<void> _exportNotes() async {
-    await _noteRepository.exportNotes();
+    final l10n = AppLocalizations.of(context)!;
+    await _noteRepository.exportNotes(l10n);
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(content: Text('Notes exported')),
@@ -149,7 +150,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
   }
 
   Future<void> _importNotes() async {
-    await _noteRepository.importNotes();
+    final l10n = AppLocalizations.of(context)!;
+    await _noteRepository.importNotes(l10n);
     if (!mounted) return;
     await context.read<NoteProvider>().loadNotes();
     ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/services/backup_service.dart
+++ b/lib/services/backup_service.dart
@@ -2,31 +2,55 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import '../models/note.dart';
 
 class BackupService {
-  Future<void> exportNotes(List<Note> notes) async {
-    final path = await FilePicker.platform.saveFile(
-      dialogTitle: 'Export Notes',
-      fileName: 'notes_backup.json',
-      type: FileType.custom,
-      allowedExtensions: ['json'],
-    );
+  Future<void> exportNotes(List<Note> notes, AppLocalizations l10n) async {
+    String? path;
+    try {
+      path = await FilePicker.platform.saveFile(
+        dialogTitle: 'Export Notes',
+        fileName: 'notes_backup.json',
+        type: FileType.custom,
+        allowedExtensions: ['json'],
+      );
+    } catch (e) {
+      debugPrint(l10n.errorWithMessage(e.toString()));
+      return;
+    }
     if (path == null) return;
     final file = File(path);
     final data = jsonEncode(notes.map((n) => n.toJson()).toList());
-    await file.writeAsString(data);
+    try {
+      await file.writeAsString(data);
+    } catch (e) {
+      debugPrint(l10n.errorWithMessage(e.toString()));
+    }
   }
 
-  Future<List<Note>> importNotes() async {
-    final result = await FilePicker.platform.pickFiles(
-      type: FileType.custom,
-      allowedExtensions: ['json'],
-    );
+  Future<List<Note>> importNotes(AppLocalizations l10n) async {
+    FilePickerResult? result;
+    try {
+      result = await FilePicker.platform.pickFiles(
+        type: FileType.custom,
+        allowedExtensions: ['json'],
+      );
+    } catch (e) {
+      debugPrint(l10n.errorWithMessage(e.toString()));
+      return [];
+    }
     if (result == null || result.files.single.path == null) return [];
     final file = File(result.files.single.path!);
-    final content = await file.readAsString();
+    String content;
+    try {
+      content = await file.readAsString();
+    } catch (e) {
+      debugPrint(l10n.errorWithMessage(e.toString()));
+      return [];
+    }
     final list = jsonDecode(content) as List<dynamic>;
     return list
         .map((e) => Note.fromJson(e as Map<String, dynamic>))

--- a/lib/services/note_repository.dart
+++ b/lib/services/note_repository.dart
@@ -1,3 +1,5 @@
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import '../models/note.dart';
 import 'db_service.dart';
 import 'backup_service.dart';
@@ -32,13 +34,13 @@ class NoteRepository {
     return _dbService.decryptNote(data);
   }
 
-  Future<void> exportNotes() async {
+  Future<void> exportNotes(AppLocalizations l10n) async {
     final notes = await _dbService.getNotes();
-    await _backupService.exportNotes(notes);
+    await _backupService.exportNotes(notes, l10n);
   }
 
-  Future<List<Note>> importNotes() async {
-    final notes = await _backupService.importNotes();
+  Future<List<Note>> importNotes(AppLocalizations l10n) async {
+    final notes = await _backupService.importNotes(l10n);
     if (notes.isNotEmpty) {
       await _dbService.saveNotes(notes);
     }


### PR DESCRIPTION
## Summary
- handle file picker read/write errors with AppLocalizations
- propagate localization through NoteRepository and settings screen

## Testing
- `flutter test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68badd38013883339d832821b3c0e8aa