### PR TITLE
Handle backup service success states

### DIFF
--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -142,21 +142,35 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   Future<void> _exportNotes() async {
     final l10n = AppLocalizations.of(context)!;
-    await _noteRepository.exportNotes(l10n);
+    final success = await _noteRepository.exportNotes(l10n);
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text(l10n.notesExported)),
+      SnackBar(
+        content: Text(success
+            ? l10n.notesExported
+            : l10n.errorWithMessage('Failed to export notes')),
+      ),
     );
   }
 
   Future<void> _importNotes() async {
     final l10n = AppLocalizations.of(context)!;
-    await _noteRepository.importNotes(l10n);
+    final notes = await _noteRepository.importNotes(l10n);
     if (!mounted) return;
-    await context.read<NoteProvider>().loadNotes();
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text(l10n.notesImported)),
-    );
+    if (notes.isNotEmpty) {
+      await context.read<NoteProvider>().loadNotes();
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(l10n.notesImported)),
+      );
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            l10n.errorWithMessage('Failed to import notes'),
+          ),
+        ),
+      );
+    }
   }
 
   @override

--- a/lib/services/backup_service.dart
+++ b/lib/services/backup_service.dart
@@ -8,7 +8,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import '../models/note.dart';
 
 class BackupService {
-  Future<void> exportNotes(List<Note> notes, AppLocalizations l10n) async {
+  Future<bool> exportNotes(List<Note> notes, AppLocalizations l10n) async {
     String? path;
     try {
       path = await FilePicker.platform.saveFile(
@@ -19,15 +19,17 @@ class BackupService {
       );
     } catch (e) {
       debugPrint(l10n.errorWithMessage(e.toString()));
-      return;
+      return false;
     }
-    if (path == null) return;
+    if (path == null) return false;
     final file = File(path);
     final data = jsonEncode(notes.map((n) => n.toJson()).toList());
     try {
       await file.writeAsString(data);
+      return true;
     } catch (e) {
       debugPrint(l10n.errorWithMessage(e.toString()));
+      return false;
     }
   }
 
@@ -52,10 +54,15 @@ class BackupService {
       debugPrint(l10n.errorWithMessage(e.toString()));
       return [];
     }
-    final list = jsonDecode(content) as List<dynamic>;
-    return list
-        .map((e) => Note.fromJson(e as Map<String, dynamic>))
-        .toList();
+    try {
+      final list = jsonDecode(content) as List<dynamic>;
+      return list
+          .map((e) => Note.fromJson(e as Map<String, dynamic>))
+          .toList();
+    } catch (e) {
+      debugPrint(l10n.errorWithMessage(e.toString()));
+      return [];
+    }
   }
 }
 

--- a/lib/services/note_repository.dart
+++ b/lib/services/note_repository.dart
@@ -34,9 +34,9 @@ class NoteRepository {
     return _dbService.decryptNote(data);
   }
 
-  Future<void> exportNotes(AppLocalizations l10n) async {
+  Future<bool> exportNotes(AppLocalizations l10n) async {
     final notes = await _dbService.getNotes();
-    await _backupService.exportNotes(notes, l10n);
+    return _backupService.exportNotes(notes, l10n);
   }
 
   Future<List<Note>> importNotes(AppLocalizations l10n) async {


### PR DESCRIPTION
## Summary
- Return `bool` from note export with error handling
- Fail gracefully in note import and decode
- Notify settings screen of backup success or failure

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68baf3f1758483339c64d3750710311f