### PR TITLE
Add hero transitions for notes with custom fade slide routes

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -95,7 +95,22 @@ class _HomeScreenState extends State<HomeScreen> {
             onPressed: () async {
               await Navigator.push(
                 context,
-                MaterialPageRoute(builder: (_) => const VoiceToNoteScreen()),
+                PageRouteBuilder(
+                  pageBuilder: (_, __, ___) => const VoiceToNoteScreen(),
+                  transitionsBuilder: (_, animation, __, child) {
+                    final offsetAnimation = Tween<Offset>(
+                      begin: const Offset(1, 0),
+                      end: Offset.zero,
+                    ).animate(animation);
+                    return FadeTransition(
+                      opacity: animation,
+                      child: SlideTransition(
+                        position: offsetAnimation,
+                        child: child,
+                      ),
+                    );
+                  },
+                ),
               );
             },
           ),
@@ -105,11 +120,24 @@ class _HomeScreenState extends State<HomeScreen> {
             onPressed: () async {
               await Navigator.push(
                 context,
-                MaterialPageRoute(
-                  builder: (_) => SettingsScreen(
+                PageRouteBuilder(
+                  pageBuilder: (_, __, ___) => SettingsScreen(
                     onThemeChanged: widget.onThemeChanged,
                     onFontScaleChanged: widget.onFontScaleChanged,
                   ),
+                  transitionsBuilder: (_, animation, __, child) {
+                    final offsetAnimation = Tween<Offset>(
+                      begin: const Offset(1, 0),
+                      end: Offset.zero,
+                    ).animate(animation);
+                    return FadeTransition(
+                      opacity: animation,
+                      child: SlideTransition(
+                        position: offsetAnimation,
+                        child: child,
+                      ),
+                    );
+                  },
                 ),
               );
               _loadMascot();
@@ -134,8 +162,22 @@ class _HomeScreenState extends State<HomeScreen> {
                   onTap: () {
                     Navigator.push(
                       context,
-                      MaterialPageRoute(
-                        builder: (_) => NoteListForDayScreen(date: d),
+                      PageRouteBuilder(
+                        pageBuilder: (_, __, ___) =>
+                            NoteListForDayScreen(date: d),
+                        transitionsBuilder: (_, animation, __, child) {
+                          final offsetAnimation = Tween<Offset>(
+                            begin: const Offset(1, 0),
+                            end: Offset.zero,
+                          ).animate(animation);
+                          return FadeTransition(
+                            opacity: animation,
+                            child: SlideTransition(
+                              position: offsetAnimation,
+                              child: child,
+                            ),
+                          );
+                        },
                       ),
                     );
                   },

--- a/lib/screens/note_detail_screen.dart
+++ b/lib/screens/note_detail_screen.dart
@@ -71,7 +71,13 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
     final availableTags = provider.notes.expand((n) => n.tags).toSet().toList();
     return Scaffold(
       appBar: AppBar(
-        title: Text(widget.note.title),
+        title: Hero(
+          tag: widget.note.id,
+          child: Material(
+            color: Colors.transparent,
+            child: Text(widget.note.title),
+          ),
+        ),
         actions: [
           TextButton(
             onPressed: _readNote,
@@ -131,9 +137,22 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
               onPressed: () {
                 Navigator.push(
                   context,
-                  MaterialPageRoute(
-                    builder: (context) =>
+                  PageRouteBuilder(
+                    pageBuilder: (_, __, ___) =>
                         ChatScreen(initialMessage: _contentCtrl.text),
+                    transitionsBuilder: (_, animation, __, child) {
+                      final offsetAnimation = Tween<Offset>(
+                        begin: const Offset(1, 0),
+                        end: Offset.zero,
+                      ).animate(animation);
+                      return FadeTransition(
+                        opacity: animation,
+                        child: SlideTransition(
+                          position: offsetAnimation,
+                          child: child,
+                        ),
+                      );
+                    },
                   ),
                 );
               },

--- a/lib/screens/note_list_for_day_screen.dart
+++ b/lib/screens/note_list_for_day_screen.dart
@@ -53,7 +53,13 @@ class NoteListForDayScreen extends StatelessWidget {
               : null;
           return Card(
             child: ListTile(
-              title: Text(note.title),
+              title: Hero(
+                tag: note.id,
+                child: Material(
+                  color: Colors.transparent,
+                  child: Text(note.title),
+                ),
+              ),
               subtitle: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 mainAxisSize: MainAxisSize.min,
@@ -83,8 +89,21 @@ class NoteListForDayScreen extends StatelessWidget {
                 }
                 Navigator.push(
                   context,
-                  MaterialPageRoute(
-                    builder: (_) => NoteDetailScreen(note: note),
+                  PageRouteBuilder(
+                    pageBuilder: (_, __, ___) => NoteDetailScreen(note: note),
+                    transitionsBuilder: (_, animation, __, child) {
+                      final offsetAnimation = Tween<Offset>(
+                        begin: const Offset(1, 0),
+                        end: Offset.zero,
+                      ).animate(animation);
+                      return FadeTransition(
+                        opacity: animation,
+                        child: SlideTransition(
+                          position: offsetAnimation,
+                          child: child,
+                        ),
+                      );
+                    },
                   ),
                 );
               },

--- a/lib/screens/note_search_delegate.dart
+++ b/lib/screens/note_search_delegate.dart
@@ -45,7 +45,13 @@ class NoteSearchDelegate extends SearchDelegate {
     return ListView(
       children: filtered
           .map((n) => ListTile(
-                title: Text(n.title),
+                title: Hero(
+                  tag: n.id,
+                  child: Material(
+                    color: Colors.transparent,
+                    child: Text(n.title),
+                  ),
+                ),
                 subtitle: Text(n.content),
                 onTap: () async {
                   if (n.locked) {
@@ -55,8 +61,21 @@ class NoteSearchDelegate extends SearchDelegate {
                   }
                   Navigator.push(
                     context,
-                    MaterialPageRoute(
-                      builder: (_) => NoteDetailScreen(note: n),
+                    PageRouteBuilder(
+                      pageBuilder: (_, __, ___) => NoteDetailScreen(note: n),
+                      transitionsBuilder: (_, animation, __, child) {
+                        final offsetAnimation = Tween<Offset>(
+                          begin: const Offset(1, 0),
+                          end: Offset.zero,
+                        ).animate(animation);
+                        return FadeTransition(
+                          opacity: animation,
+                          child: SlideTransition(
+                            position: offsetAnimation,
+                            child: child,
+                          ),
+                        );
+                      },
                     ),
                   );
                 },

--- a/lib/widgets/notes_list.dart
+++ b/lib/widgets/notes_list.dart
@@ -105,7 +105,13 @@ class _NotesListState extends State<NotesList> {
         return Card(
           child: ListTile(
             leading: note.locked ? const Icon(Icons.lock) : null,
-            title: Text(note.title),
+            title: Hero(
+              tag: note.id,
+              child: Material(
+                color: Colors.transparent,
+                child: Text(note.title),
+              ),
+            ),
             subtitle: Text(
               note.alarmTime != null
                   ? '${note.content}\n⏰ ${DateFormat.yMd(Localizations.localeOf(context).toString()).add_Hm().format(note.alarmTime!)}'
@@ -120,7 +126,22 @@ class _NotesListState extends State<NotesList> {
               }
               Navigator.push(
                 context,
-                MaterialPageRoute(builder: (_) => NoteDetailScreen(note: note)),
+                PageRouteBuilder(
+                  pageBuilder: (_, __, ___) => NoteDetailScreen(note: note),
+                  transitionsBuilder: (_, animation, __, child) {
+                    final offsetAnimation = Tween<Offset>(
+                      begin: const Offset(1, 0),
+                      end: Offset.zero,
+                    ).animate(animation);
+                    return FadeTransition(
+                      opacity: animation,
+                      child: SlideTransition(
+                        position: offsetAnimation,
+                        child: child,
+                      ),
+                    );
+                  },
+                ),
               );
             },
             trailing: Row(


### PR DESCRIPTION
## Summary
- Wrap note titles in Hero widgets for seamless transitions
- Replace MaterialPageRoute with PageRouteBuilder and fade/slide animations
- Ensure NoteDetailScreen and related routes use matching Hero tags

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bc69bd2aa0833383e7b2cd89647e53