### PR TITLE
chore: raise iOS deployment target

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '11.0'
+platform :ios, '13.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'


### PR DESCRIPTION
## Summary
- update Podfile to target iOS 13.0

## Testing
- `pod install --allow-root` *(fails: CDN: trunk URL couldn't be downloaded)*
- `flutter build ios` *(fails: Could not find a subcommand named "ios" for "flutter build".)*

------
https://chatgpt.com/codex/tasks/task_e_68bc611f4f688333876706af07f3db75