### PR TITLE
feat: remember theme mode

### DIFF
--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -29,6 +29,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
   final NoteRepository _noteRepository = NoteRepository();
   bool _requireAuth = false;
 
+  ThemeMode _themeMode = ThemeMode.system;
+
   BackupFormat _backupFormat = BackupFormat.json;
 
 
@@ -45,6 +47,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
       if (mounted) {
         setState(() => _backupFormat = v);
 
+      }
+    });
+
+    _settings.loadThemeMode().then((v) {
+      if (mounted) {
+        setState(() => _themeMode = v);
+        widget.onThemeModeChanged(_themeMode);
       }
     });
   }

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -11,6 +11,7 @@ class SettingsService {
   static const _kFontScale = 'font_scale';
   static const _kRequireAuth = 'require_auth';
   static const _kBackupFormat = 'backup_format';
+  static const _kThemeMode = 'theme_mode';
 
   static const _kHasSeenOnboarding = 'has_seen_onboarding';
 
@@ -77,5 +78,19 @@ class SettingsService {
       orElse: () => BackupFormat.json,
     );
 
+  }
+
+  Future<void> saveThemeMode(ThemeMode mode) async {
+    final sp = await _sp;
+    await sp.setString(_kThemeMode, mode.name);
+  }
+
+  Future<ThemeMode> loadThemeMode() async {
+    final sp = await _sp;
+    final value = sp.getString(_kThemeMode);
+    return ThemeMode.values.firstWhere(
+      (m) => m.name == value,
+      orElse: () => ThemeMode.system,
+    );
   }
 }


### PR DESCRIPTION
## Summary
- add theme mode field in settings screen and load it from settings service
- support persisting theme mode in settings service

## Testing
- `dart format lib/screens/settings_screen.dart lib/services/settings_service.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc808e79c8833387340ac5b8c65f46