### PR TITLE
Add Android build workflow

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -1,0 +1,25 @@
+name: Build Android APK
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          flutter-version: '3.x'
+      - run: flutter pub get
+      - run: flutter build apk --release
+      - uses: actions/upload-artifact@v3
+        with:
+          name: app-release-apk
+          path: build/app/outputs/flutter-apk/app-release.apk


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build Android release APK and upload as artifact

## Testing
- `flutter pub get`
- `flutter test` *(fails: Couldn't resolve packages `flutter_gen`, `googleapis`, `image_picker`)*


------
https://chatgpt.com/codex/tasks/task_e_68bc6114dc048333a3a039e2305a1d2a