### PR TITLE
Add swipe and long-press actions for notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A Flutter application to manage notes, schedule reminders, transcribe speech, pl
 * Chat with Gemini for analysis or conversational replies.
 * Backup and restore encrypted notes with an optional password.
 * Notes waiting to sync display a warning icon (e.g., `sync_problem`) and upload automatically when connectivity returns.
+* Swipe notes to pin, share, or delete. Long‑press a note to mark it done, set a reminder, or share.
 
 ## Firebase Configuration
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -41,6 +41,11 @@
   "delete": "Delete",
   "timeLabel": "Time",
 
+  "pin": "Pin",
+  "share": "Share",
+  "markDone": "Mark done",
+  "setReminder": "Set reminder",
+
   "noteDeleted": "Note deleted",
   "undo": "Undo",
 

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -41,6 +41,11 @@
   "delete": "Xóa",
   "timeLabel": "Thời gian",
 
+  "pin": "Ghim",
+  "share": "Chia sẻ",
+  "markDone": "Đánh dấu xong",
+  "setReminder": "Đặt nhắc nhở",
+
   "noteDeleted": "Đã xóa ghi chú",
   "undo": "Hoàn tác",
 

--- a/lib/models/note.dart
+++ b/lib/models/note.dart
@@ -57,6 +57,14 @@ class Note {
   @JsonKey(defaultValue: 0)
   final int snoozeMinutes;
 
+  /// Whether this note is pinned to the top of the list.
+  @JsonKey(defaultValue: false)
+  final bool pinned;
+
+  /// Whether this note has been marked as completed.
+  @JsonKey(defaultValue: false)
+  final bool done;
+
   /// Timestamp of the last update.
   final DateTime? updatedAt;
 
@@ -82,6 +90,8 @@ class Note {
     this.attachments = const [],
     this.locked = false,
     this.snoozeMinutes = 0,
+    this.pinned = false,
+    this.done = false,
     this.updatedAt,
     this.notificationId,
     this.eventId,
@@ -103,6 +113,8 @@ class Note {
     List<DateTime>? dates,
     bool? locked,
     int? snoozeMinutes,
+    bool? pinned,
+    bool? done,
     DateTime? updatedAt,
     Object? notificationId = _notificationIdSentinel,
 
@@ -124,6 +136,8 @@ class Note {
       attachments: attachments ?? this.attachments,
       locked: locked ?? this.locked,
       snoozeMinutes: snoozeMinutes ?? this.snoozeMinutes,
+      pinned: pinned ?? this.pinned,
+      done: done ?? this.done,
       updatedAt: updatedAt ?? this.updatedAt,
       notificationId: notificationId == _notificationIdSentinel
           ? this.notificationId

--- a/lib/models/note.g.dart
+++ b/lib/models/note.g.dart
@@ -35,6 +35,8 @@ Note _$NoteFromJson(Map<String, dynamic> json) => Note(
           [],
       locked: json['locked'] as bool? ?? false,
       snoozeMinutes: (json['snoozeMinutes'] as num?)?.toInt() ?? 0,
+      pinned: json['pinned'] as bool? ?? false,
+      done: json['done'] as bool? ?? false,
       updatedAt: json['updatedAt'] == null
           ? null
           : DateTime.parse(json['updatedAt'] as String),
@@ -57,6 +59,8 @@ Map<String, dynamic> _$NoteToJson(Note instance) => <String, dynamic>{
       'attachments': instance.attachments,
       'locked': instance.locked,
       'snoozeMinutes': instance.snoozeMinutes,
+      'pinned': instance.pinned,
+      'done': instance.done,
       'updatedAt': instance.updatedAt?.toIso8601String(),
       'notificationId': instance.notificationId,
       'eventId': instance.eventId,

--- a/lib/providers/note_provider.dart
+++ b/lib/providers/note_provider.dart
@@ -16,7 +16,16 @@ import '../services/note_repository.dart';
 import '../services/calendar_service.dart';
 import '../services/notification_service.dart';
 
-int _noteComparator(Note a, Note b) => (b.updatedAt ?? DateTime.fromMillisecondsSinceEpoch(0)).compareTo(a.updatedAt ?? DateTime.fromMillisecondsSinceEpoch(0));
+int _noteComparator(Note a, Note b) {
+  if (a.pinned != b.pinned) {
+    return b.pinned ? 1 : -1;
+  }
+  if (a.done != b.done) {
+    return a.done ? 1 : -1;
+  }
+  return (b.updatedAt ?? DateTime.fromMillisecondsSinceEpoch(0))
+      .compareTo(a.updatedAt ?? DateTime.fromMillisecondsSinceEpoch(0));
+}
 
 class NoteProvider extends ChangeNotifier {
   final NoteRepository _repository;

--- a/lib/widgets/notes_list.dart
+++ b/lib/widgets/notes_list.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
+import 'package:flutter_slidable/flutter_slidable.dart';
+import 'package:share_plus/share_plus.dart';
 
 import '../models/note.dart';
 import '../providers/note_provider.dart';
@@ -103,46 +105,44 @@ class _NotesListState extends State<NotesList> {
         }
         final note = notes[index];
         return Card(
-          child: ListTile(
-            leading: note.locked ? const Icon(Icons.lock) : null,
-            title: Text(note.title),
-            subtitle: Text(
-              note.alarmTime != null
-                  ? '${note.content}\n⏰ ${DateFormat.yMd(Localizations.localeOf(context).toString()).add_Hm().format(note.alarmTime!)}'
-                  : note.content,
-            ),
-            onTap: () async {
-              if (note.locked) {
-                final ok = await AuthService().authenticate(
-                  AppLocalizations.of(context)!,
-                );
-                if (!ok) return;
-              }
-              Navigator.push(
-                context,
-                MaterialPageRoute(builder: (_) => NoteDetailScreen(note: note)),
-              );
-            },
-            trailing: Row(
-              mainAxisSize: MainAxisSize.min,
+          child: Slidable(
+            key: ValueKey(note.id),
+            startActionPane: ActionPane(
+              motion: const DrawerMotion(),
               children: [
-                if (!provider.isSynced(note.id))
-                  const Icon(Icons.sync_problem, color: Colors.orange),
-                IconButton(
-                  icon: const Icon(Icons.delete),
-                  tooltip: AppLocalizations.of(context)!.delete,
-                  onPressed: () {
-                    final provider = context.read<NoteProvider>();
-                    final idx = provider.notes.indexWhere(
-                      (n) => n.id == note.id,
+                SlidableAction(
+                  onPressed: (_) async {
+                    final l10n = AppLocalizations.of(context)!;
+                    await provider.updateNote(
+                      note.copyWith(pinned: !note.pinned),
+                      l10n,
                     );
+                  },
+                  icon: Icons.push_pin,
+                  label: AppLocalizations.of(context)!.pin,
+                ),
+              ],
+            ),
+            endActionPane: ActionPane(
+              motion: const DrawerMotion(),
+              children: [
+                SlidableAction(
+                  onPressed: (_) {
+                    Share.share('${note.title}\n${note.content}');
+                  },
+                  icon: Icons.share,
+                  label: AppLocalizations.of(context)!.share,
+                ),
+                SlidableAction(
+                  backgroundColor: Colors.red,
+                  onPressed: (_) {
+                    final idx = provider.notes.indexWhere((n) => n.id == note.id);
                     if (idx != -1) {
                       provider.removeNoteAt(idx);
                       ScaffoldMessenger.of(context).showSnackBar(
                         SnackBar(
-                          content: Text(
-                            AppLocalizations.of(context)!.noteDeleted,
-                          ),
+                          content:
+                              Text(AppLocalizations.of(context)!.noteDeleted),
                           action: SnackBarAction(
                             label: AppLocalizations.of(context)!.undo,
                             onPressed: () => provider.addNote(note),
@@ -151,8 +151,97 @@ class _NotesListState extends State<NotesList> {
                       );
                     }
                   },
+                  icon: Icons.delete,
+                  label: AppLocalizations.of(context)!.delete,
                 ),
               ],
+            ),
+            child: ListTile(
+              leading: note.locked ? const Icon(Icons.lock) : null,
+              title: Text(note.title),
+              subtitle: Text(
+                note.alarmTime != null
+                    ? '${note.content}\n⏰ ${DateFormat.yMd(Localizations.localeOf(context).toString()).add_Hm().format(note.alarmTime!)}'
+                    : note.content,
+              ),
+              onTap: () async {
+                if (note.locked) {
+                  final ok = await AuthService().authenticate(
+                    AppLocalizations.of(context)!,
+                  );
+                  if (!ok) return;
+                }
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => NoteDetailScreen(note: note)),
+                );
+              },
+              onLongPress: () {
+                final l10n = AppLocalizations.of(context)!;
+                showModalBottomSheet(
+                  context: context,
+                  builder: (ctx) => SafeArea(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        ListTile(
+                          leading: const Icon(Icons.check),
+                          title: Text(l10n.markDone),
+                          onTap: () async {
+                            Navigator.pop(ctx);
+                            await provider.updateNote(
+                              note.copyWith(done: true, active: false),
+                              l10n,
+                            );
+                          },
+                        ),
+                        ListTile(
+                          leading: const Icon(Icons.alarm),
+                          title: Text(l10n.setReminder),
+                          onTap: () async {
+                            Navigator.pop(ctx);
+                            final date = await showDatePicker(
+                              context: context,
+                              firstDate: DateTime.now(),
+                              lastDate:
+                                  DateTime.now().add(const Duration(days: 365)),
+                              initialDate: DateTime.now(),
+                            );
+                            if (date == null) return;
+                            final time = await showTimePicker(
+                              context: context,
+                              initialTime: TimeOfDay.now(),
+                            );
+                            if (time == null) return;
+                            final alarmTime = DateTime(
+                              date.year,
+                              date.month,
+                              date.day,
+                              time.hour,
+                              time.minute,
+                            );
+                            await provider.updateNote(
+                              note.copyWith(alarmTime: alarmTime),
+                              l10n,
+                            );
+                          },
+                        ),
+                        ListTile(
+                          leading: const Icon(Icons.share),
+                          title: Text(l10n.share),
+                          onTap: () {
+                            Navigator.pop(ctx);
+                            Share.share('${note.title}\n${note.content}');
+                          },
+                        ),
+                      ],
+                    ),
+                  ),
+                );
+              },
+              trailing: provider.isSynced(note.id)
+                  ? null
+                  : const Icon(Icons.sync_problem, color: Colors.orange),
             ),
           ),
         );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   speech_to_text: ^7.3.0
   share_plus: ^10.0.2
   connectivity_plus: ^6.1.5
+  flutter_slidable: ^4.0.1
 
   local_auth: ^2.1.7
 


### PR DESCRIPTION
## Summary
- allow pin/share/delete via slidable swipe gestures
- support long-press menu to mark done, set reminders, or share
- document new note gestures

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter gen-l10n` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc69bcb70c8333b3ccf6d28479589b