### PR TITLE
refactor: add startup service and extract app widget

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,0 +1,145 @@
+import 'dart:async';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+
+import 'screens/home_screen.dart';
+import 'screens/onboarding_screen.dart';
+import 'services/settings_service.dart';
+
+final messengerKey = GlobalKey<ScaffoldMessengerState>();
+
+class MyApp extends StatefulWidget {
+  final Color themeColor;
+  final double fontScale;
+  final ThemeMode themeMode;
+  final bool authFailed;
+  final bool notificationFailed;
+  final bool hasSeenOnboarding;
+  const MyApp({
+    super.key,
+    required this.themeColor,
+    required this.fontScale,
+    required this.themeMode,
+    required this.hasSeenOnboarding,
+    this.authFailed = false,
+    this.notificationFailed = false,
+  });
+
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  Color _themeColor = Colors.blue;
+  double _fontScale = 1.0;
+  ThemeMode _themeMode = ThemeMode.system;
+  StreamSubscription<ConnectivityResult>? _connSub;
+  bool _hasSeenOnboarding = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _themeColor = widget.themeColor;
+    _fontScale = widget.fontScale;
+    _themeMode = widget.themeMode;
+    _hasSeenOnboarding = widget.hasSeenOnboarding;
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final l10n = AppLocalizations.of(context)!;
+      if (widget.authFailed) {
+        messengerKey.currentState?.showSnackBar(
+          SnackBar(
+            content: Text(l10n.authFailedMessage),
+          ),
+        );
+      }
+      if (widget.notificationFailed) {
+        messengerKey.currentState?.showSnackBar(
+          SnackBar(
+            content: Text(l10n.notificationFailedMessage),
+          ),
+        );
+      }
+    });
+    try {
+      _connSub = Connectivity().onConnectivityChanged.listen((result) {
+        if (result == ConnectivityResult.none) {
+          final l10n = AppLocalizations.of(context)!;
+          messengerKey.currentState?.showSnackBar(
+            SnackBar(
+              content: Text(l10n.noInternetConnection),
+            ),
+          );
+        }
+      });
+    } on MissingPluginException {
+      // Ignore if connectivity plugin is not available (e.g., tests)
+    }
+  }
+
+  void updateTheme(Color newColor) async {
+    setState(() => _themeColor = newColor);
+    await SettingsService().saveThemeColor(newColor);
+  }
+
+  void updateFontScale(double newScale) async {
+    setState(() => _fontScale = newScale);
+    await SettingsService().saveFontScale(newScale);
+  }
+
+  void updateThemeMode(ThemeMode newMode) async {
+    setState(() => _themeMode = newMode);
+    await SettingsService().saveThemeMode(newMode);
+  }
+
+  void _completeOnboarding() {
+    setState(() => _hasSeenOnboarding = true);
+  }
+
+  @override
+  void dispose() {
+    _connSub?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      scaffoldMessengerKey: messengerKey,
+      onGenerateTitle: (context) => AppLocalizations.of(context)!.appTitle,
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [Locale('en'), Locale('vi')],
+      theme: ThemeData(
+        colorSchemeSeed: _themeColor,
+        useMaterial3: true,
+      ),
+      darkTheme: ThemeData(
+        colorSchemeSeed: _themeColor,
+        brightness: Brightness.dark,
+        useMaterial3: true,
+      ),
+      themeMode: _themeMode,
+      builder: (context, child) => MediaQuery(
+        data: MediaQuery.of(context).copyWith(textScaleFactor: _fontScale),
+        child: child!,
+      ),
+      home: _hasSeenOnboarding
+          ? HomeScreen(
+              onThemeChanged: updateTheme,
+              onFontScaleChanged: updateFontScale,
+              onThemeModeChanged: updateThemeMode,
+            )
+          : OnboardingScreen(onFinished: _completeOnboarding),
+    );
+  }
+}
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,27 +1,17 @@
 import 'dart:async';
 
-import 'package:connectivity_plus/connectivity_plus.dart';
-import 'package:firebase_auth/firebase_auth.dart';
-import 'package:firebase_core/firebase_core.dart';
-import 'package:firebase_crashlytics/firebase_crashlytics.dart';
-import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
-
-import 'screens/home_screen.dart';
-import 'screens/onboarding_screen.dart';
-import 'services/notification_service.dart';
-import 'services/settings_service.dart';
-import 'services/auth_service.dart';
 import 'package:provider/provider.dart';
-import 'providers/note_provider.dart';
-import 'models/note.dart';
-import 'firebase_options.dart';
 
-final messengerKey = GlobalKey<ScaffoldMessengerState>();
+import 'models/note.dart';
+import 'providers/note_provider.dart';
+import 'services/auth_service.dart';
+import 'services/settings_service.dart';
+import 'services/startup_service.dart';
+import 'app.dart';
+
 late final NoteProvider noteProvider;
 
 Future<void> _onNotificationResponse(NotificationResponse response) async {
@@ -49,27 +39,10 @@ Future<void> _onNotificationResponse(NotificationResponse response) async {
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   noteProvider = NoteProvider();
-  bool authFailed = false;
-  bool notificationFailed = false;
 
-  try {
-    await Firebase.initializeApp(
-      options: DefaultFirebaseOptions.currentPlatform,
-    );
-    await FirebaseAuth.instance.signInAnonymously();
-    await FirebaseCrashlytics.instance.setCrashlyticsCollectionEnabled(true);
-    await FirebaseAnalytics.instance.logAppOpen();
-  } catch (e) {
-    authFailed = true;
-  }
-
-  try {
-    await NotificationService().init(
-      onDidReceiveNotificationResponse: _onNotificationResponse,
-    );
-  } catch (e) {
-    notificationFailed = true;
-  }
+  final startupResult = await StartupService().initialize(
+    onDidReceiveNotificationResponse: _onNotificationResponse,
+  );
 
   final settings = SettingsService();
   final requireAuth = await settings.loadRequireAuth();
@@ -84,7 +57,6 @@ void main() async {
   final themeColor = await settings.loadThemeColor();
   final fontScale = await settings.loadFontScale();
   final themeMode = await settings.loadThemeMode();
-
   final hasSeenOnboarding = await settings.loadHasSeenOnboarding();
 
   runApp(
@@ -93,156 +65,12 @@ void main() async {
       child: MyApp(
         themeColor: themeColor,
         fontScale: fontScale,
-
-        themeMode: await settings.loadThemeMode(),
-
-
+        themeMode: themeMode,
         hasSeenOnboarding: hasSeenOnboarding,
-
-        authFailed: authFailed,
-        notificationFailed: notificationFailed,
+        authFailed: startupResult.authFailed,
+        notificationFailed: startupResult.notificationFailed,
       ),
     ),
   );
-
 }
 
-class MyApp extends StatefulWidget {
-  final Color themeColor;
-  final double fontScale;
-  final ThemeMode themeMode;
-  final bool authFailed;
-  final bool notificationFailed;
-  final bool hasSeenOnboarding;
-  const MyApp({
-    super.key,
-    required this.themeColor,
-    required this.fontScale,
-    required this.themeMode,
-
-    required this.hasSeenOnboarding,
-
-    this.authFailed = false,
-    this.notificationFailed = false,
-  });
-
-
-  @override
-  State<MyApp> createState() => _MyAppState();
-}
-
-class _MyAppState extends State<MyApp> {
-  Color _themeColor = Colors.blue;
-  double _fontScale = 1.0;
-  ThemeMode _themeMode = ThemeMode.system;
-  StreamSubscription<ConnectivityResult>? _connSub;
-  bool _hasSeenOnboarding = true;
-
-  @override
-  void initState() {
-    super.initState();
-    _themeColor = widget.themeColor;
-    _fontScale = widget.fontScale;
-    _themeMode = widget.themeMode;
-
-    _hasSeenOnboarding = widget.hasSeenOnboarding;
-
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      final l10n = AppLocalizations.of(context)!;
-      if (widget.authFailed) {
-        messengerKey.currentState?.showSnackBar(
-          SnackBar(
-            content: Text(l10n.authFailedMessage),
-          ),
-        );
-      }
-      if (widget.notificationFailed) {
-        messengerKey.currentState?.showSnackBar(
-          SnackBar(
-            content: Text(l10n.notificationFailedMessage),
-          ),
-        );
-      }
-    });
-    try {
-      _connSub = Connectivity().onConnectivityChanged.listen((result) {
-        if (result == ConnectivityResult.none) {
-          final l10n = AppLocalizations.of(context)!;
-          messengerKey.currentState?.showSnackBar(
-            SnackBar(
-              content: Text(l10n.noInternetConnection),
-            ),
-          );
-        }
-      });
-    } on MissingPluginException {
-      // Ignore if connectivity plugin is not available (e.g., tests)
-    }
-  }
-
-  void updateTheme(Color newColor) async {
-    setState(() => _themeColor = newColor);
-    await SettingsService().saveThemeColor(newColor);
-  }
-
-  void updateFontScale(double newScale) async {
-    setState(() => _fontScale = newScale);
-    await SettingsService().saveFontScale(newScale);
-  }
-
-  void updateThemeMode(ThemeMode newMode) async {
-    setState(() => _themeMode = newMode);
-    await SettingsService().saveThemeMode(newMode);
-  }
-
-
-  void _completeOnboarding() {
-    setState(() => _hasSeenOnboarding = true);
-
-  }
-
-  @override
-  void dispose() {
-    _connSub?.cancel();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      scaffoldMessengerKey: messengerKey,
-      onGenerateTitle: (context) => AppLocalizations.of(context)!.appTitle,
-      localizationsDelegates: const [
-        AppLocalizations.delegate,
-        GlobalMaterialLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-      ],
-      supportedLocales: const [Locale('en'), Locale('vi')],
-      theme: ThemeData(
-        colorSchemeSeed: _themeColor,
-        useMaterial3: true,
-      ),
-      darkTheme: ThemeData(
-        colorSchemeSeed: _themeColor,
-        brightness: Brightness.dark,
-        useMaterial3: true,
-      ),
-      themeMode: _themeMode,
-      builder: (context, child) => MediaQuery(
-        data: MediaQuery.of(context).copyWith(textScaleFactor: _fontScale),
-        child: child!,
-      ),
-
-      home: _hasSeenOnboarding
-          ? HomeScreen(
-              onThemeChanged: updateTheme,
-              onFontScaleChanged: updateFontScale,
-              onThemeModeChanged: updateThemeMode,
-            )
-          : OnboardingScreen(onFinished: _completeOnboarding),
-
-
-    );
-  }
-}

--- a/lib/services/startup_service.dart
+++ b/lib/services/startup_service.dart
@@ -1,0 +1,53 @@
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:firebase_analytics/firebase_analytics.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+import '../firebase_options.dart';
+import 'notification_service.dart';
+
+class StartupResult {
+  final bool authFailed;
+  final bool notificationFailed;
+
+  const StartupResult({
+    this.authFailed = false,
+    this.notificationFailed = false,
+  });
+}
+
+class StartupService {
+  Future<StartupResult> initialize({
+    Future<void> Function(NotificationResponse)?
+        onDidReceiveNotificationResponse,
+  }) async {
+    bool authFailed = false;
+    bool notificationFailed = false;
+
+    try {
+      await Firebase.initializeApp(
+        options: DefaultFirebaseOptions.currentPlatform,
+      );
+      await FirebaseAuth.instance.signInAnonymously();
+      await FirebaseCrashlytics.instance.setCrashlyticsCollectionEnabled(true);
+      await FirebaseAnalytics.instance.logAppOpen();
+    } catch (_) {
+      authFailed = true;
+    }
+
+    try {
+      await NotificationService().init(
+        onDidReceiveNotificationResponse: onDidReceiveNotificationResponse,
+      );
+    } catch (_) {
+      notificationFailed = true;
+    }
+
+    return StartupResult(
+      authFailed: authFailed,
+      notificationFailed: notificationFailed,
+    );
+  }
+}
+

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:notes_reminder_app/main.dart';
+import 'package:notes_reminder_app/app.dart';
 import 'package:notes_reminder_app/providers/note_provider.dart';
 import 'package:provider/provider.dart';
 


### PR DESCRIPTION
## Summary
- centralize Firebase and notification initialization in a StartupService
- move MyApp widget and messenger key to new app.dart
- update imports and tests for new startup/service structure

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc929255888333a2a7c181e8f02302