### PR TITLE
Add encrypted note backup with optional password

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A Flutter application to manage notes, schedule reminders, transcribe speech, pl
 * Voice dictation to turn speech into notes.
 * Text‑to‑speech playback for notes.
 * Chat with Gemini for analysis or conversational replies.
+* Backup and restore encrypted notes with an optional password.
 
 ## Firebase Configuration
 
@@ -72,6 +73,17 @@ Run the tests with:
 ```bash
 flutter test
 ```
+
+## Backup & Restore
+
+Use the backup feature to export your notes to an encrypted JSON file. Each
+note is encrypted with AES‑GCM. When exporting, you may supply a password to
+derive the encryption key. If you leave the password blank, the key stored in
+secure storage on the device is used instead.
+
+To restore notes, choose the backup file and enter the same password you used
+when exporting (or leave it blank to use the device key). The imported notes
+will replace the existing ones on the device.
 
 
 ## Troubleshooting

--- a/lib/services/note_repository.dart
+++ b/lib/services/note_repository.dart
@@ -24,23 +24,21 @@ class NoteRepository {
     return _dbService.updateNote(note);
   }
 
-  Future<Map<String, dynamic>> encryptNote(Note note) {
-    return _dbService.encryptNote(note);
+  Future<Map<String, dynamic>> encryptNote(Note note, {String? password}) {
+    return _dbService.encryptNote(note, password: password);
   }
 
-
-
-  Future<Note> decryptNote(Map<String, dynamic> data) {
-    return _dbService.decryptNote(data);
+  Future<Note> decryptNote(Map<String, dynamic> data, {String? password}) {
+    return _dbService.decryptNote(data, password: password);
   }
 
-  Future<bool> exportNotes(AppLocalizations l10n) async {
+  Future<bool> exportNotes(AppLocalizations l10n, {String? password}) async {
     final notes = await _dbService.getNotes();
-    return _backupService.exportNotes(notes, l10n);
+    return _backupService.exportNotes(notes, l10n, password: password);
   }
 
-  Future<List<Note>> importNotes(AppLocalizations l10n) async {
-    final notes = await _backupService.importNotes(l10n);
+  Future<List<Note>> importNotes(AppLocalizations l10n, {String? password}) async {
+    final notes = await _backupService.importNotes(l10n, password: password);
     if (notes.isNotEmpty) {
       await _dbService.saveNotes(notes);
     }


### PR DESCRIPTION
## Summary
- Encrypt notes before exporting backups using AES-GCM
- Allow import/export with optional password or device key
- Document encrypted backup and restore workflow

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5bb6bce4833398d21e3627541d63