### PR TITLE
Add voice note intents for Android and iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,18 @@ Add to `ios/Runner/Info.plist`:
 * `NSMicrophoneUsageDescription` and `NSSpeechRecognitionUsageDescription` for voice input.
 * Notification permissions for alerts, badges, and sounds are requested at runtime.
 
+## Voice Commands
+
+### Android
+
+1. Open **Settings > Apps > Default apps > Assist app** and choose *Notes Reminder App*.
+2. Long-press the home button or use the assist gesture and speak to create a note.
+
+### iOS
+
+1. Open the Shortcuts app and add the **Create Note** shortcut from Notes Reminder App.
+2. Say “Hey Siri, create note” to launch the app and dictate your note.
+
 ## Build & Run
 
 ```bash

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -25,6 +25,10 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.ASSIST"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+            </intent-filter>
         </activity>
 
         <!-- Bắt buộc cho Flutter embedding v2 -->

--- a/android/app/src/main/kotlin/com/example/notes_reminder_app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/notes_reminder_app/MainActivity.kt
@@ -46,9 +46,16 @@ class MainActivity : FlutterActivity() {
     }
 
     private fun handleIntent(intent: Intent?) {
-        val action = intent?.getStringExtra("action")
-        if (action != null) {
-            methodChannel?.invokeMethod(action, null)
+        when {
+            intent?.action == Intent.ACTION_ASSIST -> {
+                methodChannel?.invokeMethod("voiceToNote", null)
+            }
+            else -> {
+                val action = intent?.getStringExtra("action")
+                if (action != null) {
+                    methodChannel?.invokeMethod(action, null)
+                }
+            }
         }
     }
 }

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,5 +1,6 @@
 import Flutter
 import UIKit
+import Intents
 
 @main
 @objc class AppDelegate: FlutterAppDelegate {
@@ -8,6 +9,27 @@ import UIKit
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
     GeneratedPluginRegistrant.register(with: self)
+    donateCreateNoteIntent()
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  private func donateCreateNoteIntent() {
+    let activity = NSUserActivity(activityType: "CreateNoteIntent")
+    activity.title = "Create Note"
+    activity.isEligibleForPrediction = true
+    activity.persistentIdentifier = NSUserActivityPersistentIdentifier("CreateNoteIntent")
+    activity.suggestedInvocationPhrase = "Create note"
+    activity.becomeCurrent()
+  }
+
+  override func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
+    if userActivity.activityType == "CreateNoteIntent" {
+      if let controller = window?.rootViewController as? FlutterViewController {
+        let channel = FlutterMethodChannel(name: "notes_reminder_app/actions", binaryMessenger: controller.binaryMessenger)
+        channel.invokeMethod("voiceToNote", arguments: nil)
+      }
+      return true
+    }
+    return super.application(application, continue: userActivity, restorationHandler: restorationHandler)
   }
 }

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -53,5 +53,11 @@
         <string>This app requires photo library access to attach images to notes.</string>
         <key>NSUserTrackingUsageDescription</key>
         <string>This identifier will be used to deliver personalized content.</string>
+        <key>NSSiriUsageDescription</key>
+        <string>This app uses Siri to create voice notes.</string>
+        <key>IntentsSupported</key>
+        <array>
+                <string>CreateNoteIntent</string>
+        </array>
 </dict>
 </plist>

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:intl/intl.dart';
 import 'package:lottie/lottie.dart';
 import 'package:provider/provider.dart';
+import 'package:flutter/services.dart';
 import '../models/note.dart';
 import '../providers/note_provider.dart';
 import '../services/settings_service.dart';
@@ -32,11 +33,21 @@ class _HomeScreenState extends State<HomeScreen> {
   String _mascotPath = 'assets/lottie/mascot.json';
   final DateTime _today = DateTime.now();
   String? _selectedTag;
+  static const _platform = MethodChannel('notes_reminder_app/actions');
 
   @override
   void initState() {
     super.initState();
     _loadMascot();
+    _platform.setMethodCallHandler((call) async {
+      if (call.method == 'voiceToNote') {
+        await Navigator.push(
+          context,
+          MaterialPageRoute(
+              builder: (_) => const VoiceToNoteScreen(autoStart: true)),
+        );
+      }
+    });
   }
 
   Future<void> _loadMascot() async {

--- a/lib/screens/voice_to_note_screen.dart
+++ b/lib/screens/voice_to_note_screen.dart
@@ -8,10 +8,12 @@ import '../services/gemini_service.dart';
 
 class VoiceToNoteScreen extends StatefulWidget {
   final stt.SpeechToText speech;
+  final bool autoStart;
 
   const VoiceToNoteScreen({
     super.key,
     stt.SpeechToText? speech,
+    this.autoStart = false,
   }) : speech = speech ?? stt.SpeechToText();
 
   @override
@@ -22,6 +24,16 @@ class _VoiceToNoteScreenState extends State<VoiceToNoteScreen> {
   String _recognized = '';
   bool _isListening = false;
   bool _isProcessing = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.autoStart) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _toggleListening();
+      });
+    }
+  }
 
   Future<void> _toggleListening() async {
     if (!_isListening) {


### PR DESCRIPTION
## Summary
- Handle Android `ACTION_ASSIST` intents and bridge to Flutter to start voice note creation.
- Donate a Siri Shortcut for "Create Note" and invoke Flutter when the intent runs.
- Document how to enable voice commands on Android and iOS.

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc69cb1b2483338ada8b1e0d217e31