### PR TITLE
Add notification service error handling tests

### DIFF
--- a/test/notification_service_test.dart
+++ b/test/notification_service_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter/foundation.dart';
 import 'dart:ui';
 import 'package:notes_reminder_app/services/notification_service.dart';
 import 'package:timezone/data/latest.dart' as tzdata;
@@ -12,8 +13,14 @@ void main() {
 
   const channel = MethodChannel('dexterx.dev/flutter_local_notifications');
   final List<MethodCall> log = [];
+  final List<String?> debug = [];
+  final debugPrintOriginal = debugPrint;
 
   setUp(() {
+    debug.clear();
+    debugPrint = (String? message, {int? wrapWidth}) {
+      debug.add(message);
+    };
     channel.setMockMethodCallHandler((MethodCall call) async {
       log.add(call);
       return null;
@@ -23,6 +30,7 @@ void main() {
 
   tearDown(() {
     channel.setMockMethodCallHandler(null);
+    debugPrint = debugPrintOriginal;
   });
 
   test('init initializes plugin', () async {
@@ -30,8 +38,10 @@ void main() {
     expect(log.any((c) => c.method == 'initialize'), isTrue);
   });
 
-  test('scheduleNotification schedules notification', () async {
+  test('scheduleNotification schedules notification with tz', () async {
     final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+    tzdata.initializeTimeZones();
+    tz.setLocalLocation(tz.getLocation('America/Detroit'));
     final service = NotificationService();
     await service.scheduleNotification(
       id: 1,
@@ -40,7 +50,51 @@ void main() {
       scheduledDate: DateTime.now().add(const Duration(minutes: 1)),
       l10n: l10n,
     );
-    expect(log.any((c) => c.method == 'zonedSchedule'), isTrue);
+    final call = log.singleWhere((c) => c.method == 'zonedSchedule');
+    final args = call.arguments as Map<dynamic, dynamic>;
+    expect(args['timeZoneName'], 'America/Detroit');
+  });
+
+  test('scheduleNotification throws if scheduledDate in the past', () async {
+    final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+    final service = NotificationService();
+    expect(
+      () => service.scheduleNotification(
+        id: 10,
+        title: 't',
+        body: 'b',
+        scheduledDate: DateTime.now().subtract(const Duration(minutes: 1)),
+        l10n: l10n,
+      ),
+      throwsArgumentError,
+    );
+  });
+
+  test('scheduleNotification logs error when permission denied', () async {
+    final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+    tzdata.initializeTimeZones();
+    tz.setLocalLocation(tz.getLocation('America/Detroit'));
+    channel.setMockMethodCallHandler((MethodCall call) async {
+      log.add(call);
+      if (call.method == 'zonedSchedule') {
+        throw PlatformException(code: 'denied');
+      }
+      return null;
+    });
+    await NotificationService().scheduleNotification(
+      id: 11,
+      title: 't',
+      body: 'b',
+      scheduledDate: DateTime.now().add(const Duration(minutes: 1)),
+      l10n: l10n,
+    );
+    final call = log.singleWhere((c) => c.method == 'zonedSchedule');
+    final args = call.arguments as Map<dynamic, dynamic>;
+    expect(args['timeZoneName'], 'America/Detroit');
+    expect(
+      debug.any((m) => m != null && m.contains('Error scheduling notification')),
+      isTrue,
+    );
   });
 
   test('scheduleDailyAtTime uses tz and localizations', () async {
@@ -78,5 +132,125 @@ void main() {
     final androidDetails = args['androidDetails'] as Map<dynamic, dynamic>;
     expect(androidDetails['channelName'], l10n.recurring);
     expect(androidDetails['channelDescription'], l10n.recurringDesc);
+  });
+
+  test('scheduleRecurring logs error when permission denied', () async {
+    final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+    tzdata.initializeTimeZones();
+    tz.setLocalLocation(tz.getLocation('America/Detroit'));
+    channel.setMockMethodCallHandler((MethodCall call) async {
+      log.add(call);
+      if (call.method == 'periodicallyShow') {
+        throw PlatformException(code: 'denied');
+      }
+      return null;
+    });
+    await NotificationService().scheduleRecurring(
+      id: 12,
+      title: 't',
+      body: 'b',
+      repeatInterval: RepeatInterval.daily,
+      l10n: l10n,
+    );
+    expect(
+      debug.any((m) =>
+          m != null && m.contains('Error scheduling recurring notification')),
+      isTrue,
+    );
+  });
+
+  test('scheduleRecurring logs duplicate id error', () async {
+    final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+    bool first = true;
+    channel.setMockMethodCallHandler((MethodCall call) async {
+      log.add(call);
+      if (call.method == 'periodicallyShow' && !first) {
+        throw PlatformException(code: 'duplicate');
+      }
+      first = false;
+      return null;
+    });
+    final service = NotificationService();
+    await service.scheduleRecurring(
+      id: 13,
+      title: 't',
+      body: 'b',
+      repeatInterval: RepeatInterval.daily,
+      l10n: l10n,
+    );
+    await service.scheduleRecurring(
+      id: 13,
+      title: 't',
+      body: 'b',
+      repeatInterval: RepeatInterval.daily,
+      l10n: l10n,
+    );
+    expect(
+      debug.where((m) =>
+              m != null && m.contains('Error scheduling recurring notification'))
+          .length,
+      1,
+    );
+  });
+
+  test('snoozeNotification cancels and schedules with tz', () async {
+    final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+    tzdata.initializeTimeZones();
+    tz.setLocalLocation(tz.getLocation('America/Detroit'));
+    final service = NotificationService();
+    await service.snoozeNotification(
+      id: 14,
+      title: 't',
+      body: 'b',
+      minutes: 5,
+      l10n: l10n,
+    );
+    expect(log.first.method, 'cancel');
+    final scheduleCall =
+        log.singleWhere((c) => c.method == 'zonedSchedule');
+    final args = scheduleCall.arguments as Map<dynamic, dynamic>;
+    expect(args['timeZoneName'], 'America/Detroit');
+  });
+
+  test('snoozeNotification throws when permission denied', () async {
+    final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+    tzdata.initializeTimeZones();
+    tz.setLocalLocation(tz.getLocation('America/Detroit'));
+    channel.setMockMethodCallHandler((MethodCall call) async {
+      log.add(call);
+      if (call.method == 'zonedSchedule') {
+        throw PlatformException(code: 'denied');
+      }
+      return null;
+    });
+    final service = NotificationService();
+    expect(
+      () => service.snoozeNotification(
+        id: 15,
+        title: 't',
+        body: 'b',
+        minutes: 5,
+        l10n: l10n,
+      ),
+      throwsA(isA<PlatformException>()),
+    );
+    final call = log.singleWhere((c) => c.method == 'zonedSchedule');
+    final args = call.arguments as Map<dynamic, dynamic>;
+    expect(args['timeZoneName'], 'America/Detroit');
+  });
+
+  test('cancel propagates platform exceptions', () async {
+    channel.setMockMethodCallHandler((MethodCall call) async {
+      log.add(call);
+      if (call.method == 'cancel') {
+        throw PlatformException(code: 'denied');
+      }
+      return null;
+    });
+    expect(
+      () => NotificationService().cancel(99),
+      throwsA(isA<PlatformException>()),
+    );
+    expect(log.single.method, 'cancel');
   });
 }


### PR DESCRIPTION
## Summary
- cover timezone handling for scheduleNotification and snooze flows
- add tests for past dates, duplicate IDs, and permission-denied errors
- verify cancellation propagates platform exceptions

## Testing
- `flutter test test/notification_service_test.dart` *(fails: command not found)*
- `apt-get update`
- `apt-get install -y flutter` *(fails: Unable to locate package)*
- `dart format test/notification_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5baee0b48333a028e6ec2b22c4ba