### PR TITLE
feat: allow injecting Gemini API key

### DIFF
--- a/lib/services/gemini_service.dart
+++ b/lib/services/gemini_service.dart
@@ -7,14 +7,18 @@ import 'package:http/http.dart' as http;
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class GeminiService {
-  static const _apiKey = String.fromEnvironment('GEMINI_API_KEY', defaultValue: '');
-
   final http.Client _client;
   final String _model;
+  final String _apiKey;
 
-  GeminiService({http.Client? client, String model = 'gemini-1.5-flash-latest'})
-      : _client = client ?? http.Client(),
-        _model = model;
+  GeminiService({
+    http.Client? client,
+    String model = 'gemini-1.5-flash-latest',
+    String? apiKey,
+  })  : _client = client ?? http.Client(),
+        _model = model,
+        _apiKey =
+            apiKey ?? const String.fromEnvironment('GEMINI_API_KEY', defaultValue: '');
 
   Future<String> chat(String userText, AppLocalizations l10n) async {
     if (_apiKey.isEmpty) return l10n.geminiApiKeyNotConfigured;

--- a/test/gemini_service_test.dart
+++ b/test/gemini_service_test.dart
@@ -37,7 +37,7 @@ void main() {
             headers: {'content-type': 'application/json'});
       });
 
-      final service = GeminiService(client: client);
+      final service = GeminiService(client: client, apiKey: 'test');
       final result = await service.analyzeNote('test note');
 
       expect(result, isNotNull);
@@ -49,7 +49,7 @@ void main() {
 
     test('returns null on http error', () async {
       final client = MockClient((_) async => http.Response('err', 500));
-      final service = GeminiService(client: client);
+      final service = GeminiService(client: client, apiKey: 'test');
 
       final result = await service.analyzeNote('note');
       expect(result, isNull);
@@ -57,7 +57,7 @@ void main() {
 
     test('returns null on network error', () async {
       final client = MockClient((_) async => throw SocketException('no net'));
-      final service = GeminiService(client: client);
+      final service = GeminiService(client: client, apiKey: 'test');
 
       final result = await service.analyzeNote('note');
       expect(result, isNull);
@@ -79,7 +79,7 @@ void main() {
 
     test('returns error on invalid api key', () async {
       final client = MockClient((_) async => http.Response('denied', 401));
-      final service = GeminiService(client: client);
+      final service = GeminiService(client: client, apiKey: 'test');
 
       final result = await service.chat('hi', l10n);
       expect(result, 'error: Invalid API key');
@@ -88,7 +88,7 @@ void main() {
     test('returns error on server issue', () async {
       final client =
           MockClient((_) async => http.Response('boom', 500, reasonPhrase: 'ERR'));
-      final service = GeminiService(client: client);
+      final service = GeminiService(client: client, apiKey: 'test');
 
       final result = await service.chat('hi', l10n);
       expect(result, 'error: 500 ERR');
@@ -96,7 +96,7 @@ void main() {
 
     test('returns no internet on socket exception', () async {
       final client = MockClient((_) async => throw SocketException('x'));
-      final service = GeminiService(client: client);
+      final service = GeminiService(client: client, apiKey: 'test');
 
       final result = await service.chat('hi', l10n);
       expect(result, 'no internet');


### PR DESCRIPTION
## Summary
- allow passing an API key into `GeminiService` and fall back to `String.fromEnvironment`
- update Gemini service tests to provide a fake API key

## Testing
- `flutter test test/gemini_service_test.dart` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bc7a9c678883339935b32c4dc5802b