### PR TITLE
Handle authentication errors gracefully

### DIFF
--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -17,8 +17,10 @@ class AuthService {
       debugPrint(l10n.errorWithMessage('${e.message ?? e.toString()}\n$st'));
       return false;
     } catch (e, st) {
+      // Catch any other unexpected errors and fail gracefully instead of
+      // bubbling the exception up to the caller which could crash the app.
       debugPrint(l10n.errorWithMessage('${e.toString()}\n$st'));
-      rethrow;
+      return false;
     }
   }
 }

--- a/test/auth_service_test.dart
+++ b/test/auth_service_test.dart
@@ -41,12 +41,13 @@ void main() {
     expect(ok, isFalse);
   });
 
-  test('authenticate rethrows on generic exception', () async {
+  test('authenticate returns false on generic exception', () async {
     when(() => mock.authenticate(
           localizedReason: any(named: 'localizedReason'),
           options: any(named: 'options'),
         )).thenThrow(Exception('fail'));
 
-    expect(() => service.authenticate(l10n), throwsException);
+    final ok = await service.authenticate(l10n);
+    expect(ok, isFalse);
   });
 }


### PR DESCRIPTION
## Summary
- Prevent unexpected crashes by returning `false` on unhandled errors in `AuthService.authenticate`.
- Extend unit tests to ensure both platform and generic exceptions result in a `false` return value.

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc928e7d708333ba61982d5d7668bb