### PR TITLE
chore: validate dependencies before building APK

### DIFF
--- a/fix_agp.sh
+++ b/fix_agp.sh
@@ -26,10 +26,15 @@ sed -i \
   's#distributionUrl=.*#distributionUrl=https\://services.gradle.org/distributions/gradle-'$REQUIRED_GRADLE'-all.zip#' \
   android/gradle/wrapper/gradle-wrapper.properties
 
-# Clean, get packages, build và cài APK
+# Clean, check dependencies, build và cài APK
 flutter clean
 flutter pub get
-flutter build apk --release --android-skip-build-dependency-validation
+
+# Kiểm tra nhanh môi trường và phụ thuộc
+flutter doctor
+(cd android && ./gradlew app:dependencies)
+
+flutter build apk --release
 adb install -r build/app/outputs/flutter-apk/app-release.apk
 
 echo "✅ Done"


### PR DESCRIPTION
## Summary
- run `flutter doctor` and Gradle dependency checks before building
- drop `--android-skip-build-dependency-validation` so builds fail on unresolved dependencies

## Testing
- `bash -n fix_agp.sh`
- `./fix_agp.sh` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68bc300f29a88333879d0550d0274b85