### PR TITLE
Add note color and pin features

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -68,6 +68,8 @@
   "addTag": "Add tag",
   "requireAuth": "Require authentication",
   "lockNote": "Lock note",
+  "pinNote": "Pin note",
+  "colorLabel": "Color",
   "authReason": "Please authenticate to continue",
   "voiceToNote": "Voice To Note",
   "stop": "Stop",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -68,6 +68,8 @@
   "addTag": "Thêm tag",
   "requireAuth": "Yêu cầu xác thực",
   "lockNote": "Khóa ghi chú",
+  "pinNote": "Ghim ghi chú",
+  "colorLabel": "Màu",
   "authReason": "Vui lòng xác thực để tiếp tục",
   "voiceToNote": "Giọng nói thành ghi chú",
   "stop": "Dừng",

--- a/lib/l10n/localization_extensions.dart
+++ b/lib/l10n/localization_extensions.dart
@@ -1,0 +1,6 @@
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+extension AppLocalizationsExtras on AppLocalizations {
+  String get pinNote => localeName == 'vi' ? 'Ghim ghi chú' : 'Pin note';
+  String get colorLabel => localeName == 'vi' ? 'Màu' : 'Color';
+}

--- a/lib/models/note.dart
+++ b/lib/models/note.dart
@@ -49,6 +49,14 @@ class Note {
   @JsonKey(defaultValue: [])
   final List<String> attachments;
 
+  /// Display color associated with the note.
+  @JsonKey(defaultValue: 0xFFFFFFFF)
+  final int color;
+
+  /// Whether the note is pinned to the top of lists.
+  @JsonKey(defaultValue: false)
+  final bool pinned;
+
   /// Indicates if the note is locked and requires authentication.
   @JsonKey(defaultValue: false)
   final bool locked;
@@ -80,6 +88,8 @@ class Note {
     this.active = false,
     this.tags = const [],
     this.attachments = const [],
+    this.color = 0xFFFFFFFF,
+    this.pinned = false,
     this.locked = false,
     this.snoozeMinutes = 0,
     this.updatedAt,
@@ -98,6 +108,8 @@ class Note {
     bool? active,
     List<String>? tags,
     List<String>? attachments,
+    int? color,
+    bool? pinned,
     String? summary,
     List<String>? actionItems,
     List<DateTime>? dates,
@@ -122,6 +134,8 @@ class Note {
       active: active ?? this.active,
       tags: tags ?? this.tags,
       attachments: attachments ?? this.attachments,
+      color: color ?? this.color,
+      pinned: pinned ?? this.pinned,
       locked: locked ?? this.locked,
       snoozeMinutes: snoozeMinutes ?? this.snoozeMinutes,
       updatedAt: updatedAt ?? this.updatedAt,

--- a/lib/models/note.g.dart
+++ b/lib/models/note.g.dart
@@ -7,60 +7,68 @@ part of 'note.dart';
 // **************************************************************************
 
 Note _$NoteFromJson(Map<String, dynamic> json) => Note(
-      id: json['id'] as String,
-      title: json['title'] as String,
-      content: json['content'] as String,
-      summary: json['summary'] as String? ?? '',
-      actionItems: (json['actionItems'] as List<dynamic>?)
-              ?.map((e) => e as String)
-              .toList() ??
-          [],
-      dates: (json['dates'] as List<dynamic>?)
-              ?.map((e) => DateTime.parse(e as String))
-              .toList() ??
-          [],
-      alarmTime: json['alarmTime'] == null
-          ? null
-          : DateTime.parse(json['alarmTime'] as String),
-      repeatInterval:
-          $enumDecodeNullable(_$RepeatIntervalEnumMap, json['repeatInterval']),
-      daily: json['daily'] as bool? ?? false,
-      active: json['active'] as bool? ?? false,
-      tags:
-          (json['tags'] as List<dynamic>?)?.map((e) => e as String).toList() ??
-              [],
-      attachments: (json['attachments'] as List<dynamic>?)
-              ?.map((e) => e as String)
-              .toList() ??
-          [],
-      locked: json['locked'] as bool? ?? false,
-      snoozeMinutes: (json['snoozeMinutes'] as num?)?.toInt() ?? 0,
-      updatedAt: json['updatedAt'] == null
-          ? null
-          : DateTime.parse(json['updatedAt'] as String),
-      notificationId: (json['notificationId'] as num?)?.toInt(),
-      eventId: json['eventId'] as String?,
-    );
+  id: json['id'] as String,
+  title: json['title'] as String,
+  content: json['content'] as String,
+  summary: json['summary'] as String? ?? '',
+  actionItems:
+      (json['actionItems'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList() ??
+      [],
+  dates:
+      (json['dates'] as List<dynamic>?)
+          ?.map((e) => DateTime.parse(e as String))
+          .toList() ??
+      [],
+  alarmTime: json['alarmTime'] == null
+      ? null
+      : DateTime.parse(json['alarmTime'] as String),
+  repeatInterval: $enumDecodeNullable(
+    _$RepeatIntervalEnumMap,
+    json['repeatInterval'],
+  ),
+  daily: json['daily'] as bool? ?? false,
+  active: json['active'] as bool? ?? false,
+  tags:
+      (json['tags'] as List<dynamic>?)?.map((e) => e as String).toList() ?? [],
+  attachments:
+      (json['attachments'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList() ??
+      [],
+  color: (json['color'] as num?)?.toInt() ?? 4294967295,
+  pinned: json['pinned'] as bool? ?? false,
+  locked: json['locked'] as bool? ?? false,
+  snoozeMinutes: (json['snoozeMinutes'] as num?)?.toInt() ?? 0,
+  updatedAt: json['updatedAt'] == null
+      ? null
+      : DateTime.parse(json['updatedAt'] as String),
+  notificationId: (json['notificationId'] as num?)?.toInt(),
+  eventId: json['eventId'] as String?,
+);
 
 Map<String, dynamic> _$NoteToJson(Note instance) => <String, dynamic>{
-      'id': instance.id,
-      'title': instance.title,
-      'content': instance.content,
-      'summary': instance.summary,
-      'actionItems': instance.actionItems,
-      'dates': instance.dates.map((e) => e.toIso8601String()).toList(),
-      'alarmTime': instance.alarmTime?.toIso8601String(),
-      'repeatInterval': _$RepeatIntervalEnumMap[instance.repeatInterval],
-      'daily': instance.daily,
-      'active': instance.active,
-      'tags': instance.tags,
-      'attachments': instance.attachments,
-      'locked': instance.locked,
-      'snoozeMinutes': instance.snoozeMinutes,
-      'updatedAt': instance.updatedAt?.toIso8601String(),
-      'notificationId': instance.notificationId,
-      'eventId': instance.eventId,
-    };
+  'id': instance.id,
+  'title': instance.title,
+  'content': instance.content,
+  'summary': instance.summary,
+  'actionItems': instance.actionItems,
+  'dates': instance.dates.map((e) => e.toIso8601String()).toList(),
+  'alarmTime': instance.alarmTime?.toIso8601String(),
+  'repeatInterval': _$RepeatIntervalEnumMap[instance.repeatInterval],
+  'daily': instance.daily,
+  'active': instance.active,
+  'tags': instance.tags,
+  'attachments': instance.attachments,
+  'color': instance.color,
+  'pinned': instance.pinned,
+  'locked': instance.locked,
+  'snoozeMinutes': instance.snoozeMinutes,
+  'updatedAt': instance.updatedAt?.toIso8601String(),
+  'notificationId': instance.notificationId,
+  'eventId': instance.eventId,
+};
 
 const _$RepeatIntervalEnumMap = {
   RepeatInterval.everyMinute: 'everyMinute',

--- a/lib/providers/note_provider.dart
+++ b/lib/providers/note_provider.dart
@@ -16,7 +16,13 @@ import '../services/note_repository.dart';
 import '../services/calendar_service.dart';
 import '../services/notification_service.dart';
 
-int _noteComparator(Note a, Note b) => (b.updatedAt ?? DateTime.fromMillisecondsSinceEpoch(0)).compareTo(a.updatedAt ?? DateTime.fromMillisecondsSinceEpoch(0));
+int _noteComparator(Note a, Note b) {
+  if (a.pinned != b.pinned) {
+    return a.pinned ? -1 : 1;
+  }
+  return (b.updatedAt ?? DateTime.fromMillisecondsSinceEpoch(0))
+      .compareTo(a.updatedAt ?? DateTime.fromMillisecondsSinceEpoch(0));
+}
 
 class NoteProvider extends ChangeNotifier {
   final NoteRepository _repository;
@@ -245,6 +251,8 @@ class NoteProvider extends ChangeNotifier {
     RepeatInterval? repeatInterval,
     bool daily = false,
     int snoozeMinutes = 0,
+    int color = 0xFFFFFFFF,
+    bool pinned = false,
     required AppLocalizations l10n,
   }) async {
     try {
@@ -292,6 +300,8 @@ class NoteProvider extends ChangeNotifier {
         content: content,
         tags: tags,
         locked: locked,
+        color: color,
+        pinned: pinned,
         alarmTime: alarmTime,
         repeatInterval: repeatInterval,
         daily: daily,

--- a/lib/screens/note_detail_screen.dart
+++ b/lib/screens/note_detail_screen.dart
@@ -8,6 +8,7 @@ import '../models/note.dart';
 import '../providers/note_provider.dart';
 import '../services/tts_service.dart';
 import '../widgets/tag_selector.dart';
+import '../l10n/localization_extensions.dart';
 import '../services/gemini_service.dart';
 import '../widgets/attachment_section.dart';
 import '../widgets/reminder_controls.dart';
@@ -35,6 +36,8 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
   RepeatInterval? _repeat;
   int _snoozeMinutes = 5;
   late List<String> _tags;
+  int _color = 0xFFFFFFFF;
+  bool _pinned = false;
   late final TTSService _ttsService;
 
   @override
@@ -49,6 +52,8 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
     _snoozeMinutes = widget.note.snoozeMinutes;
     _attachments = List.from(widget.note.attachments);
     _tags = List.from(widget.note.tags);
+    _color = widget.note.color;
+    _pinned = widget.note.pinned;
   }
 
   @override
@@ -120,6 +125,14 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
               allowCreate: true,
               onChanged: (v) => setState(() => _tags = v),
               label: AppLocalizations.of(context)!.tagsLabel,
+              selectedColor: _color,
+              onColorChanged: (c) => setState(() => _color = c),
+              colorLabel: AppLocalizations.of(context)!.colorLabel,
+            ),
+            SwitchListTile(
+              title: Text(AppLocalizations.of(context)!.pinNote),
+              value: _pinned,
+              onChanged: (v) => setState(() => _pinned = v),
             ),
             const SizedBox(height: 12),
             AttachmentSection(
@@ -164,9 +177,9 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
       if (result != null) {
         summary = result.summary;
         actionItems = result.actionItems;
-        tags = result.tags;
-        dates = result.dates;
-      }
+      tags = result.tags;
+      dates = result.dates;
+    }
     }
 
     final updated = widget.note.copyWith(
@@ -183,6 +196,8 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
       summary: summary,
       actionItems: actionItems,
       dates: dates,
+      color: _color,
+      pinned: _pinned,
     );
 
     final ok = await context.read<NoteProvider>().saveNote(updated, l10n);

--- a/lib/widgets/add_note_dialog.dart
+++ b/lib/widgets/add_note_dialog.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 
 import '../providers/note_provider.dart';
 import 'tag_selector.dart';
+import '../l10n/localization_extensions.dart';
 
 class AddNoteDialog extends StatefulWidget {
   const AddNoteDialog({super.key});
@@ -20,6 +21,8 @@ class _AddNoteDialogState extends State<AddNoteDialog> {
   DateTime? _alarmTime;
   bool _locked = false;
   List<String> _tags = [];
+  int _color = 0xFFFFFFFF;
+  bool _pinned = false;
   bool _isValid = false;
 
   @override
@@ -108,11 +111,19 @@ class _AddNoteDialogState extends State<AddNoteDialog> {
                 allowCreate: true,
                 label: l10n.tagsLabel,
                 onChanged: (v) => setState(() => _tags = v),
+                selectedColor: _color,
+                onColorChanged: (c) => setState(() => _color = c),
+                colorLabel: l10n.colorLabel,
               ),
               SwitchListTile(
                 title: Text(l10n.lockNote),
                 value: _locked,
                 onChanged: (value) => setState(() => _locked = value),
+              ),
+              SwitchListTile(
+                title: Text(l10n.pinNote),
+                value: _pinned,
+                onChanged: (v) => setState(() => _pinned = v),
               ),
               const SizedBox(height: 12),
               ElevatedButton(
@@ -145,6 +156,8 @@ class _AddNoteDialogState extends State<AddNoteDialog> {
                     content: _contentCtrl.text,
                     tags: _tags,
                     locked: _locked,
+                    color: _color,
+                    pinned: _pinned,
                     alarmTime: _alarmTime,
                     l10n: l10n,
                   );

--- a/lib/widgets/notes_list.dart
+++ b/lib/widgets/notes_list.dart
@@ -104,7 +104,17 @@ class _NotesListState extends State<NotesList> {
         final note = notes[index];
         return Card(
           child: ListTile(
-            leading: note.locked ? const Icon(Icons.lock) : null,
+            leading: Container(
+              width: 24,
+              height: 24,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: Color(note.color),
+              ),
+              child: note.locked
+                  ? const Icon(Icons.lock, size: 16, color: Colors.white)
+                  : null,
+            ),
             title: Text(note.title),
             subtitle: Text(
               note.alarmTime != null
@@ -126,6 +136,8 @@ class _NotesListState extends State<NotesList> {
             trailing: Row(
               mainAxisSize: MainAxisSize.min,
               children: [
+                if (note.pinned)
+                  const Icon(Icons.push_pin, size: 20),
                 if (!provider.isSynced(note.id))
                   const Icon(Icons.sync_problem, color: Colors.orange),
                 IconButton(

--- a/lib/widgets/tag_selector.dart
+++ b/lib/widgets/tag_selector.dart
@@ -7,6 +7,9 @@ class TagSelector extends StatefulWidget {
   final ValueChanged<List<String>> onChanged;
   final bool allowCreate;
   final String? label;
+  final int selectedColor;
+  final ValueChanged<int> onColorChanged;
+  final String? colorLabel;
 
   const TagSelector({
     super.key,
@@ -15,6 +18,9 @@ class TagSelector extends StatefulWidget {
     required this.onChanged,
     this.allowCreate = false,
     this.label,
+    required this.selectedColor,
+    required this.onColorChanged,
+    this.colorLabel,
   });
 
   @override
@@ -57,6 +63,30 @@ class _TagSelectorState extends State<TagSelector> {
       );
     }).toList();
 
+    final colorOptions = <Color>[
+      Colors.white,
+      Colors.red,
+      Colors.orange,
+      Colors.yellow,
+      Colors.green,
+      Colors.blue,
+      Colors.purple,
+      Colors.brown,
+    ];
+    final colorChips = colorOptions.map((c) {
+      final selected = widget.selectedColor == c.value;
+      return Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 4),
+        child: ChoiceChip(
+          label: const SizedBox(width: 24, height: 24),
+          selectedColor: c,
+          backgroundColor: c,
+          selected: selected,
+          onSelected: (_) => widget.onColorChanged(c.value),
+        ),
+      );
+    }).toList();
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -70,6 +100,11 @@ class _TagSelectorState extends State<TagSelector> {
             ),
             onSubmitted: _addTag,
           ),
+        if (widget.colorLabel != null) ...[
+          const SizedBox(height: 8),
+          Text(widget.colorLabel!),
+        ],
+        Wrap(children: colorChips),
       ],
     );
   }


### PR DESCRIPTION
## Summary
- allow notes to store a color and pin state
- let users select note color and toggle pin in dialogs
- show pinned notes first and display color indicators in note list

## Testing
- `flutter gen-l10n` *(fails: Invalid ARB resource name "geminiError@placeholders")*
- `flutter test` *(fails: Error: Couldn't resolve the package 'flutter_gen' in 'package:flutter_gen/gen_l10n/app_localizations.dart')*


------
https://chatgpt.com/codex/tasks/task_e_68bc69c2548883339423766d7901032f