### PR TITLE
Add Pandora UI widgets and demo usage

### DIFF
--- a/lib/pandora_ui/bottom_sheet.dart
+++ b/lib/pandora_ui/bottom_sheet.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+
+import 'tokens.dart';
+
+/// A draggable bottom sheet that traps focus when opened.
+class PandoraBottomSheet extends StatefulWidget {
+  const PandoraBottomSheet({super.key, required this.child});
+
+  final Widget child;
+
+  /// Shows the bottom sheet using [showModalBottomSheet].
+  static Future<T?> show<T>(BuildContext context, Widget child) {
+    return showModalBottomSheet<T>(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => PandoraBottomSheet(child: child),
+    );
+  }
+
+  @override
+  State<PandoraBottomSheet> createState() => _PandoraBottomSheetState();
+}
+
+class _PandoraBottomSheetState extends State<PandoraBottomSheet> {
+  final FocusScopeNode _focusNode = FocusScopeNode();
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return DraggableScrollableSheet(
+      expand: false,
+      builder: (context, controller) {
+        final theme = Theme.of(context);
+        return FocusScope(
+          node: _focusNode,
+          autofocus: true,
+          child: Container(
+            decoration: BoxDecoration(
+              color: theme.canvasColor,
+              borderRadius: const BorderRadius.vertical(
+                top: Radius.circular(PandoraTokens.radiusL),
+              ),
+            ),
+            child: SingleChildScrollView(
+              controller: controller,
+              child: widget.child,
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/pandora_ui/dismissible_wrapper.dart
+++ b/lib/pandora_ui/dismissible_wrapper.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+import 'tokens.dart';
+
+/// Wrapper adding swipe-to-dismiss behaviour to any widget.
+class DismissibleWrapper extends StatelessWidget {
+  const DismissibleWrapper({
+    super.key,
+    required this.child,
+    this.onDismissed,
+    this.dismissibleKey,
+  });
+
+  final Widget child;
+  final VoidCallback? onDismissed;
+  final Key? dismissibleKey;
+
+  @override
+  Widget build(BuildContext context) {
+    return Dismissible(
+      key: dismissibleKey ?? ValueKey(child.hashCode),
+      direction: DismissDirection.endToStart,
+      onDismissed: (_) => onDismissed?.call(),
+      background: Container(
+        color: PandoraTokens.error,
+        alignment: Alignment.centerRight,
+        padding: const EdgeInsets.symmetric(horizontal: PandoraTokens.spacingM),
+        child: const Icon(Icons.delete, color: Colors.white),
+      ),
+      child: child,
+    );
+  }
+}

--- a/lib/pandora_ui/palette_list_item.dart
+++ b/lib/pandora_ui/palette_list_item.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+import 'tokens.dart';
+
+/// Simple list item displaying a color swatch with a label.
+class PaletteListItem extends StatelessWidget {
+  const PaletteListItem({
+    super.key,
+    required this.color,
+    required this.label,
+    this.onTap,
+  });
+
+  final Color color;
+  final String label;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final textColor = Theme.of(context).textTheme.bodyMedium?.color;
+    return ListTile(
+      leading: Container(
+        width: PandoraTokens.iconL,
+        height: PandoraTokens.iconL,
+        decoration: BoxDecoration(
+          color: color,
+          borderRadius: BorderRadius.circular(PandoraTokens.radiusS),
+        ),
+      ),
+      title: Text(label, style: TextStyle(color: textColor)),
+      onTap: onTap,
+    );
+  }
+}

--- a/lib/pandora_ui/result_card.dart
+++ b/lib/pandora_ui/result_card.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+
+import 'tokens.dart';
+import 'security_cue.dart';
+
+/// A card displaying AI results including streamed text, images, code preview,
+/// actions and feedback controls.
+class ResultCard extends StatelessWidget {
+  const ResultCard({
+    super.key,
+    this.textStream,
+    this.text,
+    this.images,
+    this.code,
+    this.actions,
+    this.onFeedback,
+    this.securityMode,
+  });
+
+  /// Streamed text to display progressively.
+  final Stream<String>? textStream;
+
+  /// Static text to display if [textStream] is null.
+  final String? text;
+
+  /// Optional images to show in a wrap.
+  final List<ImageProvider>? images;
+
+  /// Optional code snippet to show in a monospace preview.
+  final String? code;
+
+  /// Optional action buttons shown at the bottom of the card.
+  final List<Widget>? actions;
+
+  /// Callback when feedback buttons are pressed. `true` for like.
+  final void Function(bool)? onFeedback;
+
+  /// Optional mode indicator.
+  final SecurityMode? securityMode;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final bgColor =
+        theme.brightness == Brightness.dark ? PandoraTokens.darkBg : PandoraTokens.neutral100;
+
+    final content = <Widget>[];
+
+    if (securityMode != null) {
+      content.add(Align(
+        alignment: Alignment.centerRight,
+        child: SecurityCue(mode: securityMode!),
+      ));
+    }
+
+    if (textStream != null) {
+      content.add(StreamBuilder<String>(
+        stream: textStream,
+        builder: (context, snapshot) {
+          return Text(snapshot.data ?? '', style: theme.textTheme.bodyMedium);
+        },
+      ));
+    } else if (text != null) {
+      content.add(Text(text!, style: theme.textTheme.bodyMedium));
+    }
+
+    if (images != null && images!.isNotEmpty) {
+      content.add(const SizedBox(height: PandoraTokens.spacingM));
+      content.add(Wrap(
+        spacing: PandoraTokens.spacingS,
+        children: images!
+            .map((img) => Image(image: img, width: 72, height: 72))
+            .toList(),
+      ));
+    }
+
+    if (code != null) {
+      content.add(const SizedBox(height: PandoraTokens.spacingM));
+      content.add(Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(PandoraTokens.spacingM),
+        decoration: BoxDecoration(
+          color: theme.colorScheme.surface,
+          borderRadius: BorderRadius.circular(PandoraTokens.radiusS),
+        ),
+        child: SelectableText(
+          code!,
+          style: const TextStyle(fontFamily: 'monospace'),
+        ),
+      ));
+    }
+
+    if (actions != null && actions!.isNotEmpty) {
+      content.add(const SizedBox(height: PandoraTokens.spacingM));
+      content.add(ButtonBar(children: actions!));
+    }
+
+    if (onFeedback != null) {
+      content.add(Row(
+        children: [
+          IconButton(
+            icon: const Icon(Icons.thumb_up),
+            onPressed: () => onFeedback!(true),
+          ),
+          IconButton(
+            icon: const Icon(Icons.thumb_down),
+            onPressed: () => onFeedback!(false),
+          ),
+        ],
+      ));
+    }
+
+    return Card(
+      color: bgColor,
+      elevation: PandoraTokens.elevationLow,
+      margin: const EdgeInsets.all(PandoraTokens.spacingM),
+      shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(PandoraTokens.radiusM)),
+      child: Padding(
+        padding: const EdgeInsets.all(PandoraTokens.spacingM),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: content,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pandora_ui/security_cue.dart
+++ b/lib/pandora_ui/security_cue.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+import 'tokens.dart';
+
+/// Visual indicator of how a result was processed.
+///
+/// The cue displays an icon representing where the work was done
+/// (on-device, hybrid or in the cloud).
+enum SecurityMode { onDevice, hybrid, cloud }
+
+class SecurityCue extends StatelessWidget {
+  const SecurityCue({super.key, required this.mode, this.size = PandoraTokens.iconM});
+
+  /// Mode the result was processed in.
+  final SecurityMode mode;
+
+  /// Size of the icon.
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    final icon = switch (mode) {
+      SecurityMode.onDevice => Icons.shield,
+      SecurityMode.hybrid => Icons.sync,
+      SecurityMode.cloud => Icons.cloud,
+    };
+
+    final color = switch (mode) {
+      SecurityMode.onDevice => Colors.green,
+      SecurityMode.hybrid => PandoraTokens.warning,
+      SecurityMode.cloud => PandoraTokens.info,
+    };
+
+    return Icon(icon, size: size, color: color);
+  }
+}

--- a/lib/pandora_ui/teach_ai_modal.dart
+++ b/lib/pandora_ui/teach_ai_modal.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+
+import 'tokens.dart';
+
+/// Simple modal dialog allowing the user to provide feedback to improve the AI.
+class TeachAiModal extends StatefulWidget {
+  const TeachAiModal({super.key, this.onSubmit});
+
+  final void Function(String)? onSubmit;
+
+  /// Convenience method to show the modal.
+  static Future<void> show(BuildContext context, {void Function(String)? onSubmit}) {
+    return showDialog<void>(
+      context: context,
+      builder: (_) => TeachAiModal(onSubmit: onSubmit),
+    );
+  }
+
+  @override
+  State<TeachAiModal> createState() => _TeachAiModalState();
+}
+
+class _TeachAiModalState extends State<TeachAiModal> {
+  final TextEditingController _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      contentPadding: const EdgeInsets.all(PandoraTokens.spacingM),
+      title: const Text('Teach AI'),
+      content: TextField(
+        controller: _controller,
+        maxLines: 5,
+        decoration: const InputDecoration(
+          hintText: 'Share feedback or corrections',
+        ),
+      ),
+      actionsPadding: const EdgeInsets.symmetric(
+        horizontal: PandoraTokens.spacingM,
+        vertical: PandoraTokens.spacingS,
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        ElevatedButton(
+          onPressed: () {
+            widget.onSubmit?.call(_controller.text);
+            Navigator.of(context).pop();
+          },
+          child: const Text('Submit'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/pandora_ui_demo.dart
+++ b/lib/widgets/pandora_ui_demo.dart
@@ -1,0 +1,91 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../pandora_ui/bottom_sheet.dart';
+import '../pandora_ui/dismissible_wrapper.dart';
+import '../pandora_ui/palette_list_item.dart';
+import '../pandora_ui/result_card.dart';
+import '../pandora_ui/security_cue.dart';
+import '../pandora_ui/teach_ai_modal.dart';
+import '../pandora_ui/tokens.dart';
+
+/// Demonstrates the Pandora UI widgets in a simple screen.
+class PandoraUiDemo extends StatelessWidget {
+  const PandoraUiDemo({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Pandora UI Demo')),
+      body: ListView(
+        padding: const EdgeInsets.all(PandoraTokens.spacingM),
+        children: [
+          const Text('Security modes'),
+          const Row(
+            children: [
+              SecurityCue(mode: SecurityMode.onDevice),
+              SizedBox(width: PandoraTokens.spacingM),
+              SecurityCue(mode: SecurityMode.hybrid),
+              SizedBox(width: PandoraTokens.spacingM),
+              SecurityCue(mode: SecurityMode.cloud),
+            ],
+          ),
+          const SizedBox(height: PandoraTokens.spacingL),
+          ResultCard(
+            textStream: Stream<String>.periodic(
+              const Duration(milliseconds: 400),
+              (i) => 'Chunk ' + (i + 1).toString(),
+            ).take(3).transform(StreamTransformer.fromHandlers(
+                handleData: (data, sink) => sink.add(data + '...'))),
+            images: const [
+              NetworkImage('https://placekitten.com/200/200'),
+            ],
+            code: "print('hello world');",
+            actions: [
+              TextButton(onPressed: () {}, child: const Text('Action')),
+            ],
+            onFeedback: (liked) {},
+            securityMode: SecurityMode.hybrid,
+          ),
+          const SizedBox(height: PandoraTokens.spacingL),
+          PaletteListItem(
+            color: Colors.blue,
+            label: 'Blue',
+            onTap: () {},
+          ),
+          const SizedBox(height: PandoraTokens.spacingL),
+          ElevatedButton(
+            onPressed: () {
+              PandoraBottomSheet.show(
+                context,
+                SizedBox(
+                  height: 200,
+                  child: Center(
+                    child: Text('Pull down to close',
+                        style: Theme.of(context).textTheme.titleMedium),
+                  ),
+                ),
+              );
+            },
+            child: const Text('Show Bottom Sheet'),
+          ),
+          const SizedBox(height: PandoraTokens.spacingL),
+          ElevatedButton(
+            onPressed: () => TeachAiModal.show(context),
+            child: const Text('Teach AI'),
+          ),
+          const SizedBox(height: PandoraTokens.spacingL),
+          DismissibleWrapper(
+            onDismissed: () {},
+            child: Container(
+              color: Theme.of(context).colorScheme.primary.withOpacity(0.2),
+              padding: const EdgeInsets.all(PandoraTokens.spacingM),
+              child: const Text('Swipe me'),
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable Pandora UI widgets (SecurityCue, ResultCard, BottomSheet, TeachAiModal, PaletteListItem, DismissibleWrapper)
- provide Pandora UI demo screen showcasing new widgets

## Testing
- `flutter analyze` *(fails: command not found)*
- `apt-get install flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8cb6a63c8333b4d17607b06af50f