### PR TITLE
chore(android): update compile and target SDK to 34

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -6,12 +6,12 @@ plugins {
 
 android {
     namespace = "com.example.notes_reminder_app"
-    compileSdk = 36
+    compileSdk = 34
 
     defaultConfig {
         applicationId = "com.example.notes_reminder_app"
         minSdk = flutter.minSdkVersion
-        targetSdk = 36
+        targetSdk = 34
         versionCode = 1
         versionName = "1.0"
     }


### PR DESCRIPTION
## Summary
- target Android API level 34 for compile and runtime

## Testing
- `flutter test` *(fails: command not found: flutter)*
- `./gradlew assembleDebug` *(fails: No such file or directory)*
- `apt-get install gradle` *(fails: error processing package ca-certificates-java)*

------
https://chatgpt.com/codex/tasks/task_e_68bc300a6d2c8333ab42475e14224df9