### PR TITLE
Expand palette list item with icon and selection options

### DIFF
--- a/lib/pandora_ui/palette_list_item.dart
+++ b/lib/pandora_ui/palette_list_item.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'tokens.dart';
 
@@ -8,17 +9,22 @@ class PaletteListItem extends StatelessWidget {
     super.key,
     required this.color,
     required this.label,
+    this.icon,
+    this.state = 'default',
     this.onTap,
   });
 
   final Color color;
   final String label;
+  final Widget? icon;
+  final String state;
   final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
     final baseStyle = Theme.of(context).textTheme.bodyMedium;
     final textColor = baseStyle?.color;
+    final selected = state == 'selected';
     return ListTile(
       leading: Container(
         width: PandoraTokens.iconL,
@@ -29,7 +35,27 @@ class PaletteListItem extends StatelessWidget {
         ),
       ),
       title: Text(label, style: baseStyle?.copyWith(color: textColor)),
-      onTap: onTap,
+      trailing: icon != null
+          ? IconTheme.merge(
+              data: IconThemeData(
+                color: selected ? PandoraTokens.primary : null,
+              ),
+              child: icon!,
+            )
+          : null,
+      onTap: onTap != null
+          ? () {
+              HapticFeedback.selectionClick();
+              onTap!();
+            }
+          : null,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(PandoraTokens.radiusM),
+      ),
+      contentPadding: const EdgeInsets.symmetric(
+        horizontal: PandoraTokens.spacingM,
+      ),
+      minLeadingWidth: PandoraTokens.touchTarget,
     );
   }
 }


### PR DESCRIPTION
## Summary
- integrate upstream palette list item features: optional icon, selection state, haptic tap
- keep token-based sizing and spacing for swatch, radius, padding and touch target

## Testing
- `dart format lib/pandora_ui/palette_list_item.dart` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bce9e39d74833393b67bbc1cabba77