### PR TITLE
Add snackbar kinds and animations

### DIFF
--- a/test/pandora_snackbar_test.dart
+++ b/test/pandora_snackbar_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:notes_reminder_app/pandora_ui/pandora_snackbar.dart';
+import 'package:notes_reminder_app/pandora_ui/tokens.dart';
+
+void main() {
+  testWidgets('snackIn and snackOut animations run', (tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: Scaffold(
+        body: PandoraSnackbar(
+          text: 'Hello',
+          kind: SnackbarKind.success,
+        ),
+      ),
+    ));
+
+    await tester.pump();
+    await tester.pump(PandoraTokens.durationShort);
+
+    final fade = tester.widget<FadeTransition>(find.byType(FadeTransition));
+    expect(fade.opacity.value, 1);
+
+    final state = tester.state(find.byType(PandoraSnackbar)) as dynamic;
+    state.hide();
+    await tester.pump();
+    await tester.pump(PandoraTokens.durationShort);
+
+    final fadeAfter =
+        tester.widget<FadeTransition>(find.byType(FadeTransition));
+    expect(fadeAfter.opacity.value, 0);
+  });
+}


### PR DESCRIPTION
## Summary
- add `SnackbarKind` with icons and token colors
- animate PandoraSnackbar show/hide using tokens and blur background
- test animations with WidgetTester

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8cb45c948333a42837afbe694443