### PR TITLE
feat: add firebase crashlytics and analytics

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("kotlin-android")
     id("dev.flutter.flutter-gradle-plugin")
     id("com.google.gms.google-services")
+    id("com.google.firebase.crashlytics")
 }
 
 android {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -32,6 +32,13 @@
             android:name="flutterEmbedding"
             android:value="2" />
 
+        <meta-data
+            android:name="firebase_crashlytics_collection_enabled"
+            android:value="true" />
+        <meta-data
+            android:name="firebase_analytics_collection_enabled"
+            android:value="true" />
+
         <receiver android:name=".WidgetProvider">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -22,6 +22,7 @@ plugins {
     id("com.android.application") version "8.1.1" apply false
     id("org.jetbrains.kotlin.android") version "1.9.23" apply false
     id("com.google.gms.google-services") version "4.4.2" apply false
+    id("com.google.firebase.crashlytics") version "2.9.9" apply false
 }
 
 dependencyResolutionManagement {

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -53,5 +53,9 @@
         <string>This app requires photo library access to attach images to notes.</string>
         <key>NSUserTrackingUsageDescription</key>
         <string>This identifier will be used to deliver personalized content.</string>
+        <key>FirebaseCrashlyticsCollectionEnabled</key>
+        <true/>
+        <key>FirebaseAnalyticsCollectionEnabled</key>
+        <true/>
 </dict>
 </plist>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -28,6 +30,8 @@ void main() async {
       options: DefaultFirebaseOptions.currentPlatform,
     );
     await FirebaseAuth.instance.signInAnonymously();
+    await FirebaseCrashlytics.instance.setCrashlyticsCollectionEnabled(true);
+    await FirebaseAnalytics.instance.logAppOpen();
   } catch (e) {
     authFailed = true;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,9 @@ dependencies:
   cloud_firestore: ^6.0.1
   firebase_auth: ^6.0.2
 
+  firebase_crashlytics: ^5.0.1
+  firebase_analytics: ^12.0.1
+
   google_sign_in: ^6.2.1
 
 


### PR DESCRIPTION
## Summary
- add firebase_crashlytics and firebase_analytics packages
- initialize Crashlytics and log analytics events
- configure Android/iOS for Crashlytics and analytics

## Testing
- ⚠️ `flutter analyze` (flutter: command not found)
- ⚠️ `flutter test` (flutter: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68bc69ca19848333910e233c12ec2e02