### PR TITLE
Refactor ToolbarButton to use design tokens and add disabled state

### DIFF
--- a/lib/pandora_ui/toolbar_button.dart
+++ b/lib/pandora_ui/toolbar_button.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'path/to/tokens.dart'; // Đường dẫn đến tokens.dart
+import 'tokens.dart';
 
 class ToolbarButton extends StatelessWidget {
   final Widget icon;
@@ -7,7 +7,8 @@ class ToolbarButton extends StatelessWidget {
   final VoidCallback onPressed;
   final bool disabled;
 
-  ToolbarButton({
+  const ToolbarButton({
+    super.key,
     required this.icon,
     required this.label,
     required this.onPressed,
@@ -16,22 +17,32 @@ class ToolbarButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ElevatedButton(
-      onPressed: disabled ? null : onPressed,
-      style: ElevatedButton.styleFrom(
-        padding: EdgeInsets.symmetric(vertical: 12, horizontal: 16),
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-          side: BorderSide(color: Colors.transparent), // Có thể thay đổi màu viền nếu cần
+    final borderColor =
+        disabled ? PandoraTokens.neutral200 : Colors.transparent;
+    return Opacity(
+      opacity: disabled
+          ? PandoraTokens.opacityDisabled
+          : PandoraTokens.opacityEnabled,
+      child: ElevatedButton(
+        onPressed: disabled ? null : onPressed,
+        style: ElevatedButton.styleFrom(
+          padding: EdgeInsets.symmetric(
+            vertical: PandoraTokens.spacingS,
+            horizontal: PandoraTokens.spacingM,
+          ),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(PandoraTokens.radiusM),
+            side: BorderSide(color: borderColor),
+          ),
+          backgroundColor: PandoraTokens.neutral100,
         ),
-        backgroundColor: disabled ? Colors.grey : Color.fromARGB(255, /* lấy màu từ tokens.dart */),
-      ),
-      child: Row(
-        children: [
-          icon,
-          SizedBox(width: 8),
-          Text(label),
-        ],
+        child: Row(
+          children: [
+            icon,
+            SizedBox(width: PandoraTokens.spacingS),
+            Text(label),
+          ],
+        ),
       ),
     );
   }

--- a/test/pandora_ui/toolbar_button_test.dart
+++ b/test/pandora_ui/toolbar_button_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:notes_reminder_app/pandora_ui/toolbar_button.dart';
+import 'package:notes_reminder_app/pandora_ui/tokens.dart';
+
+void main() {
+  testWidgets('ToolbarButton enabled state', (WidgetTester tester) async {
+    var pressed = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ToolbarButton(
+          icon: const Icon(Icons.add),
+          label: 'Add',
+          onPressed: () {
+            pressed = true;
+          },
+        ),
+      ),
+    );
+
+    final opacityWidget = tester.widget<Opacity>(
+      find.ancestor(of: find.byType(ElevatedButton), matching: find.byType(Opacity)),
+    );
+
+    expect(opacityWidget.opacity, PandoraTokens.opacityEnabled);
+
+    await tester.tap(find.byType(ElevatedButton));
+    expect(pressed, isTrue);
+  });
+
+  testWidgets('ToolbarButton disabled state', (WidgetTester tester) async {
+    var pressed = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ToolbarButton(
+          icon: const Icon(Icons.add),
+          label: 'Add',
+          onPressed: () {
+            pressed = true;
+          },
+          disabled: true,
+        ),
+      ),
+    );
+
+    final button = tester.widget<ElevatedButton>(find.byType(ElevatedButton));
+    expect(button.onPressed, isNull);
+
+    final opacityWidget = tester.widget<Opacity>(
+      find.ancestor(of: find.byType(ElevatedButton), matching: find.byType(Opacity)),
+    );
+    expect(opacityWidget.opacity, PandoraTokens.opacityDisabled);
+
+    final style = button.style!;
+    final shape = style.shape!.resolve({MaterialState.disabled}) as RoundedRectangleBorder;
+    expect(shape.side.color, PandoraTokens.neutral200);
+
+    await tester.tap(find.byType(ElevatedButton));
+    expect(pressed, isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- import design tokens in ToolbarButton
- replace hardcoded styles with `PandoraTokens`
- add disabled state with token-based opacity and border color
- add widget test covering enabled and disabled states

## Testing
- `flutter test` *(fails: Error: Couldn't resolve the package 'flutter_gen' in 'package:flutter_gen/gen_l10n/app_localizations.dart')*
- `flutter test test/pandora_ui/toolbar_button_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_68bc8cb307908333b8dfc34472238690