### PR TITLE
Remove obsolete vosk_flutter dependency and clean archive override

### DIFF
--- a/lib/screens/voice_to_note_screen.dart
+++ b/lib/screens/voice_to_note_screen.dart
@@ -1,81 +1,29 @@
-import 'dart:convert';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 import 'package:speech_to_text/speech_to_text.dart' as stt;
-import 'package:vosk_flutter/vosk_flutter.dart' as vosk;
 
 import '../providers/note_provider.dart';
 import '../services/gemini_service.dart';
 
 class VoiceToNoteScreen extends StatefulWidget {
   final stt.SpeechToText speech;
-  final vosk.VoskFlutterPlugin vosk;
 
   const VoiceToNoteScreen({
     super.key,
     stt.SpeechToText? speech,
-    vosk.VoskFlutterPlugin? vosk,
-  })  : speech = speech ?? stt.SpeechToText(),
-        vosk = vosk ?? vosk.VoskFlutterPlugin();
+  }) : speech = speech ?? stt.SpeechToText();
 
   @override
   State<VoiceToNoteScreen> createState() => _VoiceToNoteScreenState();
 }
 
 class _VoiceToNoteScreenState extends State<VoiceToNoteScreen> {
-  vosk.SpeechService? _voskService;
-  vosk.Recognizer? _voskRecognizer;
-
   String _recognized = '';
   bool _isListening = false;
   bool _isProcessing = false;
-  bool _offlineMode = false;
-
-  Future<void> _startOffline() async {
-    if (_voskRecognizer == null) {
-      final locale = Localizations.localeOf(context);
-      final code = {
-            'vi': 'vi',
-            'en': 'en',
-          }[locale.languageCode] ??
-          'en';
-      try {
-        final model = await widget.vosk
-            .createModel('assets/models/vosk-model-small-$code');
-        _voskRecognizer = await widget.vosk.createRecognizer(model: model);
-        _voskService = await widget.vosk.initSpeechService(_voskRecognizer!);
-      } catch (e) {
-        if (!mounted) return;
-        final l10n = AppLocalizations.of(context)!;
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(l10n.errorWithMessage(e.toString())),
-          ),
-        );
-        return;
-      }
-      _voskService!.onResult().listen((event) {
-        final data = jsonDecode(event) as Map<String, dynamic>;
-        setState(() => _recognized = data['text'] ?? '');
-      });
-    }
-    await _voskService!.start();
-  }
 
   Future<void> _toggleListening() async {
-    if (_offlineMode) {
-      if (!_isListening) {
-        await _startOffline();
-        setState(() => _isListening = true);
-      } else {
-        await _voskService?.stop();
-        setState(() => _isListening = false);
-      }
-      return;
-    }
-
     if (!_isListening) {
       final available = await widget.speech.initialize();
       if (available) {
@@ -114,26 +62,20 @@ class _VoiceToNoteScreenState extends State<VoiceToNoteScreen> {
   @override
   void dispose() {
     widget.speech.stop();
-    _voskService?.stop();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-          title: Text(AppLocalizations.of(context)!.voiceToNote)),
+      appBar:
+          AppBar(title: Text(AppLocalizations.of(context)!.voiceToNote)),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(
           children: [
             Expanded(
               child: SingleChildScrollView(child: Text(_recognized)),
-            ),
-            SwitchListTile(
-              title: Text(AppLocalizations.of(context)!.offlineMode),
-              value: _offlineMode,
-              onChanged: (v) => setState(() => _offlineMode = v),
             ),
             if (_isProcessing) const CircularProgressIndicator(),
             Row(
@@ -147,8 +89,7 @@ class _VoiceToNoteScreenState extends State<VoiceToNoteScreen> {
                 const SizedBox(width: 8),
                 ElevatedButton(
                   onPressed: _isProcessing ? null : _convertToNote,
-                  child:
-                      Text(AppLocalizations.of(context)!.convertToNote),
+                  child: Text(AppLocalizations.of(context)!.convertToNote),
                 ),
               ],
             )

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -7,9 +7,17 @@
 #include "generated_plugin_registrant.h"
 
 #include <audioplayers_linux/audioplayers_linux_plugin.h>
+#include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
+#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) audioplayers_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "AudioplayersLinuxPlugin");
   audioplayers_linux_plugin_register_with_registrar(audioplayers_linux_registrar);
+  g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
+  flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,8 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   audioplayers_linux
+  flutter_secure_storage_linux
+  url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,15 +6,35 @@ import FlutterMacOS
 import Foundation
 
 import audioplayers_darwin
+import cloud_firestore
+import connectivity_plus
+import firebase_auth
+import firebase_core
 import flutter_local_notifications
+import flutter_native_timezone
+import flutter_secure_storage_macos
 import flutter_tts
+import google_sign_in_ios
+import local_auth_darwin
 import path_provider_foundation
+import share_plus
 import shared_preferences_foundation
+import speech_to_text
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioplayersDarwinPlugin.register(with: registry.registrar(forPlugin: "AudioplayersDarwinPlugin"))
+  FLTFirebaseFirestorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseFirestorePlugin"))
+  ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
+  FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
+  FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
+  FlutterNativeTimezonePlugin.register(with: registry.registrar(forPlugin: "FlutterNativeTimezonePlugin"))
+  FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   FlutterTtsPlugin.register(with: registry.registrar(forPlugin: "FlutterTtsPlugin"))
+  FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
+  LocalAuthPlugin.register(with: registry.registrar(forPlugin: "LocalAuthPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+  SpeechToTextPlugin.register(with: registry.registrar(forPlugin: "SpeechToTextPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -10,7 +10,7 @@ packages:
     source: hosted
     version: "1.3.61"
   archive:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       name: archive
       sha256: "2fde1607386ab523f7a36bb3e7edb43bd58e6edaf2ffb29d8a6d578b297fdbbd"
@@ -105,14 +105,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
-  build_cli_annotations:
-    dependency: transitive
-    description:
-      name: build_cli_annotations
-      sha256: b59d2769769efd6c9ff6d4c4cede0be115a566afc591705c2040b707534b1172
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.0"
   characters:
     dependency: transitive
     description:
@@ -121,14 +113,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
-  checked_yaml:
-    dependency: transitive
-    description:
-      name: checked_yaml
-      sha256: "959525d3162f249993882720d52b7e0c833978df229be20702b33d48d91de70f"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.4"
   clock:
     dependency: transitive
     description:
@@ -173,7 +157,7 @@ packages:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: "b5e72753cf63becce2c61fd04dfe0f1c430cc5278b53a1342dc5ad839eab29ec"
+      sha256: b5e72753cf63becce2c61fd04dfe0f1c430cc5278b53a1342dc5ad839eab29ec
       url: "https://pub.dev"
     source: hosted
     version: "6.1.5"
@@ -209,6 +193,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.6"
+  cryptography:
+    dependency: "direct main"
+    description:
+      name: cryptography
+      sha256: d146b76d33d94548cf035233fbc2f4338c1242fa119013bead807d033fc4ae05
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.0"
   dbus:
     dependency: transitive
     description:
@@ -507,7 +499,7 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: "b9c29a161230ee03d3ccf545097fccd9b87a5264228c5d348202e0f0c28f9010"
+      sha256: b9c29a161230ee03d3ccf545097fccd9b87a5264228c5d348202e0f0c28f9010
       url: "https://pub.dev"
     source: hosted
     version: "1.2.2"
@@ -684,14 +676,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.0"
-  package_config:
-    dependency: transitive
-    description:
-      name: package_config
-      sha256: f096c55ebb7deb7e384101542bfba8c52696c1b56fca2eb62827989ef2353bbc
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.2.0"
   path:
     dependency: transitive
     description:
@@ -756,46 +740,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.11.1"
-  permission_handler:
-    dependency: transitive
-    description:
-      name: permission_handler
-      sha256: bc56bfe9d3f44c3c612d8d393bd9b174eb796d706759f9b495ac254e4294baa5
-      url: "https://pub.dev"
-    source: hosted
-    version: "10.4.5"
-  permission_handler_android:
-    dependency: transitive
-    description:
-      name: permission_handler_android
-      sha256: "59c6322171c29df93a22d150ad95f3aa19ed86542eaec409ab2691b8f35f9a47"
-      url: "https://pub.dev"
-    source: hosted
-    version: "10.3.6"
-  permission_handler_apple:
-    dependency: transitive
-    description:
-      name: permission_handler_apple
-      sha256: "99e220bce3f8877c78e4ace901082fb29fa1b4ebde529ad0932d8d664b34f3f5"
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.1.4"
-  permission_handler_platform_interface:
-    dependency: transitive
-    description:
-      name: permission_handler_platform_interface
-      sha256: "6760eb5ef34589224771010805bea6054ad28453906936f843a8cc4d3a55c4a4"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.12.0"
-  permission_handler_windows:
-    dependency: transitive
-    description:
-      name: permission_handler_windows
-      sha256: cc074aace208760f1eee6aa4fae766b45d947df85bc831cde77009cdb4720098
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.3"
   petitparser:
     dependency: transitive
     description:
@@ -852,22 +796,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.5+1"
-  pub_semver:
-    dependency: transitive
-    description:
-      name: pub_semver
-      sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.2.0"
-  pubspec_parse:
-    dependency: transitive
-    description:
-      name: pubspec_parse
-      sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.5.0"
   share_plus:
     dependency: "direct main"
     description:
@@ -1113,14 +1041,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "15.0.2"
-  vosk_flutter:
-    dependency: "direct main"
-    description:
-      name: vosk_flutter
-      sha256: "03ad3789891e669f1ee637674ff112b72185a8c8dd3cf7f71fd5e7373ed41c42"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.48"
   web:
     dependency: transitive
     description:
@@ -1161,14 +1081,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.6.1"
-  yaml:
-    dependency: transitive
-    description:
-      name: yaml
-      sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.3"
 sdks:
   dart: ">=3.8.0 <4.0.0"
   flutter: ">=3.29.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,14 +15,13 @@ dependencies:
   timezone: ^0.10.1
   flutter_native_timezone: ^2.0.0
   lottie: ^3.3.1
-  http: ^0.13.5
+  http: ^1.2.1
   shared_preferences: ^2.3.2
   audioplayers: ^6.5.0
   intl: ^0.20.2
   provider: ^6.1.2
   flutter_tts: ^4.2.3
   speech_to_text: ^7.3.0
-  vosk_flutter: ^0.3.48
   share_plus: ^10.0.2
   connectivity_plus: ^6.1.5
 
@@ -50,9 +49,6 @@ dev_dependencies:
     sdk: flutter
   uuid: ^4.5.1
 
-dependency_overrides:
-  archive: ^4.0.0
-
 flutter:
   generate: true
   uses-material-design: true
@@ -60,6 +56,3 @@ flutter:
     - assets/lottie/mascot.json
     - assets/lottie/mascot2.json
     - assets/lottie/mascot3.json
-    - assets/models/
-    - assets/models/vosk-model-small-en/
-    - assets/models/vosk-model-small-vi/

--- a/test/voice_to_note_screen_test.dart
+++ b/test/voice_to_note_screen_test.dart
@@ -3,19 +3,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:speech_to_text/speech_to_text.dart' as stt;
-import 'package:vosk_flutter/vosk_flutter.dart' as vosk;
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:notes_reminder_app/screens/voice_to_note_screen.dart';
 
 class MockSpeechToText extends Mock implements stt.SpeechToText {}
 
-class MockVosk extends Mock implements vosk.VoskFlutterPlugin {}
-
-class MockSpeechService extends Mock implements vosk.SpeechService {}
-
-class MockRecognizer extends Mock implements vosk.Recognizer {}
-
-class MockModel extends Mock implements vosk.Model {}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -75,98 +67,5 @@ void main() {
       expect(find.text(l10n.microphonePermissionMessage), findsOneWidget);
     });
 
-    testWidgets('offline mode uses Vosk', (tester) async {
-      final speech = MockSpeechToText();
-      when(() => speech.stop()).thenAnswer((_) async {});
-      final voskPlugin = MockVosk();
-      final service = MockSpeechService();
-      final recognizer = MockRecognizer();
-      final model = MockModel();
-      when(() => voskPlugin.createModel(any())).thenAnswer((_) async => model);
-      when(
-        () => voskPlugin.createRecognizer(model: model),
-      ).thenAnswer((_) async => recognizer);
-      when(
-        () => voskPlugin.initSpeechService(recognizer),
-      ).thenAnswer((_) async => service);
-      final controller = StreamController<String>();
-      when(() => service.onResult()).thenAnswer((_) => controller.stream);
-      when(() => service.start()).thenAnswer((_) async {});
-      when(() => service.stop()).thenAnswer((_) async {});
-
-      await tester.pumpWidget(
-        MaterialApp(
-          locale: const Locale('en'),
-          localizationsDelegates: AppLocalizations.localizationsDelegates,
-          supportedLocales: AppLocalizations.supportedLocales,
-          home: VoiceToNoteScreen(speech: speech, vosk: voskPlugin),
-        ),
-      );
-
-      await tester.tap(find.byType(Switch));
-      await tester.pumpAndSettle();
-      final l10n = await AppLocalizations.delegate.load(const Locale('en'));
-      await tester.tap(find.text(l10n.speak));
-      await tester.pump();
-
-      controller.add('{"text": "offline"}');
-      await tester.pump();
-
-      expect(find.text('offline'), findsOneWidget);
-      verify(() => voskPlugin.createModel(any())).called(1);
-      verify(() => voskPlugin.createRecognizer(model: model)).called(1);
-      verify(() => voskPlugin.initSpeechService(recognizer)).called(1);
-      verify(() => service.start()).called(1);
-      await controller.close();
-    });
-
-    testWidgets('_startOffline initializes Vosk only once', (tester) async {
-      final speech = MockSpeechToText();
-      when(() => speech.stop()).thenAnswer((_) async {});
-      final voskPlugin = MockVosk();
-      final service = MockSpeechService();
-      final recognizer = MockRecognizer();
-      final model = MockModel();
-      when(() => voskPlugin.createModel(any())).thenAnswer((_) async => model);
-      when(
-        () => voskPlugin.createRecognizer(model: model),
-      ).thenAnswer((_) async => recognizer);
-      when(
-        () => voskPlugin.initSpeechService(recognizer),
-      ).thenAnswer((_) async => service);
-      when(() => service.onResult()).thenAnswer((_) => const Stream.empty());
-      when(() => service.start()).thenAnswer((_) async {});
-      when(() => service.stop()).thenAnswer((_) async {});
-
-      await tester.pumpWidget(
-        MaterialApp(
-          locale: const Locale('en'),
-          localizationsDelegates: AppLocalizations.localizationsDelegates,
-          supportedLocales: AppLocalizations.supportedLocales,
-          home: VoiceToNoteScreen(speech: speech, vosk: voskPlugin),
-        ),
-      );
-
-      await tester.tap(find.byType(Switch));
-      await tester.pumpAndSettle();
-      final l10n = await AppLocalizations.delegate.load(const Locale('en'));
-
-      // Start listening offline
-      await tester.tap(find.text(l10n.speak));
-      await tester.pump();
-
-      // Stop listening
-      await tester.tap(find.text(l10n.stop));
-      await tester.pump();
-
-      // Start again
-      await tester.tap(find.text(l10n.speak));
-      await tester.pump();
-
-      verify(() => voskPlugin.createModel(any())).called(1);
-      verify(() => voskPlugin.createRecognizer(model: model)).called(1);
-      verify(() => voskPlugin.initSpeechService(recognizer)).called(1);
-      verify(() => service.start()).called(2);
-    });
   });
 }

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -7,11 +7,38 @@
 #include "generated_plugin_registrant.h"
 
 #include <audioplayers_windows/audioplayers_windows_plugin.h>
+#include <cloud_firestore/cloud_firestore_plugin_c_api.h>
+#include <connectivity_plus/connectivity_plus_windows_plugin.h>
+#include <firebase_auth/firebase_auth_plugin_c_api.h>
+#include <firebase_core/firebase_core_plugin_c_api.h>
+#include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <flutter_tts/flutter_tts_plugin.h>
+#include <local_auth_windows/local_auth_plugin.h>
+#include <share_plus/share_plus_windows_plugin_c_api.h>
+#include <speech_to_text_windows/speech_to_text_windows.h>
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   AudioplayersWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("AudioplayersWindowsPlugin"));
+  CloudFirestorePluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("CloudFirestorePluginCApi"));
+  ConnectivityPlusWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
+  FirebaseAuthPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FirebaseAuthPluginCApi"));
+  FirebaseCorePluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
+  FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   FlutterTtsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterTtsPlugin"));
+  LocalAuthPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("LocalAuthPlugin"));
+  SharePlusWindowsPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
+  SpeechToTextWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SpeechToTextWindows"));
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -4,7 +4,16 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   audioplayers_windows
+  cloud_firestore
+  connectivity_plus
+  firebase_auth
+  firebase_core
+  flutter_secure_storage_windows
   flutter_tts
+  local_auth_windows
+  share_plus
+  speech_to_text_windows
+  url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
## Summary
- drop `vosk_flutter` plugin and related offline voice logic
- update dependencies (`http` 1.2.1, `lottie` 3.3.1) and remove `archive` override
- regenerate plugin registrants and lockfile to use `archive` 4.0.7

## Testing
- `flutter pub deps | grep -C 1 archive`
- `flutter test` *(fails: Couldn't resolve package `flutter_gen` and other missing types)*

------
https://chatgpt.com/codex/tasks/task_e_68bc300bfca48333b47fc0ce99aee364