### PR TITLE
Refactor note detail screen into composable widgets

### DIFF
--- a/lib/widgets/ai_suggestions_dialog.dart
+++ b/lib/widgets/ai_suggestions_dialog.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+import '../services/gemini_service.dart';
+
+class AISuggestionsResult {
+  final String summary;
+  final List<String> actionItems;
+  final List<String> tags;
+  final List<DateTime> dates;
+
+  AISuggestionsResult({
+    required this.summary,
+    required this.actionItems,
+    required this.tags,
+    required this.dates,
+  });
+}
+
+class AISuggestionsDialog extends StatefulWidget {
+  final NoteAnalysis analysis;
+  final AppLocalizations l10n;
+  const AISuggestionsDialog(
+      {super.key, required this.analysis, required this.l10n});
+
+  @override
+  State<AISuggestionsDialog> createState() => _AISuggestionsDialogState();
+}
+
+class _AISuggestionsDialogState extends State<AISuggestionsDialog> {
+  late TextEditingController _summaryCtrl;
+  late TextEditingController _actionCtrl;
+  late TextEditingController _tagsCtrl;
+  late TextEditingController _datesCtrl;
+
+  @override
+  void initState() {
+    super.initState();
+    _summaryCtrl = TextEditingController(text: widget.analysis.summary);
+    _actionCtrl =
+        TextEditingController(text: widget.analysis.actionItems.join('\n'));
+    _tagsCtrl =
+        TextEditingController(text: widget.analysis.suggestedTags.join(', '));
+    _datesCtrl = TextEditingController(
+      text: widget.analysis.dates
+          .map((d) => DateFormat('yyyy-MM-dd').format(d))
+          .join(', '),
+    );
+  }
+
+  @override
+  void dispose() {
+    _summaryCtrl.dispose();
+    _actionCtrl.dispose();
+    _tagsCtrl.dispose();
+    _datesCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = widget.l10n;
+    return AlertDialog(
+      title: Text(l10n.aiSuggestionsTitle),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              controller: _summaryCtrl,
+              decoration: InputDecoration(labelText: l10n.summaryLabel),
+            ),
+            TextField(
+              controller: _actionCtrl,
+              decoration: InputDecoration(labelText: l10n.actionItemsLabel),
+              maxLines: null,
+            ),
+            TextField(
+              controller: _tagsCtrl,
+              decoration: InputDecoration(labelText: l10n.tagsLabel),
+            ),
+            TextField(
+              controller: _datesCtrl,
+              decoration: InputDecoration(labelText: l10n.datesLabel),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: Text(l10n.cancel),
+        ),
+        TextButton(
+          onPressed: () {
+            final result = AISuggestionsResult(
+              summary: _summaryCtrl.text,
+              actionItems: _actionCtrl.text
+                  .split('\n')
+                  .map((e) => e.trim())
+                  .where((e) => e.isNotEmpty)
+                  .toList(),
+              tags: _tagsCtrl.text
+                  .split(',')
+                  .map((e) => e.trim())
+                  .where((e) => e.isNotEmpty)
+                  .toList(),
+              dates: _datesCtrl.text
+                  .split(',')
+                  .map((e) => DateTime.tryParse(e.trim()))
+                  .whereType<DateTime>()
+                  .toList(),
+            );
+            Navigator.pop(context, result);
+          },
+          child: Text(l10n.save),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/attachment_section.dart
+++ b/lib/widgets/attachment_section.dart
@@ -1,0 +1,168 @@
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:audioplayers/audioplayers.dart';
+
+class AttachmentSection extends StatelessWidget {
+  final List<String> attachments;
+  final ValueChanged<List<String>> onChanged;
+
+  const AttachmentSection(
+      {super.key, required this.attachments, required this.onChanged});
+
+  Future<void> _pickImage(BuildContext context) async {
+    final picker = ImagePicker();
+    final file = await picker.pickImage(source: ImageSource.gallery);
+    if (file != null) {
+      final newList = List<String>.from(attachments)..add(file.path);
+      onChanged(newList);
+    }
+  }
+
+  Future<void> _pickAudio(BuildContext context) async {
+    final res = await FilePicker.platform.pickFiles(type: FileType.audio);
+    if (res != null && res.files.single.path != null) {
+      final newList = List<String>.from(attachments)
+        ..add(res.files.single.path!);
+      onChanged(newList);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            ElevatedButton.icon(
+              onPressed: () => _pickImage(context),
+              icon: const Icon(Icons.image),
+              label: Text(l10n.imageLabel),
+            ),
+            const SizedBox(width: 8),
+            ElevatedButton.icon(
+              onPressed: () => _pickAudio(context),
+              icon: const Icon(Icons.audiotrack),
+              label: Text(l10n.audioLabel),
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        ...attachments.asMap().entries.map(
+          (entry) {
+            final index = entry.key;
+            final a = entry.value;
+            final ext = a.split('.').last.toLowerCase();
+            if (['jpg', 'jpeg', 'png', 'gif', 'bmp'].contains(ext)) {
+              return Stack(
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 4),
+                    child: Image.file(File(a)),
+                  ),
+                  Positioned(
+                    top: 0,
+                    right: 0,
+                    child: IconButton(
+                      icon: const Icon(Icons.close),
+                      onPressed: () {
+                        final newList = List<String>.from(attachments)
+                          ..removeAt(index);
+                        onChanged(newList);
+                      },
+                    ),
+                  ),
+                ],
+              );
+            }
+            if (['mp3', 'wav'].contains(ext)) {
+              return _AudioAttachment(
+                path: a,
+                onDelete: () {
+                  final newList = List<String>.from(attachments)
+                    ..removeAt(index);
+                  onChanged(newList);
+                },
+              );
+            }
+            return ListTile(
+              title: Text(a.split('/').last),
+              trailing: IconButton(
+                icon: const Icon(Icons.delete),
+                onPressed: () {
+                  final newList = List<String>.from(attachments)
+                    ..removeAt(index);
+                  onChanged(newList);
+                },
+              ),
+            );
+          },
+        ),
+      ],
+    );
+  }
+}
+
+class _AudioAttachment extends StatefulWidget {
+  final String path;
+  final VoidCallback? onDelete;
+  const _AudioAttachment({required this.path, this.onDelete});
+
+  @override
+  State<_AudioAttachment> createState() => _AudioAttachmentState();
+}
+
+class _AudioAttachmentState extends State<_AudioAttachment> {
+  final AudioPlayer _player = AudioPlayer();
+  bool _playing = false;
+
+  @override
+  void dispose() {
+    _player.dispose();
+    super.dispose();
+  }
+
+  Future<void> _toggle() async {
+    try {
+      if (_playing) {
+        await _player.pause();
+      } else {
+        await _player.play(DeviceFileSource(widget.path));
+      }
+      if (!mounted) return;
+      setState(() => _playing = !_playing);
+    } catch (e) {
+      if (!mounted) return;
+      final l10n = AppLocalizations.of(context)!;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(l10n.errorWithMessage(e.toString()))),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Text(widget.path.split('/').last),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            icon: Icon(_playing ? Icons.pause : Icons.play_arrow),
+            onPressed: _toggle,
+          ),
+          if (widget.onDelete != null)
+            IconButton(
+              icon: const Icon(Icons.delete),
+              onPressed: widget.onDelete,
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/reminder_controls.dart
+++ b/lib/widgets/reminder_controls.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:intl/intl.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+class ReminderControls extends StatelessWidget {
+  final DateTime? alarmTime;
+  final RepeatInterval? repeat;
+  final int snoozeMinutes;
+  final ValueChanged<DateTime?> onAlarmTimeChanged;
+  final ValueChanged<RepeatInterval?> onRepeatChanged;
+  final ValueChanged<int> onSnoozeChanged;
+
+  const ReminderControls({
+    super.key,
+    required this.alarmTime,
+    required this.repeat,
+    required this.snoozeMinutes,
+    required this.onAlarmTimeChanged,
+    required this.onRepeatChanged,
+    required this.onSnoozeChanged,
+  });
+
+  Future<void> _pickAlarmTime(BuildContext context) async {
+    final now = DateTime.now();
+    final picked = await showDatePicker(
+      context: context,
+      firstDate: now,
+      lastDate: DateTime(now.year + 2),
+      initialDate: alarmTime ?? now,
+    );
+    if (picked != null) {
+      final time = await showTimePicker(
+        context: context,
+        initialTime: alarmTime != null
+            ? TimeOfDay.fromDateTime(alarmTime!)
+            : TimeOfDay.now(),
+      );
+      if (time != null) {
+        onAlarmTimeChanged(
+          DateTime(
+              picked.year, picked.month, picked.day, time.hour, time.minute),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            ElevatedButton(
+              onPressed: () => _pickAlarmTime(context),
+              child: Text(l10n.selectReminderTime),
+            ),
+            if (alarmTime != null)
+              Padding(
+                padding: const EdgeInsets.only(left: 8),
+                child: Text(
+                  DateFormat.yMd(
+                    Localizations.localeOf(context).toString(),
+                  ).add_Hm().format(alarmTime!),
+                ),
+              ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        Row(
+          children: [
+            Text(l10n.repeatLabel),
+            const SizedBox(width: 8),
+            DropdownButton<RepeatInterval?>(
+              value: repeat,
+              onChanged: onRepeatChanged,
+              items: [
+                DropdownMenuItem<RepeatInterval?>(
+                  value: null,
+                  child: Text(l10n.repeatNone),
+                ),
+                DropdownMenuItem<RepeatInterval?>(
+                  value: RepeatInterval.everyMinute,
+                  child: Text(l10n.repeatEveryMinute),
+                ),
+                DropdownMenuItem<RepeatInterval?>(
+                  value: RepeatInterval.hourly,
+                  child: Text(l10n.repeatHourly),
+                ),
+                DropdownMenuItem<RepeatInterval?>(
+                  value: RepeatInterval.daily,
+                  child: Text(l10n.repeatDaily),
+                ),
+                DropdownMenuItem<RepeatInterval?>(
+                  value: RepeatInterval.weekly,
+                  child: Text(l10n.repeatWeekly),
+                ),
+              ],
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        Text(l10n.snoozeLabel(snoozeMinutes)),
+        Slider(
+          value: snoozeMinutes.toDouble(),
+          min: 1,
+          max: 60,
+          divisions: 59,
+          label: snoozeMinutes.toString(),
+          onChanged: (v) => onSnoozeChanged(v.round()),
+        ),
+      ],
+    );
+  }
+}

--- a/test/ai_suggestions_dialog_test.dart
+++ b/test/ai_suggestions_dialog_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:notes_reminder_app/widgets/ai_suggestions_dialog.dart';
+import 'package:notes_reminder_app/services/gemini_service.dart';
+
+void main() {
+  testWidgets('AISuggestionsDialog returns edited data', (tester) async {
+    final analysis = NoteAnalysis(
+      summary: 'sum',
+      actionItems: const ['do'],
+      suggestedTags: const ['tag'],
+      dates: [DateTime(2024, 1, 1)],
+    );
+    AISuggestionsResult? result;
+
+    await tester.pumpWidget(MaterialApp(
+      locale: const Locale('en'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Builder(
+        builder: (context) {
+          return ElevatedButton(
+            onPressed: () async {
+              result = await showDialog<AISuggestionsResult>(
+                context: context,
+                builder: (_) => AISuggestionsDialog(
+                  analysis: analysis,
+                  l10n: AppLocalizations.of(context)!,
+                ),
+              );
+            },
+            child: const Text('open'),
+          );
+        },
+      ),
+    ));
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    expect(find.byType(AlertDialog), findsOneWidget);
+    await tester.enterText(find.byLabelText('Summary'), 'new');
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+    expect(result?.summary, 'new');
+  });
+}

--- a/test/attachment_section_test.dart
+++ b/test/attachment_section_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:notes_reminder_app/widgets/attachment_section.dart';
+
+void main() {
+  testWidgets('AttachmentSection deletes attachment', (tester) async {
+    List<String>? changed;
+    await tester.pumpWidget(MaterialApp(
+      locale: const Locale('en'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: AttachmentSection(
+        attachments: const ['a.txt'],
+        onChanged: (v) => changed = v,
+      ),
+    ));
+
+    expect(find.text('a.txt'), findsOneWidget);
+    await tester.tap(find.byIcon(Icons.delete));
+    await tester.pumpAndSettle();
+    expect(changed, isEmpty);
+  });
+}

--- a/test/reminder_controls_test.dart
+++ b/test/reminder_controls_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:notes_reminder_app/widgets/reminder_controls.dart';
+
+void main() {
+  testWidgets('ReminderControls updates repeat and snooze', (tester) async {
+    RepeatInterval? repeat;
+    int? snooze;
+    await tester.pumpWidget(MaterialApp(
+      locale: const Locale('en'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: ReminderControls(
+        alarmTime: null,
+        repeat: null,
+        snoozeMinutes: 5,
+        onAlarmTimeChanged: (_) {},
+        onRepeatChanged: (v) => repeat = v,
+        onSnoozeChanged: (v) => snooze = v,
+      ),
+    ));
+
+    await tester.tap(find.byType(DropdownButton<RepeatInterval?>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Daily').last);
+    await tester.pumpAndSettle();
+    expect(repeat, RepeatInterval.daily);
+
+    await tester.drag(find.byType(Slider), const Offset(200, 0));
+    await tester.pumpAndSettle();
+    expect(snooze, isNotNull);
+    expect(snooze, isNot(5));
+  });
+}


### PR DESCRIPTION
## Summary
- Extract reminder controls, attachment section, and AI suggestions into dedicated widgets
- Simplify `NoteDetailScreen` to orchestrate state and delegate UI to new widgets
- Add unit tests for the newly created widgets

## Testing
- `flutter test` *(fails: Because notes_reminder_app depends on flutter_localizations from sdk which depends on intl 0.19.0, intl 0.19.0 is required. So, because notes_reminder_app depends on intl ^0.20.2, version solving failed.)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5bace9f8833396efdd5e1b39b771