### PR TITLE
Add Pandora UI tokens

### DIFF
--- a/lib/pandora_ui/palette_list_item.dart
+++ b/lib/pandora_ui/palette_list_item.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import '../theme/tokens.dart';
+import 'tokens.dart';
 
 /// Simple list item displaying a color swatch with a label.
 class PaletteListItem extends StatelessWidget {

--- a/lib/pandora_ui/tokens.dart
+++ b/lib/pandora_ui/tokens.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+/// Basic design tokens used by Pandora UI components.
+///
+/// These values mirror the defaults defined in [Tokens] but are
+/// accessible without a BuildContext, for example in tests.
+class PandoraTokens {
+  PandoraTokens._();
+
+  /// Minimum dimension for interactive widgets.
+  static const double touchTarget = 48.0;
+
+  /// Medium spacing value.
+  static const double spacingM = 16.0;
+
+  /// Medium border radius.
+  static const double radiusM = 12.0;
+
+  /// Primary brand color.
+  static const Color primary = Color(0xFF4255FF);
+}


### PR DESCRIPTION
## Summary
- add constants for touch targets, spacing, radius and primary color
- expose PandoraTokens for tests and components

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf04139ec83338ea56085d06a6892