### PR TITLE
Inject HTTP client into GeminiService and expand tests

### DIFF
--- a/lib/services/gemini_service.dart
+++ b/lib/services/gemini_service.dart
@@ -8,7 +8,13 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class GeminiService {
   static const _apiKey = String.fromEnvironment('GEMINI_API_KEY', defaultValue: '');
-  static const _model = 'gemini-1.5-flash-latest';
+
+  final http.Client _client;
+  final String _model;
+
+  GeminiService({http.Client? client, String model = 'gemini-1.5-flash-latest'})
+      : _client = client ?? http.Client(),
+        _model = model;
 
   Future<String> chat(String userText, AppLocalizations l10n) async {
     if (_apiKey.isEmpty) return l10n.geminiApiKeyNotConfigured;
@@ -23,7 +29,7 @@ class GeminiService {
     };
 
     try {
-      final res = await http
+      final res = await _client
           .post(
             uri,
             headers: {'Content-Type': 'application/json'},
@@ -74,7 +80,7 @@ class GeminiService {
 
     http.Response res;
     try {
-      res = await http
+      res = await _client
           .post(
             uri,
             headers: {'Content-Type': 'application/json'},

--- a/test/gemini_service_test.dart
+++ b/test/gemini_service_test.dart
@@ -1,44 +1,106 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:notes_reminder_app/services/gemini_service.dart';
 
-void main() {
-  test('analyzeNote parses valid response', () async {
-    final service = GeminiService();
-    final analysisJson = {
-      'summary': 'note summary',
-      'actionItems': ['task1'],
-      'suggestedTags': ['tag1', 'tag2'],
-      'dates': ['2024-01-01T00:00:00Z']
-    };
-    final apiResponse = {
-      'candidates': [
-        {
-          'content': {
-            'parts': [
-              {'text': jsonEncode(analysisJson)}
-            ]
-          }
-        }
-      ]
-    };
+class MockL10n extends Mock implements AppLocalizations {}
 
-    final client = MockClient((request) async {
-      expect(request.method, 'POST');
-      return http.Response(jsonEncode(apiResponse), 200,
-          headers: {'content-type': 'application/json'});
+void main() {
+  group('analyzeNote', () {
+    test('parses valid response', () async {
+      final analysisJson = {
+        'summary': 'note summary',
+        'actionItems': ['task1'],
+        'suggestedTags': ['tag1', 'tag2'],
+        'dates': ['2024-01-01T00:00:00Z']
+      };
+      final apiResponse = {
+        'candidates': [
+          {
+            'content': {
+              'parts': [
+                {'text': jsonEncode(analysisJson)}
+              ]
+            }
+          }
+        ]
+      };
+
+      final client = MockClient((request) async {
+        expect(request.method, 'POST');
+        return http.Response(jsonEncode(apiResponse), 200,
+            headers: {'content-type': 'application/json'});
+      });
+
+      final service = GeminiService(client: client);
+      final result = await service.analyzeNote('test note');
+
+      expect(result, isNotNull);
+      expect(result!.summary, analysisJson['summary']);
+      expect(result.actionItems, analysisJson['actionItems']);
+      expect(result.suggestedTags, analysisJson['suggestedTags']);
+      expect(result.dates.first, DateTime.parse(analysisJson['dates']![0]));
     });
 
-    final result = await http.runWithClient(
-        () => service.analyzeNote('test note'), () => client);
+    test('returns null on http error', () async {
+      final client = MockClient((_) async => http.Response('err', 500));
+      final service = GeminiService(client: client);
 
-    expect(result, isNotNull);
-    expect(result!.summary, analysisJson['summary']);
-    expect(result.actionItems, analysisJson['actionItems']);
-    expect(result.suggestedTags, analysisJson['suggestedTags']);
-    expect(result.dates.first, DateTime.parse(analysisJson['dates']![0]));
+      final result = await service.analyzeNote('note');
+      expect(result, isNull);
+    });
+
+    test('returns null on network error', () async {
+      final client = MockClient((_) async => throw SocketException('no net'));
+      final service = GeminiService(client: client);
+
+      final result = await service.analyzeNote('note');
+      expect(result, isNull);
+    });
+  });
+
+  group('chat', () {
+    late MockL10n l10n;
+
+    setUp(() {
+      l10n = MockL10n();
+      when(() => l10n.geminiApiKeyNotConfigured).thenReturn('no key');
+      when(() => l10n.noResponse).thenReturn('no response');
+      when(() => l10n.noInternetConnection).thenReturn('no internet');
+      when(() => l10n.networkError).thenReturn('network error');
+      when(() => l10n.geminiError(any())).thenAnswer(
+          (invocation) => 'error: ${invocation.positionalArguments.first}');
+    });
+
+    test('returns error on invalid api key', () async {
+      final client = MockClient((_) async => http.Response('denied', 401));
+      final service = GeminiService(client: client);
+
+      final result = await service.chat('hi', l10n);
+      expect(result, 'error: Invalid API key');
+    });
+
+    test('returns error on server issue', () async {
+      final client =
+          MockClient((_) async => http.Response('boom', 500, reasonPhrase: 'ERR'));
+      final service = GeminiService(client: client);
+
+      final result = await service.chat('hi', l10n);
+      expect(result, 'error: 500 ERR');
+    });
+
+    test('returns no internet on socket exception', () async {
+      final client = MockClient((_) async => throw SocketException('x'));
+      final service = GeminiService(client: client);
+
+      final result = await service.chat('hi', l10n);
+      expect(result, 'no internet');
+    });
   });
 }
+


### PR DESCRIPTION
## Summary
- Inject `http.Client` and model name into `GeminiService` via constructor
- Refactor Gemini API calls to use the injected client
- Add unit tests with mocked clients verifying success and error flows

## Testing
- `flutter test --dart-define=GEMINI_API_KEY=dummy` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc65d4eed08333b04354908a64fcaf