### PR TITLE
Use global scaffold messenger key

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,6 +16,8 @@ import 'package:provider/provider.dart';
 import 'providers/note_provider.dart';
 import 'firebase_options.dart';
 
+final messengerKey = GlobalKey<ScaffoldMessengerState>();
+
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   bool authFailed = false;
@@ -93,14 +95,14 @@ class _MyAppState extends State<MyApp> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final l10n = AppLocalizations.of(context)!;
       if (widget.authFailed) {
-        ScaffoldMessenger.of(context).showSnackBar(
+        messengerKey.currentState?.showSnackBar(
           SnackBar(
             content: Text(l10n.authFailedMessage),
           ),
         );
       }
       if (widget.notificationFailed) {
-        ScaffoldMessenger.of(context).showSnackBar(
+        messengerKey.currentState?.showSnackBar(
           SnackBar(
             content: Text(l10n.notificationFailedMessage),
           ),
@@ -111,7 +113,7 @@ class _MyAppState extends State<MyApp> {
       _connSub = Connectivity().onConnectivityChanged.listen((result) {
         if (result == ConnectivityResult.none) {
           final l10n = AppLocalizations.of(context)!;
-          ScaffoldMessenger.of(context).showSnackBar(
+          messengerKey.currentState?.showSnackBar(
             SnackBar(
               content: Text(l10n.noInternetConnection),
             ),
@@ -142,6 +144,7 @@ class _MyAppState extends State<MyApp> {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      scaffoldMessengerKey: messengerKey,
       onGenerateTitle: (context) => AppLocalizations.of(context)!.appTitle,
       localizationsDelegates: const [
         AppLocalizations.delegate,


### PR DESCRIPTION
## Summary
- use a global `messengerKey` for displaying snack bars
- pass `scaffoldMessengerKey` to `MaterialApp`

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68baf3eccefc833397111b6791baf9e9