### PR TITLE
Set minSdk to 23

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         applicationId = "com.example.notes_reminder_app"
-        minSdk = flutter.minSdkVersion
+        minSdk = 23
         targetSdk = 34
         versionCode = 1
         versionName = "1.0"


### PR DESCRIPTION
## Summary
- bump Android minSdk to 23

## Testing
- `gradle app:dependencies` *(fails: FLUTTER_ROOT not set)*

------
https://chatgpt.com/codex/tasks/task_e_68bc35aa42a48333a0cbdc8e039b234d