### PR TITLE
feat: add new UI widgets

### DIFF
--- a/lib/pandora_ui/tokens.dart
+++ b/lib/pandora_ui/tokens.dart
@@ -40,6 +40,9 @@ class PandoraTokens {
   static const double iconM = 24.0;
   static const double iconL = 32.0;
 
+  // Minimum touch target size
+  static const double touchTarget = 48.0;
+
   // Icons
   static const IconData hintIcon = Icons.lightbulb_outline;
 

--- a/lib/screens/note_list_for_day_screen.dart
+++ b/lib/screens/note_list_for_day_screen.dart
@@ -7,7 +7,7 @@ import '../models/note.dart';
 import '../providers/note_provider.dart';
 import '../services/auth_service.dart';
 import 'note_detail_screen.dart';
-import '../pandora_ui/hint_chip.dart';
+import '../widgets/hint_chip.dart';
 import '../pandora_ui/result_card.dart';
 
 class NoteListForDayScreen extends StatelessWidget {

--- a/lib/widgets/hint_chip.dart
+++ b/lib/widgets/hint_chip.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../pandora_ui/tokens.dart';
+
+class _ChipStyle {
+  final Color background;
+  final Color text;
+  final double opacity;
+
+  const _ChipStyle({
+    required this.background,
+    required this.text,
+    required this.opacity,
+  });
+}
+
+const Map<String, _ChipStyle> _chipStyles = {
+  'default': _ChipStyle(
+    background: PandoraTokens.neutral200,
+    text: PandoraTokens.neutral900,
+    opacity: PandoraTokens.opacityDisabled,
+  ),
+  'armed': _ChipStyle(
+    background: PandoraTokens.error,
+    text: PandoraTokens.neutral100,
+    opacity: PandoraTokens.opacityFocus,
+  ),
+  'active': _ChipStyle(
+    background: PandoraTokens.secondary,
+    text: PandoraTokens.neutral100,
+    opacity: PandoraTokens.opacityEnabled,
+  ),
+};
+
+/// Simple chip widget displaying an icon with a label.
+class HintChip extends StatelessWidget {
+  const HintChip({
+    super.key,
+    required this.label,
+    this.icon,
+    this.state = 'default',
+    required this.onPressed,
+    this.style,
+  });
+
+  final String label;
+  final Widget? icon;
+  final String state;
+  final VoidCallback onPressed;
+  final TextStyle? style;
+
+  @override
+  Widget build(BuildContext context) {
+    final _ChipStyle styleData = _chipStyles[state] ?? _chipStyles['default']!;
+
+    return ConstrainedBox(
+      constraints: const BoxConstraints(
+        minHeight: PandoraTokens.touchTarget,
+        minWidth: PandoraTokens.touchTarget,
+      ),
+      child: InkWell(
+        onTap: () {
+          HapticFeedback.selectionClick();
+          onPressed();
+        },
+        borderRadius: BorderRadius.circular(PandoraTokens.radiusM),
+        child: Ink(
+          decoration: BoxDecoration(
+            color: styleData.background.withOpacity(styleData.opacity),
+            borderRadius: BorderRadius.circular(PandoraTokens.radiusM),
+          ),
+          padding: const EdgeInsets.symmetric(
+            horizontal: PandoraTokens.spacingM,
+            vertical: PandoraTokens.spacingS,
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              icon ??
+                  Icon(
+                    PandoraTokens.hintIcon,
+                    size: PandoraTokens.iconS,
+                    color: PandoraTokens.warning,
+                  ),
+              const SizedBox(width: PandoraTokens.spacingM),
+              Text(
+                label,
+                style: (style ??
+                        const TextStyle(
+                          fontSize: PandoraTokens.fontSizeS,
+                          fontFamily: PandoraTokens.fontFamily,
+                        ))
+                    .copyWith(color: styleData.text),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/widgets/notes_list.dart
+++ b/lib/widgets/notes_list.dart
@@ -6,7 +6,7 @@ import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:share_plus/share_plus.dart';
 
 import '../pandora_ui/result_card.dart';
-import '../pandora_ui/toolbar_button.dart';
+import 'toolbar_button.dart';
 
 import '../models/note.dart';
 import '../providers/note_provider.dart';

--- a/lib/widgets/notes_tab.dart
+++ b/lib/widgets/notes_tab.dart
@@ -9,7 +9,7 @@ import '../services/settings_service.dart';
 import '../screens/note_search_delegate.dart';
 import '../screens/voice_to_note_screen.dart';
 import '../screens/settings_screen.dart';
-import '../pandora_ui/toolbar_button.dart';
+import 'toolbar_button.dart';
 import 'add_note_dialog.dart';
 import 'tag_filtered_notes_list.dart';
 

--- a/lib/widgets/palette_list_item.dart
+++ b/lib/widgets/palette_list_item.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../pandora_ui/tokens.dart';
+
+/// List item displaying a color swatch with an optional icon and label.
+class PaletteListItem extends StatelessWidget {
+  const PaletteListItem({
+    super.key,
+    required this.color,
+    required this.label,
+    this.icon,
+    this.state = 'default',
+    this.onTap,
+  });
+
+  final Color color;
+  final String label;
+  final Widget? icon;
+  final String state;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final selected = state == 'selected';
+
+    return ListTile(
+      leading: Container(
+        width: PandoraTokens.iconL,
+        height: PandoraTokens.iconL,
+        decoration: BoxDecoration(
+          color: color,
+          borderRadius: BorderRadius.circular(PandoraTokens.radiusS),
+        ),
+      ),
+      title: Text(label),
+      trailing: icon != null
+          ? IconTheme.merge(
+              data: IconThemeData(
+                color: selected ? PandoraTokens.primary : null,
+              ),
+              child: icon!,
+            )
+          : null,
+      onTap: onTap != null
+          ? () {
+              HapticFeedback.selectionClick();
+              onTap!();
+            }
+          : null,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(PandoraTokens.radiusM),
+      ),
+      contentPadding: const EdgeInsets.symmetric(
+        horizontal: PandoraTokens.spacingM,
+      ),
+      minLeadingWidth: PandoraTokens.touchTarget,
+    );
+  }
+}
+

--- a/lib/widgets/pandora_ui_demo.dart
+++ b/lib/widgets/pandora_ui_demo.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 
 import '../pandora_ui/bottom_sheet.dart';
 import '../pandora_ui/dismissible_wrapper.dart';
-import '../pandora_ui/palette_list_item.dart';
+import 'palette_list_item.dart';
 import '../pandora_ui/result_card.dart';
 import '../pandora_ui/security_cue.dart';
 import '../pandora_ui/teach_ai_modal.dart';

--- a/lib/widgets/toolbar_button.dart
+++ b/lib/widgets/toolbar_button.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../pandora_ui/tokens.dart';
+
+class _ToolbarButtonStyle {
+  final Color background;
+  final Color foreground;
+  final bool enabled;
+
+  const _ToolbarButtonStyle({
+    required this.background,
+    required this.foreground,
+    required this.enabled,
+  });
+}
+
+const Map<String, _ToolbarButtonStyle> _toolbarStyles = {
+  'default': _ToolbarButtonStyle(
+    background: PandoraTokens.primary,
+    foreground: PandoraTokens.neutral100,
+    enabled: true,
+  ),
+  'active': _ToolbarButtonStyle(
+    background: PandoraTokens.secondary,
+    foreground: PandoraTokens.neutral100,
+    enabled: true,
+  ),
+  'disabled': _ToolbarButtonStyle(
+    background: PandoraTokens.neutral300,
+    foreground: PandoraTokens.neutral100,
+    enabled: false,
+  ),
+};
+
+/// Toolbar button with icon and label.
+class ToolbarButton extends StatelessWidget {
+  const ToolbarButton({
+    super.key,
+    required this.icon,
+    required this.label,
+    required this.onPressed,
+    this.state = 'default',
+  });
+
+  final Widget icon;
+  final String label;
+  final VoidCallback onPressed;
+  final String state;
+
+  @override
+  Widget build(BuildContext context) {
+    final style = _toolbarStyles[state] ?? _toolbarStyles['default']!;
+
+    return ConstrainedBox(
+      constraints: const BoxConstraints(
+        minHeight: PandoraTokens.touchTarget,
+        minWidth: PandoraTokens.touchTarget,
+      ),
+      child: ElevatedButton.icon(
+        onPressed: style.enabled
+            ? () {
+                HapticFeedback.selectionClick();
+                onPressed();
+              }
+            : null,
+        icon: icon,
+        label: Text(label),
+        style: ElevatedButton.styleFrom(
+          backgroundColor: style.background,
+          foregroundColor: style.foreground,
+          padding: const EdgeInsets.symmetric(
+            vertical: PandoraTokens.spacingS,
+            horizontal: PandoraTokens.spacingM,
+          ),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(PandoraTokens.radiusM),
+          ),
+          elevation: PandoraTokens.elevationLow,
+          minimumSize: const Size(
+            PandoraTokens.touchTarget,
+            PandoraTokens.touchTarget,
+          ),
+        ),
+      ),
+    );
+  }
+}
+

--- a/test/widgets/toolbar_button_test.dart
+++ b/test/widgets/toolbar_button_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:notes_reminder_app/pandora_ui/toolbar_button.dart';
+import 'package:notes_reminder_app/widgets/toolbar_button.dart';
 import 'package:notes_reminder_app/pandora_ui/tokens.dart';
 
 void main() {
@@ -38,7 +38,7 @@ void main() {
           onPressed: () {
             pressed = true;
           },
-          disabled: true,
+          state: 'disabled',
         ),
       ),
     );
@@ -52,8 +52,8 @@ void main() {
     expect(opacityWidget.opacity, PandoraTokens.opacityDisabled);
 
     final style = button.style!;
-    final shape = style.shape!.resolve({MaterialState.disabled}) as RoundedRectangleBorder;
-    expect(shape.side.color, PandoraTokens.neutral200);
+    final bg = style.backgroundColor!.resolve({MaterialState.disabled});
+    expect(bg, PandoraTokens.neutral300);
 
     await tester.tap(find.byType(ElevatedButton));
     expect(pressed, isFalse);


### PR DESCRIPTION
## Summary
- add touch target token
- implement hint chip, toolbar button, and palette list item widgets with state, icon, and label support
- update imports and tests to use new widgets

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc96a266688333ab864ccfed11d083