### PR TITLE
Add path_provider import to backup service

### DIFF
--- a/lib/services/backup_service.dart
+++ b/lib/services/backup_service.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'package:pdf/widgets.dart' as pw;
+import 'package:path_provider/path_provider.dart';
 import 'package:uuid/uuid.dart';
 
 


### PR DESCRIPTION
## Summary
- Import `path_provider` in `BackupService` so `getApplicationDocumentsDirectory` resolves

## Testing
- `flutter pub get` *(fails: requires Dart >=3.8.0, current 3.5.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bc928e232c83338c65222e59994f11