### PR TITLE
Use UUID for imported Markdown notes

### DIFF
--- a/lib/services/backup_service.dart
+++ b/lib/services/backup_service.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'package:pdf/widgets.dart' as pw;
+import 'package:uuid/uuid.dart';
 
 
 import '../models/note.dart';
@@ -146,11 +147,12 @@ class BackupService {
         final lines = content.split('\n');
         String? title;
         final buffer = StringBuffer();
+        final uuid = Uuid();
         for (final line in lines) {
           if (line.startsWith('# ')) {
             if (title != null) {
               notes.add(
-                Note(id: '${notes.length}', title: title!, content: buffer.toString().trim()),
+                Note(id: uuid.v4(), title: title!, content: buffer.toString().trim()),
               );
               buffer.clear();
             }
@@ -161,7 +163,7 @@ class BackupService {
         }
         if (title != null) {
           notes.add(
-            Note(id: '${notes.length}', title: title!, content: buffer.toString().trim()),
+            Note(id: uuid.v4(), title: title!, content: buffer.toString().trim()),
           );
         }
         return notes;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1234,7 +1234,7 @@ packages:
     source: hosted
     version: "3.1.4"
   uuid:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       name: uuid
       sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,18 +49,18 @@ dependencies:
   firebase_analytics: ^12.0.1
 
   google_sign_in: ^6.2.1
-
-
-dev_dependencies:
-  flutter_test:
-    sdk: flutter
-  flutter_lints: ^2.0.0
-  mocktail: ^1.0.4
-  integration_test:
-    sdk: flutter
   uuid: ^4.5.1
-  build_runner: ^2.4.6
-  json_serializable: ^6.7.1
+
+
+  dev_dependencies:
+    flutter_test:
+      sdk: flutter
+    flutter_lints: ^2.0.0
+    mocktail: ^1.0.4
+    integration_test:
+      sdk: flutter
+    build_runner: ^2.4.6
+    json_serializable: ^6.7.1
 
 flutter:
   generate: true


### PR DESCRIPTION
## Summary
- Generate unique IDs with `Uuid` when importing Markdown backups
- Declare `uuid` as a runtime dependency

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc809026bc8333aa4210fd36222ca5