### PR TITLE
refactor: extract note tab widgets

### DIFF
--- a/lib/widgets/notes_tab.dart
+++ b/lib/widgets/notes_tab.dart
@@ -1,0 +1,185 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:lottie/lottie.dart';
+import 'package:provider/provider.dart';
+import 'package:flutter/services.dart';
+
+import '../providers/note_provider.dart';
+import '../services/settings_service.dart';
+import '../screens/note_search_delegate.dart';
+import '../screens/voice_to_note_screen.dart';
+import '../screens/settings_screen.dart';
+import 'add_note_dialog.dart';
+import 'tag_filtered_notes_list.dart';
+
+class NotesTab extends StatefulWidget {
+  final Function(Color) onThemeChanged;
+  final Function(double) onFontScaleChanged;
+
+  const NotesTab({
+    super.key,
+    required this.onThemeChanged,
+    required this.onFontScaleChanged,
+  });
+
+  @override
+  State<NotesTab> createState() => _NotesTabState();
+}
+
+class _NotesTabState extends State<NotesTab> {
+  String _mascotPath = 'assets/lottie/mascot.json';
+  static const _platform = MethodChannel('notes_reminder_app/actions');
+
+  @override
+  void initState() {
+    super.initState();
+    _loadMascot();
+    _platform.setMethodCallHandler((call) async {
+      if (call.method == 'voiceToNote') {
+        await Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => const VoiceToNoteScreen(autoStart: true),
+          ),
+        );
+      }
+    });
+  }
+
+  Future<void> _loadMascot() async {
+    _mascotPath = await SettingsService().loadMascotPath();
+    if (mounted) setState(() {});
+  }
+
+  void _addNote() {
+    showDialog(context: context, builder: (_) => const AddNoteDialog());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = context.watch<NoteProvider>();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(AppLocalizations.of(context)!.appTitle),
+        actions: [
+          ValueListenableBuilder<SyncStatus>(
+            valueListenable: provider.syncStatus,
+            builder: (context, status, _) {
+              final l10n = AppLocalizations.of(context)!;
+              String text;
+              switch (status) {
+                case SyncStatus.syncing:
+                  text = l10n.syncStatusSyncing;
+                  break;
+                case SyncStatus.error:
+                  text = l10n.syncStatusError;
+                  break;
+                case SyncStatus.idle:
+                default:
+                  text = l10n.syncStatusIdle;
+              }
+              return Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 8),
+                child: Center(child: Text(text)),
+              );
+            },
+          ),
+          IconButton(
+            icon: const Icon(Icons.search),
+            onPressed: () => showSearch(
+              context: context,
+              delegate: NoteSearchDelegate(context.read<NoteProvider>().notes),
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.mic),
+            onPressed: () async {
+              await Navigator.push(
+                context,
+                PageRouteBuilder(
+                  pageBuilder: (_, __, ___) => const VoiceToNoteScreen(),
+                  transitionsBuilder: (_, animation, __, child) {
+                    final offsetAnimation = Tween<Offset>(
+                      begin: const Offset(1, 0),
+                      end: Offset.zero,
+                    ).animate(animation);
+                    return FadeTransition(
+                      opacity: animation,
+                      child: SlideTransition(
+                        position: offsetAnimation,
+                        child: child,
+                      ),
+                    );
+                  },
+                ),
+              );
+            },
+          ),
+          IconButton(
+            icon: const Icon(Icons.settings),
+            tooltip: AppLocalizations.of(context)!.settingsTooltip,
+            onPressed: () async {
+              await Navigator.push(
+                context,
+                PageRouteBuilder(
+                  pageBuilder: (_, __, ___) => SettingsScreen(
+                    onThemeChanged: widget.onThemeChanged,
+                    onFontScaleChanged: widget.onFontScaleChanged,
+                  ),
+                  transitionsBuilder: (_, animation, __, child) {
+                    final offsetAnimation = Tween<Offset>(
+                      begin: const Offset(1, 0),
+                      end: Offset.zero,
+                    ).animate(animation);
+                    return FadeTransition(
+                      opacity: animation,
+                      child: SlideTransition(
+                        position: offsetAnimation,
+                        child: child,
+                      ),
+                    );
+                  },
+                ),
+              );
+              _loadMascot();
+            },
+          ),
+          PopupMenuButton<String>(
+            onSelected: (value) async {
+              if (value == 'backup') {
+                final ok = await context.read<NoteProvider>().backupNow();
+                if (!mounted) return;
+                final l10n = AppLocalizations.of(context)!;
+                if (ok) {
+                  ScaffoldMessenger.of(
+                    context,
+                  ).showSnackBar(SnackBar(content: Text(l10n.notesExported)));
+                }
+              }
+            },
+            itemBuilder: (context) => [
+              PopupMenuItem(
+                value: 'backup',
+                child: Text(AppLocalizations.of(context)!.backupNow),
+              ),
+            ],
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          const SizedBox(height: 8),
+          SizedBox(width: 140, height: 140, child: Lottie.asset(_mascotPath)),
+          const SizedBox(height: 8),
+          const Expanded(child: TagFilteredNotesList()),
+        ],
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _addNote,
+        tooltip: AppLocalizations.of(context)!.addNoteTooltip,
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/lib/widgets/tag_filtered_notes_list.dart
+++ b/lib/widgets/tag_filtered_notes_list.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+
+import '../models/note.dart';
+import '../providers/note_provider.dart';
+import '../screens/note_list_for_day_screen.dart';
+import 'notes_list.dart';
+import 'tag_filter_menu.dart';
+
+class TagFilteredNotesList extends StatefulWidget {
+  const TagFilteredNotesList({super.key});
+
+  @override
+  State<TagFilteredNotesList> createState() => _TagFilteredNotesListState();
+}
+
+class _TagFilteredNotesListState extends State<TagFilteredNotesList> {
+  String? _selectedTag;
+  final DateTime _today = DateTime.now();
+
+  List<Note> _notesForDay(DateTime day, List<Note> notes) {
+    return notes
+        .where(
+          (n) =>
+              n.alarmTime != null &&
+              n.alarmTime!.year == day.year &&
+              n.alarmTime!.month == day.month &&
+              n.alarmTime!.day == day.day,
+        )
+        .toList();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = context.watch<NoteProvider>();
+    final notes = provider.notes;
+    final tags = notes.expand((n) => n.tags).toSet().toList();
+    final filteredNotes = _selectedTag == null
+        ? notes
+        : notes.where((n) => n.tags.contains(_selectedTag!)).toList();
+    final weekDays = List.generate(7, (i) => _today.add(Duration(days: i)));
+
+    return Column(
+      children: [
+        TagFilterMenu(
+          tags: tags,
+          selectedTag: _selectedTag,
+          onSelected: (value) {
+            setState(() => _selectedTag = value);
+          },
+        ),
+        SizedBox(
+          height: 80,
+          child: ListView.builder(
+            scrollDirection: Axis.horizontal,
+            itemCount: weekDays.length,
+            itemBuilder: (context, i) {
+              final d = weekDays[i];
+              final hasNotes = _notesForDay(d, filteredNotes).isNotEmpty;
+              return GestureDetector(
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    PageRouteBuilder(
+                      pageBuilder: (_, __, ___) =>
+                          NoteListForDayScreen(date: d),
+                      transitionsBuilder: (_, animation, __, child) {
+                        final offsetAnimation = Tween<Offset>(
+                          begin: const Offset(1, 0),
+                          end: Offset.zero,
+                        ).animate(animation);
+                        return FadeTransition(
+                          opacity: animation,
+                          child: SlideTransition(
+                            position: offsetAnimation,
+                            child: child,
+                          ),
+                        );
+                      },
+                    ),
+                  );
+                },
+                child: Container(
+                  width: 60,
+                  margin: const EdgeInsets.all(4),
+                  decoration: BoxDecoration(
+                    color: hasNotes ? Colors.orange : Colors.white,
+                    border: Border.all(color: Colors.black),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Text(
+                        DateFormat.E(
+                          Localizations.localeOf(context).toString(),
+                        ).format(d),
+                      ),
+                      Text('${d.day}'),
+                    ],
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+        const SizedBox(height: 8),
+        Expanded(child: NotesList(notes: filteredNotes)),
+      ],
+    );
+  }
+}

--- a/test/tag_filtered_notes_list_test.dart
+++ b/test/tag_filtered_notes_list_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:notes_reminder_app/providers/note_provider.dart';
+import 'package:notes_reminder_app/widgets/tag_filtered_notes_list.dart';
+import 'package:notes_reminder_app/models/note.dart';
+
+void main() {
+  testWidgets('filters notes by tag', (tester) async {
+    final provider = NoteProvider();
+    await tester.pumpWidget(
+      ChangeNotifierProvider.value(
+        value: provider,
+        child: MaterialApp(
+          locale: const Locale('vi'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const Scaffold(body: TagFilteredNotesList()),
+        ),
+      ),
+    );
+
+    await provider.addNote(
+      const Note(
+        id: '1',
+        title: 'n1',
+        content: 'c1',
+        summary: '',
+        actionItems: [],
+        dates: [],
+        tags: ['work'],
+      ),
+    );
+    await provider.addNote(
+      const Note(
+        id: '2',
+        title: 'n2',
+        content: 'c2',
+        summary: '',
+        actionItems: [],
+        dates: [],
+        tags: ['home'],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('n1'), findsOneWidget);
+    expect(find.text('n2'), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.label));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('work').last);
+    await tester.pumpAndSettle();
+
+    expect(find.text('n1'), findsOneWidget);
+    expect(find.text('n2'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary
- move notes tab code into reusable widgets
- add tag-filtered notes list widget and test

## Testing
- `~/flutter/bin/flutter test` *(fails: Couldn't resolve the package 'flutter_gen' and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7a9977a08333b596ddab9a60d334