### PR TITLE
chore: move uuid to dev dependencies

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1090,7 +1090,7 @@ packages:
     source: hosted
     version: "3.1.4"
   uuid:
-    dependency: "direct main"
+    dependency: "direct dev"
     description:
       name: uuid
       sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,6 @@ dependencies:
   intl: ^0.20.2
   provider: ^6.1.2
   flutter_tts: ^4.2.3
-  uuid: ^4.5.1
   speech_to_text: ^7.3.0
   vosk_flutter: ^0.3.48
   share_plus: ^10.0.2
@@ -48,6 +47,7 @@ dev_dependencies:
   google_sign_in_platform_interface: ^2.4.0
   integration_test:
     sdk: flutter
+  uuid: ^4.5.1
 
 dependency_overrides:
   archive: ^4.0.0


### PR DESCRIPTION
## Summary
- move `uuid` package from `dependencies` to `dev_dependencies`
- update lock file entry for `uuid`

## Testing
- `flutter pub get` *(fails: Because vosk_flutter 0.3.48 depends on http ^0.13.5 and no versions of vosk_flutter match >0.3.48 <0.4.0, vosk_flutter ^0.3.48 requires http ^0.13.5)*
- `flutter test` *(fails: Because vosk_flutter 0.3.48 depends on http ^0.13.5 and no versions of vosk_flutter match >0.3.48 <0.4.0, vosk_flutter ^0.3.48 requires http ^0.13.5)*

------
https://chatgpt.com/codex/tasks/task_e_68baf3efdd288333a2a6c2819a408a9f