### PR TITLE
Add notification action callbacks and payload support

### DIFF
--- a/integration_test/sync_and_notification_test.dart
+++ b/integration_test/sync_and_notification_test.dart
@@ -142,6 +142,7 @@ void main() {
       body: 'b',
       scheduledDate: date,
       l10n: l10n,
+      payload: 'p',
     );
 
     await service.snoozeNotification(
@@ -150,6 +151,7 @@ void main() {
       body: 'b',
       minutes: 5,
       l10n: l10n,
+      payload: 'p',
     );
 
     expect(calls.any((c) => c.method == 'zonedSchedule'), isTrue);

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -83,6 +83,7 @@
   "recurring": "Recurring",
   "daily": "Daily",
   "snooze": "Snooze",
+  "done": "Done",
   "scheduledDesc": "Scheduled notifications",
   "recurringDesc": "Recurring notifications",
   "dailyDesc": "Daily notifications",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -83,6 +83,7 @@
   "recurring": "Định kỳ",
   "daily": "Hàng ngày",
   "snooze": "Báo lại",
+  "done": "Xong",
   "scheduledDesc": "Thông báo đã lên lịch",
   "recurringDesc": "Thông báo định kỳ",
   "dailyDesc": "Thông báo hàng ngày",

--- a/lib/providers/note_provider.dart
+++ b/lib/providers/note_provider.dart
@@ -277,6 +277,7 @@ class NoteProvider extends ChangeNotifier {
             body: content,
             scheduledDate: alarmTime,
             l10n: l10n,
+            payload: id,
           );
         }
         eventId = await _calendarService.createEvent(
@@ -401,6 +402,7 @@ class NoteProvider extends ChangeNotifier {
             body: note.content,
             scheduledDate: note.alarmTime!,
             l10n: l10n,
+            payload: note.id,
           );
         }
         updated = updated.copyWith(notificationId: nid, active: true);
@@ -444,6 +446,7 @@ class NoteProvider extends ChangeNotifier {
       body: note.content,
       minutes: note.snoozeMinutes,
       l10n: l10n,
+      payload: note.id,
     );
   }
 

--- a/test/note_provider_test.dart
+++ b/test/note_provider_test.dart
@@ -68,6 +68,7 @@ void main() {
         body: any(named: 'body'),
         scheduledDate: any(named: 'scheduledDate'),
         l10n: l10n,
+        payload: any(named: 'payload'),
       ),
     ).thenAnswer((_) async {});
     when(
@@ -104,6 +105,7 @@ void main() {
         body: 'c',
         scheduledDate: any(named: 'scheduledDate'),
         l10n: l10n,
+        payload: captureAny(named: 'payload'),
       ),
     ).captured;
     expect(captured.first, isA<int>());
@@ -202,6 +204,7 @@ void main() {
           body: any(named: 'body'),
           minutes: any(named: 'minutes'),
           l10n: l10n,
+          payload: any(named: 'payload'),
         )).thenAnswer((_) async {});
 
     final provider = NoteProvider(
@@ -220,6 +223,7 @@ void main() {
           body: 'c',
           minutes: 5,
           l10n: l10n,
+          payload: note.id,
         )).called(1);
   });
 }

--- a/test/notification_service_test.dart
+++ b/test/notification_service_test.dart
@@ -49,6 +49,7 @@ void main() {
       body: 'b',
       scheduledDate: DateTime.now().add(const Duration(minutes: 1)),
       l10n: l10n,
+      payload: 'p',
     );
     final call = log.singleWhere((c) => c.method == 'zonedSchedule');
     final args = call.arguments as Map<dynamic, dynamic>;
@@ -65,6 +66,7 @@ void main() {
         body: 'b',
         scheduledDate: DateTime.now().subtract(const Duration(minutes: 1)),
         l10n: l10n,
+        payload: 'p',
       ),
       throwsArgumentError,
     );
@@ -87,6 +89,7 @@ void main() {
       body: 'b',
       scheduledDate: DateTime.now().add(const Duration(minutes: 1)),
       l10n: l10n,
+      payload: 'p',
     );
     final call = log.singleWhere((c) => c.method == 'zonedSchedule');
     final args = call.arguments as Map<dynamic, dynamic>;
@@ -204,6 +207,7 @@ void main() {
       body: 'b',
       minutes: 5,
       l10n: l10n,
+      payload: 'p',
     );
     expect(log.first.method, 'cancel');
     final scheduleCall =
@@ -231,6 +235,7 @@ void main() {
         body: 'b',
         minutes: 5,
         l10n: l10n,
+        payload: 'p',
       ),
       throwsA(isA<PlatformException>()),
     );


### PR DESCRIPTION
## Summary
- add done and snooze actions to Android notifications with payload data
- handle notification callbacks in main to complete or snooze notes
- pass note id payload when scheduling or snoozing notifications

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc69c561688333a72edfed98a0be5e