### PR TITLE
Propagate theme mode changes to notes and settings

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -184,6 +184,11 @@ class _MyAppState extends State<MyApp> {
     await SettingsService().saveFontScale(newScale);
   }
 
+  void updateThemeMode(ThemeMode newMode) async {
+    setState(() => _themeMode = newMode);
+    await SettingsService().saveThemeMode(newMode);
+  }
+
 
   void _completeOnboarding() {
     setState(() => _hasSeenOnboarding = true);
@@ -227,6 +232,7 @@ class _MyAppState extends State<MyApp> {
           ? HomeScreen(
               onThemeChanged: updateTheme,
               onFontScaleChanged: updateFontScale,
+              onThemeModeChanged: updateThemeMode,
             )
           : OnboardingScreen(onFinished: _completeOnboarding),
 

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -34,6 +34,7 @@ class _HomeScreenState extends State<HomeScreen> {
       NotesTab(
         onThemeChanged: widget.onThemeChanged,
         onFontScaleChanged: widget.onFontScaleChanged,
+        onThemeModeChanged: widget.onThemeModeChanged,
       ),
       NoteListForDayScreen(date: DateTime.now()),
       const VoiceToNoteScreen(),
@@ -41,6 +42,7 @@ class _HomeScreenState extends State<HomeScreen> {
       SettingsScreen(
         onThemeChanged: widget.onThemeChanged,
         onFontScaleChanged: widget.onFontScaleChanged,
+        onThemeModeChanged: widget.onThemeModeChanged,
       ),
     ];
   }

--- a/lib/widgets/notes_tab.dart
+++ b/lib/widgets/notes_tab.dart
@@ -15,11 +15,13 @@ import 'tag_filtered_notes_list.dart';
 class NotesTab extends StatefulWidget {
   final Function(Color) onThemeChanged;
   final Function(double) onFontScaleChanged;
+  final Function(ThemeMode) onThemeModeChanged;
 
   const NotesTab({
     super.key,
     required this.onThemeChanged,
     required this.onFontScaleChanged,
+    required this.onThemeModeChanged,
   });
 
   @override
@@ -126,6 +128,7 @@ class _NotesTabState extends State<NotesTab> {
                   pageBuilder: (_, __, ___) => SettingsScreen(
                     onThemeChanged: widget.onThemeChanged,
                     onFontScaleChanged: widget.onFontScaleChanged,
+                    onThemeModeChanged: widget.onThemeModeChanged,
                   ),
                   transitionsBuilder: (_, animation, __, child) {
                     final offsetAnimation = Tween<Offset>(


### PR DESCRIPTION
## Summary
- forward theme mode changes through HomeScreen to NotesTab and SettingsScreen
- expose onThemeModeChanged in NotesTab and handle in main

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc845415d883338eff49ae824b18d2