### PR TITLE
Remove duplicate note localization keys

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -62,8 +62,6 @@
 
   "exportNotes": "Export notes",
   "importNotes": "Import notes",
-  "notesExported": "Notes exported",
-  "notesImported": "Notes imported",
 
   "tagsLabel": "Tags",
   "allTags": "All tags",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -62,8 +62,6 @@
 
   "exportNotes": "Xuất ghi chú",
   "importNotes": "Nhập ghi chú",
-  "notesExported": "Đã xuất ghi chú",
-  "notesImported": "Đã nhập ghi chú",
 
   "tagsLabel": "Tag",
   "allTags": "Tất cả tag",


### PR DESCRIPTION
## Summary
- remove duplicate `notesExported`/`notesImported` entries from English and Vietnamese ARB files

## Testing
- `flutter gen-l10n` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68baf3ed5a188333b0d00ff435fbb77f