### PR TITLE
Add SnackbarKind and enhance PandoraSnackbar transitions

### DIFF
--- a/test/pandora_snackbar_test.dart
+++ b/test/pandora_snackbar_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:notes_reminder_app/pandora_ui/pandora_snackbar.dart';
 import 'package:notes_reminder_app/pandora_ui/tokens.dart';
@@ -28,5 +29,24 @@ void main() {
     final fadeAfter =
         tester.widget<FadeTransition>(find.byType(FadeTransition));
     expect(fadeAfter.opacity.value, 0);
+  });
+
+  testWidgets('has status semantics', (tester) async {
+    final semantics = SemanticsTester(tester);
+
+    await tester.pumpWidget(const MaterialApp(
+      home: Scaffold(
+        body: PandoraSnackbar(
+          text: 'Hello',
+          kind: SnackbarKind.success,
+        ),
+      ),
+    ));
+
+    final node = tester.getSemantics(find.byType(PandoraSnackbar));
+    expect(node.hasFlag(SemanticsFlag.isLiveRegion), isTrue);
+    expect(node.label, 'Hello');
+
+    semantics.dispose();
   });
 }


### PR DESCRIPTION
## Summary
- introduce `SnackbarKind` with icon and color scheme resolution
- refactor `PandoraSnackbar` to use `FadeTransition` and `SlideTransition` and apply semantics role `status`
- test snack bar animations and semantics

## Testing
- `flutter test test/pandora_snackbar_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9a9796948333ad600697750018ad