### PR TITLE
Handle auth exceptions and add PlatformException test

### DIFF
--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:local_auth/local_auth.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
@@ -11,8 +13,12 @@ class AuthService {
         localizedReason: l10n.authReason,
         options: const AuthenticationOptions(stickyAuth: true),
       );
-    } catch (_) {
+    } on PlatformException catch (e, st) {
+      debugPrint(l10n.errorWithMessage('${e.message ?? e.toString()}\n$st'));
       return false;
+    } catch (e, st) {
+      debugPrint(l10n.errorWithMessage('${e.toString()}\n$st'));
+      rethrow;
     }
   }
 }

--- a/test/auth_service_test.dart
+++ b/test/auth_service_test.dart
@@ -1,4 +1,5 @@
 import 'dart:ui';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:local_auth/local_auth.dart';
@@ -30,13 +31,22 @@ void main() {
     expect(ok, isTrue);
   });
 
-  test('authenticate returns false on failure', () async {
+  test('authenticate returns false on PlatformException', () async {
+    when(() => mock.authenticate(
+          localizedReason: any(named: 'localizedReason'),
+          options: any(named: 'options'),
+        )).thenThrow(const PlatformException(code: 'fail'));
+
+    final ok = await service.authenticate(l10n);
+    expect(ok, isFalse);
+  });
+
+  test('authenticate rethrows on generic exception', () async {
     when(() => mock.authenticate(
           localizedReason: any(named: 'localizedReason'),
           options: any(named: 'options'),
         )).thenThrow(Exception('fail'));
 
-    final ok = await service.authenticate(l10n);
-    expect(ok, isFalse);
+    expect(() => service.authenticate(l10n), throwsException);
   });
 }


### PR DESCRIPTION
## Summary
- catch `PlatformException` and log detailed error in `AuthService`
- rethrow unexpected errors for caller handling
- add unit tests for successful auth, platform error, and generic exception

## Testing
- `flutter test test/auth_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7aa6d91c8333a7e4c66088b892ba