### PR TITLE
Add iOS permission usage descriptions

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -43,7 +43,15 @@
 	</array>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
+        <key>UIApplicationSupportsIndirectInputEvents</key>
+        <true/>
+        <key>NSMicrophoneUsageDescription</key>
+        <string>This app needs microphone access to record audio notes.</string>
+        <key>NSSpeechRecognitionUsageDescription</key>
+        <string>This app uses speech recognition to transcribe voice into text.</string>
+        <key>NSPhotoLibraryUsageDescription</key>
+        <string>This app requires photo library access to attach images to notes.</string>
+        <key>NSUserTrackingUsageDescription</key>
+        <string>This identifier will be used to deliver personalized content.</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- declare microphone, speech recognition, photo library, and tracking usage descriptions in Info.plist

## Testing
- `flutter build ios --no-codesign` *(fails: process hung after resolving dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3a63eb7c8333996019deb70b4a42