### PR TITLE
chore(android): add google services plugin

### DIFF
--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -21,6 +21,7 @@ plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "8.1.1" apply false
     id("org.jetbrains.kotlin.android") version "1.9.23" apply false
+    id("com.google.gms.google-services") version "4.4.2" apply false
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
## Summary
- add Google Services plugin declaration in Android settings

## Testing
- `gradle help --scan -Dscan.acceptTermsOfService=yes` *(fails: Flutter SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc610576b88333985d6e85c0452a4c