### PR TITLE
Handle note deletion with actual index lookup

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -157,20 +157,24 @@ class _HomeScreenState extends State<HomeScreen> {
               icon: const Icon(Icons.delete),
               tooltip: AppLocalizations.of(context)!.delete,
               onPressed: () {
-                final note = context.read<NoteProvider>().notes[index];
-                context.read<NoteProvider>().removeNoteAt(index);
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(
-                    content: Text(
-                      AppLocalizations.of(context)!.noteDeleted,
+                final provider = context.read<NoteProvider>();
+                final note = notes[index];
+                final idx =
+                    provider.notes.indexWhere((n) => n.id == note.id);
+                if (idx != -1) {
+                  provider.removeNoteAt(idx);
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      content: Text(
+                        AppLocalizations.of(context)!.noteDeleted,
+                      ),
+                      action: SnackBarAction(
+                        label: AppLocalizations.of(context)!.undo,
+                        onPressed: () => provider.addNote(note),
+                      ),
                     ),
-                    action: SnackBarAction(
-                      label: AppLocalizations.of(context)!.undo,
-                      onPressed: () =>
-                          context.read<NoteProvider>().addNote(note),
-                    ),
-                  ),
-                );
+                  );
+                }
               },
             ),
           ),


### PR DESCRIPTION
## Summary
- Ensure delete actions search for the real note index before removal
- Use saved note for undo SnackBar

## Testing
- `flutter test` *(fails: command not found: flutter)*
- `dart format lib/screens/home_screen.dart` *(fails: command not found: dart)*

------
https://chatgpt.com/codex/tasks/task_e_68baf3edc0ec83339dd159dee01d202f