### PR TITLE
fix: remove stray dependency marker

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -483,25 +483,23 @@ packages:
     dependency: transitive
     description:
       name: google_sign_in_platform_interface
-      sha256: "8736443134d2cccadd4f228d600177cb3947e36683466a6ab96877ce6932885a"
+      sha256: "5f6f79cf139c197261adb6ac024577518ae48fdff8e53205c5373b5f6430a8aa"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "2.5.0"
   google_sign_in_web:
     dependency: transitive
     description:
       name: google_sign_in_web
-      sha256: "09ac306b2787b48f19c857b9f93375b654f774643c75bd6a1a078c85f4f7b468"
+      sha256: "460547beb4962b7623ac0fb8122d6b8268c951cf0b646dd150d60498430e4ded"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "0.12.4+4"
   http:
     dependency: "direct main"
     description:
       name: http
- codex/update-http-package-and-dependencies
-      sha256: "bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007"
-
+      sha256: bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,6 @@ dependencies:
   timezone: ^0.10.1
   flutter_native_timezone: ^2.0.0
   lottie: ^3.3.1
- codex/update-http-package-and-dependencies
   http: ^1.1.0
 
   shared_preferences: ^2.3.2


### PR DESCRIPTION
## Summary
- remove stray `codex/update-http-package-and-dependencies` marker from pubspec
- regenerate dependency lock file

## Testing
- `flutter pub get`
- `flutter test` *(fails: The Dart compiler exited unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_e_68bc359d57008333a0ca454fc8b9248d