### PR TITLE
Localize notes import/export SnackBars

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -44,6 +44,9 @@
   "noteDeleted": "Note deleted",
   "undo": "Undo",
 
+  "notesExported": "Notes exported",
+  "notesImported": "Notes imported",
+
   "repeatLabel": "Repeat:",
   "repeatNone": "None",
   "repeatEveryMinute": "Every minute",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -44,6 +44,9 @@
   "noteDeleted": "Đã xóa ghi chú",
   "undo": "Hoàn tác",
 
+  "notesExported": "Đã xuất ghi chú",
+  "notesImported": "Đã nhập ghi chú",
+
   "repeatLabel": "Lặp lại:",
   "repeatNone": "Không",
   "repeatEveryMinute": "Mỗi phút",

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -145,7 +145,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     await _noteRepository.exportNotes(l10n);
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Notes exported')),
+      SnackBar(content: Text(l10n.notesExported)),
     );
   }
 
@@ -155,7 +155,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     if (!mounted) return;
     await context.read<NoteProvider>().loadNotes();
     ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Notes imported')),
+      SnackBar(content: Text(l10n.notesImported)),
     );
   }
 


### PR DESCRIPTION
## Summary
- add `notesExported` and `notesImported` localizations in English and Vietnamese
- use localized strings in SnackBars when exporting or importing notes

## Testing
- `flutter test` *(fails: command not found; attempted to install flutter but package not available)*

------
https://chatgpt.com/codex/tasks/task_e_68baee7038208333a38698650248cf4c