### PR TITLE
Remove duplicate connectivity_plus and http override

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -507,10 +507,10 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
+      sha256: "b9c29a161230ee03d3ccf545097fccd9b87a5264228c5d348202e0f0c28f9010"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.6"
+    version: "1.2.2"
   http_parser:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,7 +36,6 @@ dependencies:
   firebase_core: ^4.1.0
   cloud_firestore: ^6.0.1
   firebase_auth: ^6.0.2
-  connectivity_plus: ^6.1.5
 
   google_sign_in: ^6.2.1
 
@@ -51,7 +50,6 @@ dev_dependencies:
     sdk: flutter
 
 dependency_overrides:
-  http: ^0.13.5
   archive: ^4.0.0
 
 flutter:


### PR DESCRIPTION
## Summary
- remove duplicated `connectivity_plus` entry
- drop `http` dependency override and update lockfile

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68baee6b8be88333929b2d0ee48260f7