### PR TITLE
Initialize toolbar button tests with Tokens theme

### DIFF
--- a/test/widgets/toolbar_button_test.dart
+++ b/test/widgets/toolbar_button_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:notes_reminder_app/pandora_ui/toolbar_button.dart';
 import 'package:notes_reminder_app/pandora_ui/tokens.dart';
+import 'package:notes_reminder_app/theme/tokens.dart';
 
 void main() {
   testWidgets('ToolbarButton enabled state respects touch target',
@@ -9,6 +10,16 @@ void main() {
     var pressed = false;
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(
+          colorScheme: ColorScheme.fromSeed(
+            seedColor: Tokens.light.colors.primary,
+            background: Tokens.light.colors.background,
+            surface: Tokens.light.colors.surface,
+          ),
+          fontFamily: Tokens.light.typography.fontFamily,
+          useMaterial3: true,
+          extensions: const [Tokens.light],
+        ),
         home: ToolbarButton(
           icon: const Icon(Icons.add),
           label: 'Add',
@@ -34,6 +45,16 @@ void main() {
     var pressed = false;
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(
+          colorScheme: ColorScheme.fromSeed(
+            seedColor: Tokens.light.colors.primary,
+            background: Tokens.light.colors.background,
+            surface: Tokens.light.colors.surface,
+          ),
+          fontFamily: Tokens.light.typography.fontFamily,
+          useMaterial3: true,
+          extensions: const [Tokens.light],
+        ),
         home: ToolbarButton(
           icon: const Icon(Icons.add),
           label: 'Add',


### PR DESCRIPTION
## Summary
- initialize MaterialApp theme in toolbar button tests using Tokens
- keep touch-target size and disabled color assertions

## Testing
- `dart format test/widgets/toolbar_button_test.dart` *(fails: command not found)*
- `flutter test test/widgets/toolbar_button_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bce9e9430c8333bb1f8e0b5f0e74dc