### PR TITLE
Downgrade http dependency to 0.13.5

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   timezone: ^0.10.1
   flutter_native_timezone: ^2.0.0
   lottie: ^3.3.1
-  http: ^1.2.2
+  http: ^0.13.5
   shared_preferences: ^2.3.2
   audioplayers: ^6.5.0
   intl: ^0.20.2


### PR DESCRIPTION
## Summary
- Downgrade http package to version ^0.13.5 in pubspec.yaml

## Testing
- `flutter pub get` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bc27ae1d848333992a453d87a8de4c