### PR TITLE
Refactor HomeScreen notes list into widgets

### DIFF
--- a/lib/widgets/notes_list.dart
+++ b/lib/widgets/notes_list.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+
+import '../models/note.dart';
+import '../providers/note_provider.dart';
+import '../services/auth_service.dart';
+import '../screens/note_detail_screen.dart';
+
+class NotesList extends StatefulWidget {
+  final List<Note> notes;
+
+  const NotesList({super.key, required this.notes});
+
+  @override
+  State<NotesList> createState() => _NotesListState();
+}
+
+class _NotesListState extends State<NotesList> {
+  final ScrollController _scrollController = ScrollController();
+  bool _isLoadingMore = false;
+  bool _hasMore = true;
+  DateTime? _lastFetched;
+  static const _pageSize = 20;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController.addListener(_onScroll);
+    WidgetsBinding.instance.addPostFrameCallback((_) => _initialFetch());
+  }
+
+  Future<void> _initialFetch() async {
+    final provider = context.read<NoteProvider>();
+    if (provider.notes.isNotEmpty) {
+      setState(() {
+        _lastFetched = provider.notes.last.updatedAt;
+        _hasMore = provider.notes.length >= _pageSize;
+      });
+    } else {
+      final notes = await provider.fetchNotesPage(null, _pageSize);
+      if (!mounted) return;
+      setState(() {
+        if (notes.isNotEmpty) {
+          _lastFetched = notes.last.updatedAt;
+          _hasMore = notes.length == _pageSize;
+        }
+      });
+    }
+  }
+
+  void _onScroll() {
+    if (!_hasMore || _isLoadingMore) return;
+    if (_scrollController.position.pixels >=
+        _scrollController.position.maxScrollExtent - 200) {
+      _loadMore();
+    }
+  }
+
+  Future<void> _loadMore() async {
+    setState(() => _isLoadingMore = true);
+    final notes = await context.read<NoteProvider>().fetchNotesPage(
+      _lastFetched,
+      _pageSize,
+    );
+    if (!mounted) return;
+    setState(() {
+      _isLoadingMore = false;
+      if (notes.isNotEmpty) {
+        _lastFetched = notes.last.updatedAt;
+      }
+      if (notes.length < _pageSize) {
+        _hasMore = false;
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final notes = widget.notes;
+    if (notes.isEmpty) {
+      return Center(child: Text(AppLocalizations.of(context)!.noNotes));
+    }
+
+    final provider = context.watch<NoteProvider>();
+    final itemCount = notes.length + (_isLoadingMore ? 1 : 0);
+    return ListView.builder(
+      controller: _scrollController,
+      itemCount: itemCount,
+      itemBuilder: (context, index) {
+        if (index >= notes.length) {
+          return const Padding(
+            padding: EdgeInsets.symmetric(vertical: 16),
+            child: Center(child: CircularProgressIndicator()),
+          );
+        }
+        final note = notes[index];
+        return Card(
+          child: ListTile(
+            leading: note.locked ? const Icon(Icons.lock) : null,
+            title: Text(note.title),
+            subtitle: Text(
+              note.alarmTime != null
+                  ? '${note.content}\n⏰ ${DateFormat.yMd(Localizations.localeOf(context).toString()).add_Hm().format(note.alarmTime!)}'
+                  : note.content,
+            ),
+            onTap: () async {
+              if (note.locked) {
+                final ok = await AuthService().authenticate(
+                  AppLocalizations.of(context)!,
+                );
+                if (!ok) return;
+              }
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => NoteDetailScreen(note: note)),
+              );
+            },
+            trailing: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (!provider.isSynced(note.id))
+                  const Icon(Icons.sync_problem, color: Colors.orange),
+                IconButton(
+                  icon: const Icon(Icons.delete),
+                  tooltip: AppLocalizations.of(context)!.delete,
+                  onPressed: () {
+                    final provider = context.read<NoteProvider>();
+                    final idx = provider.notes.indexWhere(
+                      (n) => n.id == note.id,
+                    );
+                    if (idx != -1) {
+                      provider.removeNoteAt(idx);
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Text(
+                            AppLocalizations.of(context)!.noteDeleted,
+                          ),
+                          action: SnackBarAction(
+                            label: AppLocalizations.of(context)!.undo,
+                            onPressed: () => provider.addNote(note),
+                          ),
+                        ),
+                      );
+                    }
+                  },
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/widgets/tag_filter_menu.dart
+++ b/lib/widgets/tag_filter_menu.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+class TagFilterMenu extends StatelessWidget {
+  final List<String> tags;
+  final String? selectedTag;
+  final ValueChanged<String?> onSelected;
+
+  const TagFilterMenu({
+    super.key,
+    required this.tags,
+    required this.selectedTag,
+    required this.onSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return PopupMenuButton<String?>(
+      icon: const Icon(Icons.label),
+      onSelected: onSelected,
+      itemBuilder: (context) => [
+        PopupMenuItem<String?>(
+          value: null,
+          child: Text(AppLocalizations.of(context)!.allTags),
+        ),
+        ...tags.map((t) => PopupMenuItem<String?>(value: t, child: Text(t))),
+      ],
+    );
+  }
+}

--- a/test/home_screen_test.dart
+++ b/test/home_screen_test.dart
@@ -42,6 +42,7 @@ void main() {
 
   testWidgets('filter notes by tag', (tester) async {
     final provider = NoteProvider();
+    final l10n = await AppLocalizations.delegate.load(const Locale('vi'));
     await tester.pumpWidget(
       ChangeNotifierProvider.value(
         value: provider,
@@ -91,7 +92,7 @@ void main() {
 
     await tester.tap(find.byIcon(Icons.label));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('All').last);
+    await tester.tap(find.text(l10n.allTags).last);
     await tester.pumpAndSettle();
 
     expect(find.text('n1'), findsOneWidget);

--- a/test/tag_filter_menu_test.dart
+++ b/test/tag_filter_menu_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:notes_reminder_app/widgets/tag_filter_menu.dart';
+
+void main() {
+  testWidgets('TagFilterMenu selects tag', (tester) async {
+    String? selected;
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('en'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          appBar: AppBar(
+            actions: [
+              TagFilterMenu(
+                tags: const ['work', 'home'],
+                selectedTag: null,
+                onSelected: (tag) => selected = tag,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byIcon(Icons.label));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('work').last);
+    await tester.pumpAndSettle();
+
+    expect(selected, 'work');
+  });
+}


### PR DESCRIPTION
## Summary
- extract notes list, infinite scroll, and tag filter into reusable widgets
- simplify HomeScreen layout and state management
- add widget test for tag filter and update existing tests

## Testing
- `flutter test` *(fails: Couldn't resolve the package 'flutter_gen' and other plugin dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bc65df315883339a31d7a11ee988c5