### PR TITLE
Add localized message for failed note save

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -94,6 +94,7 @@
   "actionItemsLabel": "Action items",
   "datesLabel": "Dates",
   "authFailedMessage": "Anonymous sign-in failed. Limited functionality.",
-  "notificationFailedMessage": "Notification setup failed."
+  "notificationFailedMessage": "Notification setup failed.",
+  "saveNoteFailed": "Failed to save note"
 
 }

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -94,6 +94,7 @@
   "actionItemsLabel": "Cần làm",
   "datesLabel": "Ngày",
   "authFailedMessage": "Đăng nhập ẩn danh thất bại. Chức năng bị hạn chế.",
-  "notificationFailedMessage": "Thiết lập thông báo thất bại."
+  "notificationFailedMessage": "Thiết lập thông báo thất bại.",
+  "saveNoteFailed": "Lưu ghi chú thất bại"
 
 }

--- a/lib/screens/note_detail_screen.dart
+++ b/lib/screens/note_detail_screen.dart
@@ -409,7 +409,7 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
       Navigator.pop(context);
     } else {
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(l10n.errorWithMessage('Failed to save note'))),
+        SnackBar(content: Text(l10n.saveNoteFailed)),
       );
     }
   }


### PR DESCRIPTION
## Summary
- add `saveNoteFailed` localization key in English and Vietnamese
- show localized `saveNoteFailed` message in note detail screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68baf3ef64a88333ba52ee039b0ba3c2