### PR TITLE
Add haptic-driven UI widgets with security cues

### DIFF
--- a/lib/models/security_cue.dart
+++ b/lib/models/security_cue.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/services.dart';
+
+/// Describes where data is processed and which haptic feedback to use.
+enum SecurityCue { onDevice, hybrid, cloud }
+
+extension SecurityCueHaptics on SecurityCue {
+  /// Triggers a haptic feedback associated with the security cue.
+  Future<void> triggerHaptic() {
+    switch (this) {
+      case SecurityCue.onDevice:
+        return HapticFeedback.selectionClick();
+      case SecurityCue.hybrid:
+        return HapticFeedback.lightImpact();
+      case SecurityCue.cloud:
+        return HapticFeedback.heavyImpact();
+    }
+  }
+}

--- a/lib/widgets/result_card.dart
+++ b/lib/widgets/result_card.dart
@@ -1,0 +1,95 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../models/security_cue.dart';
+
+/// A card that listens to a [Stream] of text and shows a shimmer while loading.
+class ResultCard extends StatefulWidget {
+  const ResultCard({
+    super.key,
+    required this.resultStream,
+    this.securityCue = SecurityCue.onDevice,
+  });
+
+  final Stream<String> resultStream;
+  final SecurityCue securityCue;
+
+  @override
+  State<ResultCard> createState() => _ResultCardState();
+}
+
+class _ResultCardState extends State<ResultCard>
+    with SingleTickerProviderStateMixin {
+  String? _result;
+  late final AnimationController _controller;
+  StreamSubscription<String>? _sub;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 2),
+    )..repeat();
+    _sub = widget.resultStream.listen((event) {
+      setState(() {
+        _result = (_result ?? '') + event;
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_result == null) {
+      // Show a simple shimmer while waiting for stream data.
+      return AnimatedBuilder(
+        animation: _controller,
+        builder: (context, child) {
+          return Container(
+            height: 60,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(8),
+              gradient: LinearGradient(
+                colors: [
+                  Colors.grey.shade300,
+                  Colors.grey.shade100,
+                  Colors.grey.shade300,
+                ],
+                stops: [
+                  (_controller.value - 0.3).clamp(0.0, 1.0),
+                  _controller.value.clamp(0.0, 1.0),
+                  (_controller.value + 0.3).clamp(0.0, 1.0),
+                ],
+              ),
+            ),
+          );
+        },
+      );
+    }
+
+    return GestureDetector(
+      onTap: () {
+        widget.securityCue.triggerHaptic();
+      },
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 300),
+        curve: const Cubic(0.65, 0, 0.35, 1), // custom easing
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(8),
+          boxShadow: const [BoxShadow(color: Colors.black12, blurRadius: 4)],
+        ),
+        child: Text(_result!),
+      ),
+    );
+  }
+}

--- a/lib/widgets/snackbar.dart
+++ b/lib/widgets/snackbar.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+
+import '../models/security_cue.dart';
+
+/// Simple snackbar that slides in with a custom easing and triggers haptics.
+class SimpleSnackBar extends StatefulWidget {
+  const SimpleSnackBar({
+    super.key,
+    required this.message,
+    this.securityCue = SecurityCue.onDevice,
+    this.curve = Curves.easeOutBack,
+  });
+
+  final String message;
+  final SecurityCue securityCue;
+  final Curve curve;
+
+  @override
+  State<SimpleSnackBar> createState() => _SimpleSnackBarState();
+}
+
+class _SimpleSnackBarState extends State<SimpleSnackBar>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<Offset> _offset;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 300),
+    )..forward();
+    _offset = Tween(
+      begin: const Offset(0, 1),
+      end: Offset.zero,
+    ).animate(CurvedAnimation(parent: _controller, curve: widget.curve));
+    widget.securityCue.triggerHaptic();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SlideTransition(
+      position: _offset,
+      child: Material(
+        color: Colors.black87,
+        borderRadius: BorderRadius.circular(8),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Text(
+            widget.message,
+            style: const TextStyle(color: Colors.white),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Shows the [SimpleSnackBar] using an [Overlay].
+void showSimpleSnackBar(BuildContext context, String message, SecurityCue cue) {
+  final overlay = Overlay.of(context);
+  final entry = OverlayEntry(
+    builder: (_) => Positioned(
+      bottom: 20,
+      left: 20,
+      right: 20,
+      child: SimpleSnackBar(message: message, securityCue: cue),
+    ),
+  );
+  overlay.insert(entry);
+  Future.delayed(const Duration(seconds: 2), () => entry.remove());
+}

--- a/lib/widgets/teach_ai_modal.dart
+++ b/lib/widgets/teach_ai_modal.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+
+import '../models/security_cue.dart';
+
+/// Modal dialog that lets user "teach" the AI with custom easing.
+class TeachAiModal extends StatefulWidget {
+  const TeachAiModal({super.key, this.securityCue = SecurityCue.onDevice});
+
+  final SecurityCue securityCue;
+
+  @override
+  State<TeachAiModal> createState() => _TeachAiModalState();
+}
+
+class _TeachAiModalState extends State<TeachAiModal>
+    with SingleTickerProviderStateMixin {
+  late final TextEditingController _ctrl;
+  late final AnimationController _anim;
+
+  @override
+  void initState() {
+    super.initState();
+    _ctrl = TextEditingController();
+    _anim = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 400),
+    )..forward();
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    _anim.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final curved = CurvedAnimation(parent: _anim, curve: Curves.easeOutQuart);
+    return ScaleTransition(
+      scale: curved,
+      child: AlertDialog(
+        title: const Text('Teach AI'),
+        content: TextField(controller: _ctrl),
+        actions: [
+          TextButton(
+            onPressed: () {
+              widget.securityCue.triggerHaptic();
+              Navigator.pop(context, _ctrl.text);
+            },
+            child: const Text('Send'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/result_card_test.dart
+++ b/test/result_card_test.dart
@@ -1,0 +1,48 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:notes_reminder_app/models/security_cue.dart';
+import 'package:notes_reminder_app/widgets/result_card.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('ResultCard shows stream text and triggers haptic', (
+    tester,
+  ) async {
+    int hapticCalls = 0;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+          if (call.method.startsWith('HapticFeedback')) {
+            hapticCalls++;
+          }
+          return null;
+        });
+
+    final controller = StreamController<String>();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ResultCard(
+          resultStream: controller.stream,
+          securityCue: SecurityCue.onDevice,
+        ),
+      ),
+    );
+
+    // Initially shows shimmer
+    expect(find.byType(AnimatedBuilder), findsWidgets);
+
+    controller.add('hi');
+    await tester.pump();
+    expect(find.text('hi'), findsOneWidget);
+
+    await tester.tap(find.byType(ResultCard));
+    await tester.pump();
+    expect(hapticCalls, greaterThan(0));
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null);
+  });
+}

--- a/test/snackbar_test.dart
+++ b/test/snackbar_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:notes_reminder_app/models/security_cue.dart';
+import 'package:notes_reminder_app/widgets/snackbar.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('SimpleSnackBar shows message and haptic', (tester) async {
+    int hapticCalls = 0;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+          if (call.method.startsWith('HapticFeedback')) {
+            hapticCalls++;
+          }
+          return null;
+        });
+
+    await tester.pumpWidget(
+      const MaterialApp(home: Scaffold(body: SizedBox())),
+    );
+
+    final BuildContext context = tester.element(find.byType(SizedBox));
+    showSimpleSnackBar(context, 'Hello', SecurityCue.hybrid);
+    await tester.pump();
+
+    expect(find.text('Hello'), findsOneWidget);
+    expect(hapticCalls, greaterThan(0));
+
+    // Allow the snackbar's timer to complete.
+    await tester.pump(const Duration(seconds: 3));
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null);
+  });
+}

--- a/test/teach_ai_modal_test.dart
+++ b/test/teach_ai_modal_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:notes_reminder_app/models/security_cue.dart';
+import 'package:notes_reminder_app/widgets/teach_ai_modal.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('TeachAiModal returns input and triggers haptic', (tester) async {
+    int hapticCalls = 0;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+          if (call.method.startsWith('HapticFeedback')) {
+            hapticCalls++;
+          }
+          return null;
+        });
+
+    String? result;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) {
+            return ElevatedButton(
+              onPressed: () async {
+                result = await showDialog<String>(
+                  context: context,
+                  builder: (_) => const TeachAiModal(),
+                );
+              },
+              child: const Text('open'),
+            );
+          },
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), 'foo');
+    await tester.tap(find.text('Send'));
+    await tester.pumpAndSettle();
+
+    expect(result, 'foo');
+    expect(hapticCalls, greaterThan(0));
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null);
+  });
+}


### PR DESCRIPTION
## Summary
- add `SecurityCue` enum linking on-device/hybrid/cloud modes to distinct haptic feedback
- introduce `ResultCard`, `SimpleSnackBar`, and `TeachAiModal` widgets with streaming shimmer, feedback, and custom easing
- cover new widgets with unit tests

## Testing
- `flutter test test/result_card_test.dart test/snackbar_test.dart test/teach_ai_modal_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_68bc96a41a1883339137b42c5af0b92f