### PR TITLE
Handle offline speech init errors

### DIFF
--- a/lib/screens/voice_to_note_screen.dart
+++ b/lib/screens/voice_to_note_screen.dart
@@ -41,10 +41,21 @@ class _VoiceToNoteScreenState extends State<VoiceToNoteScreen> {
             'en': 'en',
           }[locale.languageCode] ??
           'en';
-      final model = await widget.vosk
-          .createModel('assets/models/vosk-model-small-$code');
-      _voskRecognizer = await widget.vosk.createRecognizer(model: model);
-      _voskService = await widget.vosk.initSpeechService(_voskRecognizer!);
+      try {
+        final model = await widget.vosk
+            .createModel('assets/models/vosk-model-small-$code');
+        _voskRecognizer = await widget.vosk.createRecognizer(model: model);
+        _voskService = await widget.vosk.initSpeechService(_voskRecognizer!);
+      } catch (e) {
+        if (!mounted) return;
+        final l10n = AppLocalizations.of(context)!;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(l10n.errorWithMessage(e.toString())),
+          ),
+        );
+        return;
+      }
       _voskService!.onResult().listen((event) {
         final data = jsonDecode(event) as Map<String, dynamic>;
         setState(() => _recognized = data['text'] ?? '');


### PR DESCRIPTION
## Summary
- add error handling when initializing offline speech recognition

## Testing
- `dart format lib/screens/voice_to_note_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68badd39e91c8333ab7fca5d687257d4