### PR TITLE
Load Flutter SDK path from local.properties

### DIFF
--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -4,9 +4,16 @@ pluginManagement {
         google()
         mavenCentral()
     }
-    // dùng biến môi trường FLUTTER_ROOT thay vì Properties lằng nhằng
-    val flutterRoot = System.getenv("FLUTTER_ROOT")
-        ?: throw GradleException("FLUTTER_ROOT not set; export it to your Flutter SDK path")
+
+    val localProperties = java.util.Properties()
+    val localPropertiesFile = rootDir.resolve("local.properties")
+    if (localPropertiesFile.exists()) {
+        localPropertiesFile.inputStream().use { localProperties.load(it) }
+    }
+    val flutterRoot = localProperties.getProperty("flutter.sdk")
+        ?: throw GradleException(
+            "Flutter SDK not found. Define location with flutter.sdk in the local.properties file."
+        )
     includeBuild("$flutterRoot/packages/flutter_tools/gradle")
 }
 


### PR DESCRIPTION
## Summary
- read the Flutter SDK path from `local.properties` instead of `FLUTTER_ROOT`

## Testing
- `gradle help` *(fails: Flutter SDK not found. Define location with flutter.sdk in the local.properties file.)*


------
https://chatgpt.com/codex/tasks/task_e_68bc3a6464c48333abd637db10ef44d8