### PR TITLE
fix: remove duplicate pinned field in Note model

### DIFF
--- a/lib/models/note.dart
+++ b/lib/models/note.dart
@@ -65,10 +65,6 @@ class Note {
   @JsonKey(defaultValue: 0)
   final int snoozeMinutes;
 
-  /// Whether this note is pinned to the top of the list.
-  @JsonKey(defaultValue: false)
-  final bool pinned;
-
   /// Whether this note has been marked as completed.
   @JsonKey(defaultValue: false)
   final bool done;
@@ -100,7 +96,6 @@ class Note {
     this.pinned = false,
     this.locked = false,
     this.snoozeMinutes = 0,
-    this.pinned = false,
     this.done = false,
     this.updatedAt,
     this.notificationId,
@@ -125,7 +120,6 @@ class Note {
     List<DateTime>? dates,
     bool? locked,
     int? snoozeMinutes,
-    bool? pinned,
     bool? done,
     DateTime? updatedAt,
     Object? notificationId = _notificationIdSentinel,
@@ -150,7 +144,6 @@ class Note {
       pinned: pinned ?? this.pinned,
       locked: locked ?? this.locked,
       snoozeMinutes: snoozeMinutes ?? this.snoozeMinutes,
-      pinned: pinned ?? this.pinned,
       done: done ?? this.done,
       updatedAt: updatedAt ?? this.updatedAt,
       notificationId: notificationId == _notificationIdSentinel


### PR DESCRIPTION
## Summary
- remove duplicate `pinned` field and parameter from `Note`
- update constructor and `copyWith` to use single `pinned` field

## Testing
- `dart run build_runner build --delete-conflicting-outputs` *(fails: command not found: dart)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7a98beac8333908cdf4edbfb07c4