### PR TITLE
feat(db): surface decryption failures

### DIFF
--- a/lib/services/note_repository.dart
+++ b/lib/services/note_repository.dart
@@ -9,11 +9,13 @@ class NoteRepository {
   final BackupService _backupService;
 
   NoteRepository({DbService? dbService, BackupService? backupService})
-      : _dbService = dbService ?? DbService(),
-        _backupService = backupService ?? BackupService();
+    : _dbService = dbService ?? DbService(),
+      _backupService = backupService ?? BackupService();
 
-  Future<List<Note>> getNotes() {
-    return _dbService.getNotes();
+  Future<List<Note>> getNotes({
+    void Function(String noteId)? onDecryptFailure,
+  }) {
+    return _dbService.getNotes(onDecryptFailure: onDecryptFailure);
   }
 
   Future<void> saveNotes(List<Note> notes) {
@@ -37,12 +39,14 @@ class NoteRepository {
     return _backupService.exportNotes(notes, l10n, password: password);
   }
 
-  Future<List<Note>> importNotes(AppLocalizations l10n, {String? password}) async {
+  Future<List<Note>> importNotes(
+    AppLocalizations l10n, {
+    String? password,
+  }) async {
     final notes = await _backupService.importNotes(l10n, password: password);
     if (notes.isNotEmpty) {
       await _dbService.saveNotes(notes);
     }
     return notes;
   }
-
 }

--- a/test/db_service_test.dart
+++ b/test/db_service_test.dart
@@ -1,0 +1,41 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:notes_reminder_app/services/db_service.dart';
+import 'package:notes_reminder_app/models/note.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    FlutterSecureStorage.setMockInitialValues({});
+  });
+
+  test('getNotes reports corrupted entries', () async {
+    final db = DbService();
+    final notes = const [
+      Note(id: 'good', title: 't', content: 'c'),
+      Note(id: 'bad', title: 't2', content: 'c2'),
+    ];
+    await db.saveNotes(notes);
+
+    final sp = await SharedPreferences.getInstance();
+    final raw = sp.getString('notes_v2');
+    final list = (jsonDecode(raw!) as List).cast<Map<String, dynamic>>();
+    final badMap = list.firstWhere((m) => m['id'] == 'bad');
+    final tagBytes = base64Decode(badMap['tag']);
+    tagBytes[0] ^= 0xFF;
+    badMap['tag'] = base64Encode(tagBytes);
+    await sp.setString('notes_v2', jsonEncode(list));
+
+    final failed = <String>[];
+    final result = await db.getNotes(onDecryptFailure: failed.add);
+
+    expect(result.length, 1);
+    expect(result.first.id, 'good');
+    expect(failed, ['bad']);
+  });
+}


### PR DESCRIPTION
## Summary
- collect IDs for notes that fail decryption and log each failure
- allow higher layers to receive decryption errors via a callback
- test that corrupted note entries report their IDs

## Testing
- `flutter test` *(fails: Couldn't resolve package 'flutter_gen' due to invalid ARB resource name)*

------
https://chatgpt.com/codex/tasks/task_e_68bc65dbc2648333b535448175c73c36