### PR TITLE
Add sync status and auto backup

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -94,5 +94,9 @@
   "authFailedMessage": "Anonymous sign-in failed. Limited functionality.",
   "notificationFailedMessage": "Notification setup failed.",
   "saveNoteFailed": "Failed to save note"
-
+,
+  "backupNow": "Backup now",
+  "syncStatusIdle": "Synced",
+  "syncStatusSyncing": "Syncing...",
+  "syncStatusError": "Sync error"
 }

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -94,5 +94,9 @@
   "authFailedMessage": "Đăng nhập ẩn danh thất bại. Chức năng bị hạn chế.",
   "notificationFailedMessage": "Thiết lập thông báo thất bại.",
   "saveNoteFailed": "Lưu ghi chú thất bại"
-
+,
+  "backupNow": "Sao lưu ngay",
+  "syncStatusIdle": "Đã đồng bộ",
+  "syncStatusSyncing": "Đang đồng bộ...",
+  "syncStatusError": "Lỗi đồng bộ"
 }

--- a/lib/providers/note_provider.dart
+++ b/lib/providers/note_provider.dart
@@ -16,6 +16,8 @@ import '../services/note_repository.dart';
 import '../services/calendar_service.dart';
 import '../services/notification_service.dart';
 
+enum SyncStatus { idle, syncing, error }
+
 int _noteComparator(Note a, Note b) => (b.updatedAt ?? DateTime.fromMillisecondsSinceEpoch(0)).compareTo(a.updatedAt ?? DateTime.fromMillisecondsSinceEpoch(0));
 
 class NoteProvider extends ChangeNotifier {
@@ -35,6 +37,8 @@ class NoteProvider extends ChangeNotifier {
   final SplayTreeSet<Note> _notes = SplayTreeSet<Note>(_noteComparator);
   String _draft = '';
   final Set<String> _unsyncedNoteIds = {};
+  final ValueNotifier<SyncStatus> syncStatus =
+      ValueNotifier<SyncStatus>(SyncStatus.idle);
 
   Set<String> get unsyncedNoteIds => Set.unmodifiable(_unsyncedNoteIds);
   bool isSynced(String id) => !_unsyncedNoteIds.contains(id);
@@ -79,6 +83,7 @@ class NoteProvider extends ChangeNotifier {
 
   Future<void> _syncUnsyncedNotes() async {
     if (_unsyncedNoteIds.isEmpty || Firebase.apps.isEmpty) return;
+    syncStatus.value = SyncStatus.syncing;
     try {
       final user = _auth.currentUser ?? await _auth.signInAnonymously();
       final ids = List<String>.from(_unsyncedNoteIds);
@@ -103,19 +108,23 @@ class NoteProvider extends ChangeNotifier {
       await batch.commit();
       await _saveUnsyncedNoteIds();
       notifyListeners();
+      syncStatus.value = SyncStatus.idle;
     } catch (e, st) {
       debugPrint('syncUnsyncedNotes error: $e\n$st');
+      syncStatus.value = SyncStatus.error;
     }
   }
 
   @override
   void dispose() {
     _connectivitySubscription?.cancel();
+    unawaited(_repository.autoBackup());
     super.dispose();
   }
 
 
   Future<bool> loadNotes() async {
+    syncStatus.value = SyncStatus.syncing;
     _notes..clear();
     _notes.addAll(await _repository.getNotes());
     await _loadUnsyncedNoteIds();
@@ -175,7 +184,12 @@ class NoteProvider extends ChangeNotifier {
     }
     await _saveUnsyncedNoteIds();
     notifyListeners();
+    syncStatus.value = success ? SyncStatus.idle : SyncStatus.error;
     return success;
+  }
+
+  Future<bool> backupNow() {
+    return _repository.autoBackup();
   }
 
   Future<List<Note>> fetchNotesPage(DateTime? startAfter, int limit) async {

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -74,6 +74,28 @@ class _HomeScreenState extends State<HomeScreen> {
       appBar: AppBar(
         title: Text(AppLocalizations.of(context)!.appTitle),
         actions: [
+          ValueListenableBuilder<SyncStatus>(
+            valueListenable: provider.syncStatus,
+            builder: (context, status, _) {
+              final l10n = AppLocalizations.of(context)!;
+              String text;
+              switch (status) {
+                case SyncStatus.syncing:
+                  text = l10n.syncStatusSyncing;
+                  break;
+                case SyncStatus.error:
+                  text = l10n.syncStatusError;
+                  break;
+                case SyncStatus.idle:
+                default:
+                  text = l10n.syncStatusIdle;
+              }
+              return Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 8),
+                child: Center(child: Text(text)),
+              );
+            },
+          ),
           TagFilterMenu(
             tags: tags,
             selectedTag: _selectedTag,
@@ -114,6 +136,26 @@ class _HomeScreenState extends State<HomeScreen> {
               );
               _loadMascot();
             },
+          ),
+          PopupMenuButton<String>(
+            onSelected: (value) async {
+              if (value == 'backup') {
+                final ok = await context.read<NoteProvider>().backupNow();
+                if (!mounted) return;
+                final l10n = AppLocalizations.of(context)!;
+                if (ok) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text(l10n.notesExported)),
+                  );
+                }
+              }
+            },
+            itemBuilder: (context) => [
+              PopupMenuItem(
+                value: 'backup',
+                child: Text(AppLocalizations.of(context)!.backupNow),
+              ),
+            ],
           ),
         ],
       ),

--- a/lib/services/backup_service.dart
+++ b/lib/services/backup_service.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:path_provider/path_provider.dart';
 
 import '../models/note.dart';
 import 'db_service.dart';
@@ -82,6 +83,23 @@ class BackupService {
     } catch (e) {
       debugPrint(l10n.errorWithMessage(e.toString()));
       return [];
+    }
+  }
+
+  Future<bool> autoBackup(List<Note> notes,
+      {String fileName = 'notes_autobackup.json'}) async {
+    try {
+      final dir = await getApplicationDocumentsDirectory();
+      final file = File('${dir.path}/$fileName');
+      final list = <Map<String, dynamic>>[];
+      for (final n in notes) {
+        list.add(await _dbService.encryptNote(n));
+      }
+      await file.writeAsString(jsonEncode(list));
+      return true;
+    } catch (e) {
+      debugPrint('autoBackup error: $e');
+      return false;
     }
   }
 }

--- a/lib/services/note_repository.dart
+++ b/lib/services/note_repository.dart
@@ -49,4 +49,9 @@ class NoteRepository {
     }
     return notes;
   }
+
+  Future<bool> autoBackup() async {
+    final notes = await _dbService.getNotes();
+    return _backupService.autoBackup(notes);
+  }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -837,7 +837,7 @@ packages:
     source: hosted
     version: "1.9.1"
   path_provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_provider
       sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,8 @@ dependencies:
   flutter_secure_storage: ^9.0.0
   file_picker: ^6.1.1
 
+  path_provider: ^2.1.5
+
   json_annotation: ^4.8.1
 
   firebase_core: ^4.1.0


### PR DESCRIPTION
## Summary
- track sync state in `NoteProvider` with a new `SyncStatus` notifier and expose `backupNow`
- show sync status in HomeScreen AppBar and add a "Backup now" menu
- implement automatic backups via `BackupService.autoBackup` and call it when provider disposes

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc69c181808333b1660d2dc8116294