### PR TITLE
Add theme mode callback to settings flow

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -83,6 +83,7 @@ void main() async {
   }
   final themeColor = await settings.loadThemeColor();
   final fontScale = await settings.loadFontScale();
+  final themeMode = await settings.loadThemeMode();
 
   final hasSeenOnboarding = await settings.loadHasSeenOnboarding();
 
@@ -92,6 +93,7 @@ void main() async {
       child: MyApp(
         themeColor: themeColor,
         fontScale: fontScale,
+        themeMode: themeMode,
 
         hasSeenOnboarding: hasSeenOnboarding,
 
@@ -114,6 +116,7 @@ class MyApp extends StatefulWidget {
     super.key,
     required this.themeColor,
     required this.fontScale,
+    required this.themeMode,
 
     required this.hasSeenOnboarding,
 
@@ -138,6 +141,7 @@ class _MyAppState extends State<MyApp> {
     super.initState();
     _themeColor = widget.themeColor;
     _fontScale = widget.fontScale;
+    _themeMode = widget.themeMode;
 
     _hasSeenOnboarding = widget.hasSeenOnboarding;
 
@@ -184,6 +188,11 @@ class _MyAppState extends State<MyApp> {
     await SettingsService().saveFontScale(newScale);
   }
 
+  void updateThemeMode(ThemeMode newMode) async {
+    setState(() => _themeMode = newMode);
+    await SettingsService().saveThemeMode(newMode);
+  }
+
 
   void _completeOnboarding() {
     setState(() => _hasSeenOnboarding = true);
@@ -227,6 +236,7 @@ class _MyAppState extends State<MyApp> {
           ? HomeScreen(
               onThemeChanged: updateTheme,
               onFontScaleChanged: updateFontScale,
+              onThemeModeChanged: updateThemeMode,
             )
           : OnboardingScreen(onFinished: _completeOnboarding),
 

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -34,6 +34,7 @@ class _HomeScreenState extends State<HomeScreen> {
       NotesTab(
         onThemeChanged: widget.onThemeChanged,
         onFontScaleChanged: widget.onFontScaleChanged,
+        onThemeModeChanged: widget.onThemeModeChanged,
       ),
       NoteListForDayScreen(date: DateTime.now()),
       const VoiceToNoteScreen(),
@@ -41,6 +42,7 @@ class _HomeScreenState extends State<HomeScreen> {
       SettingsScreen(
         onThemeChanged: widget.onThemeChanged,
         onFontScaleChanged: widget.onFontScaleChanged,
+        onThemeModeChanged: widget.onThemeModeChanged,
       ),
     ];
   }

--- a/lib/widgets/notes_tab.dart
+++ b/lib/widgets/notes_tab.dart
@@ -15,11 +15,13 @@ import 'tag_filtered_notes_list.dart';
 class NotesTab extends StatefulWidget {
   final Function(Color) onThemeChanged;
   final Function(double) onFontScaleChanged;
+  final Function(ThemeMode) onThemeModeChanged;
 
   const NotesTab({
     super.key,
     required this.onThemeChanged,
     required this.onFontScaleChanged,
+    required this.onThemeModeChanged,
   });
 
   @override
@@ -126,6 +128,7 @@ class _NotesTabState extends State<NotesTab> {
                   pageBuilder: (_, __, ___) => SettingsScreen(
                     onThemeChanged: widget.onThemeChanged,
                     onFontScaleChanged: widget.onFontScaleChanged,
+                    onThemeModeChanged: widget.onThemeModeChanged,
                   ),
                   transitionsBuilder: (_, animation, __, child) {
                     final offsetAnimation = Tween<Offset>(

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -14,7 +14,12 @@ void main() {
         supportedLocales: AppLocalizations.supportedLocales,
         home: ChangeNotifierProvider(
           create: (_) => NoteProvider(),
-          child: MyApp(themeColor: Colors.blue, fontScale: 1.0),
+          child: MyApp(
+            themeColor: Colors.blue,
+            fontScale: 1.0,
+            themeMode: ThemeMode.system,
+            hasSeenOnboarding: true,
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- Allow `NotesTab` to forward a theme mode change callback to `SettingsScreen`
- Wire `onThemeModeChanged` through `HomeScreen` and application initialization
- Update widget test to construct `MyApp` with theme mode

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bc845ccc9c833392f3d1adf012d137