### PR TITLE
Use Gradle 8.1 bin for Android build

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-8.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/fix_agp.sh
+++ b/fix_agp.sh
@@ -2,7 +2,7 @@
 set -e
 
 REQUIRED_AGP="8.1.1"
-REQUIRED_GRADLE="8.7"
+REQUIRED_GRADLE="8.1"
 REQUIRED_KOTLIN="1.9.23"
 
 # Đọc phiên bản AGP đang dùng
@@ -38,7 +38,7 @@ fi
 # Nâng Gradle Wrapper lên
 echo "Setting Gradle wrapper to $REQUIRED_GRADLE"
 sed -i \
-  's#distributionUrl=.*#distributionUrl=https\://services.gradle.org/distributions/gradle-'$REQUIRED_GRADLE'-all.zip#' \
+  's#distributionUrl=.*#distributionUrl=https\://services.gradle.org/distributions/gradle-'$REQUIRED_GRADLE'-bin.zip#' \
   android/gradle/wrapper/gradle-wrapper.properties
 
 # Clean, check dependencies, build và cài APK


### PR DESCRIPTION
## Summary
- Switch Gradle wrapper to 8.1 bin distribution
- Update fix_agp.sh to expect Gradle 8.1

## Testing
- `cd android && ./gradlew --version` *(fails: No such file or directory)*
- `gradle --no-daemon --console=plain wrapper --gradle-version 8.1 --distribution-type bin` *(fails: FLUTTER_ROOT not set; export it to your Flutter SDK path)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68bc35a589708333a00dd72dbed79db0