### PR TITLE
Add bottom navigation tabs for core screens

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -161,6 +161,7 @@ class _MyAppState extends State<MyApp> {
         data: MediaQuery.of(context).copyWith(textScaleFactor: _fontScale),
         child: child!,
       ),
+      // Home screen with bottom navigation bar
       home: HomeScreen(
         onThemeChanged: updateTheme,
         onFontScaleChanged: updateFontScale,

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -9,6 +9,7 @@ import '../services/settings_service.dart';
 import '../widgets/add_note_dialog.dart';
 import '../widgets/notes_list.dart';
 import '../widgets/tag_filter_menu.dart';
+import 'chat_screen.dart';
 import 'note_list_for_day_screen.dart';
 import 'note_search_delegate.dart';
 import 'settings_screen.dart';
@@ -29,6 +30,67 @@ class HomeScreen extends StatefulWidget {
 }
 
 class _HomeScreenState extends State<HomeScreen> {
+  int _currentIndex = 0;
+  late final List<Widget> _screens;
+
+  @override
+  void initState() {
+    super.initState();
+    _screens = [
+      const _NotesTab(),
+      NoteListForDayScreen(date: DateTime.now()),
+      const VoiceToNoteScreen(),
+      const ChatScreen(initialMessage: ''),
+      SettingsScreen(
+        onThemeChanged: widget.onThemeChanged,
+        onFontScaleChanged: widget.onFontScaleChanged,
+      ),
+    ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    return Scaffold(
+      body: IndexedStack(index: _currentIndex, children: _screens),
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _currentIndex,
+        onTap: (i) => setState(() => _currentIndex = i),
+        items: [
+          const BottomNavigationBarItem(
+            icon: Icon(Icons.note),
+            label: 'Notes',
+          ),
+          const BottomNavigationBarItem(
+            icon: Icon(Icons.alarm),
+            label: 'Reminders',
+          ),
+          BottomNavigationBarItem(
+            icon: const Icon(Icons.mic),
+            label: l10n.voiceToNote,
+          ),
+          BottomNavigationBarItem(
+            icon: const Icon(Icons.smart_toy),
+            label: l10n.chatAI,
+          ),
+          BottomNavigationBarItem(
+            icon: const Icon(Icons.settings),
+            label: l10n.settings,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _NotesTab extends StatefulWidget {
+  const _NotesTab();
+
+  @override
+  State<_NotesTab> createState() => _NotesTabState();
+}
+
+class _NotesTabState extends State<_NotesTab> {
   String _mascotPath = 'assets/lottie/mascot.json';
   final DateTime _today = DateTime.now();
   String? _selectedTag;
@@ -89,31 +151,6 @@ class _HomeScreenState extends State<HomeScreen> {
               context: context,
               delegate: NoteSearchDelegate(context.read<NoteProvider>().notes),
             ),
-          ),
-          IconButton(
-            icon: const Icon(Icons.mic),
-            onPressed: () async {
-              await Navigator.push(
-                context,
-                MaterialPageRoute(builder: (_) => const VoiceToNoteScreen()),
-              );
-            },
-          ),
-          IconButton(
-            icon: const Icon(Icons.settings),
-            tooltip: AppLocalizations.of(context)!.settingsTooltip,
-            onPressed: () async {
-              await Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => SettingsScreen(
-                    onThemeChanged: widget.onThemeChanged,
-                    onFontScaleChanged: widget.onFontScaleChanged,
-                  ),
-                ),
-              );
-              _loadMascot();
-            },
           ),
         ],
       ),


### PR DESCRIPTION
## Summary
- Introduce a bottom navigation bar with Notes, Reminders, Voice, AI, and Settings tabs
- Move existing HomeScreen content into a dedicated Notes tab
- Wire each tab to its respective screen (VoiceToNote, Chat, Settings, etc.)

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc69ba883c8333a8eda0c49dba985d