### PR TITLE
Add theme mode configuration to MyApp

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -92,6 +92,7 @@ void main() async {
       child: MyApp(
         themeColor: themeColor,
         fontScale: fontScale,
+        themeMode: await settings.loadThemeMode(),
 
         hasSeenOnboarding: hasSeenOnboarding,
 
@@ -114,6 +115,7 @@ class MyApp extends StatefulWidget {
     super.key,
     required this.themeColor,
     required this.fontScale,
+    required this.themeMode,
 
     required this.hasSeenOnboarding,
 
@@ -138,6 +140,7 @@ class _MyAppState extends State<MyApp> {
     super.initState();
     _themeColor = widget.themeColor;
     _fontScale = widget.fontScale;
+    _themeMode = widget.themeMode;
 
     _hasSeenOnboarding = widget.hasSeenOnboarding;
 
@@ -184,6 +187,11 @@ class _MyAppState extends State<MyApp> {
     await SettingsService().saveFontScale(newScale);
   }
 
+  void updateThemeMode(ThemeMode newMode) async {
+    setState(() => _themeMode = newMode);
+    await SettingsService().saveThemeMode(newMode);
+  }
+
 
   void _completeOnboarding() {
     setState(() => _hasSeenOnboarding = true);
@@ -227,6 +235,7 @@ class _MyAppState extends State<MyApp> {
           ? HomeScreen(
               onThemeChanged: updateTheme,
               onFontScaleChanged: updateFontScale,
+              onThemeModeChanged: updateThemeMode,
             )
           : OnboardingScreen(onFinished: _completeOnboarding),
 


### PR DESCRIPTION
## Summary
- pass stored ThemeMode into MyApp at startup
- expose updateThemeMode to persist changes via SettingsService
- wire HomeScreen to update app theme mode

## Testing
- `dart format lib/main.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8454d1848333905ab3d90d4fdcf3