### PR TITLE
chore: add Google services plugin

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.application")
     id("kotlin-android")
     id("dev.flutter.flutter-gradle-plugin")
+    id("com.google.gms.google-services")
 }
 
 android {


### PR DESCRIPTION
## Summary
- add `com.google.gms.google-services` plugin to Android app build to enable Firebase features

## Testing
- `flutterfire configure` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*
- `flutter build apk` *(fails: command not found)*
- `flutter build ios` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bc3a62f0a48333ab0ddc671f7ddae0