### PR TITLE
feat: localize home screen and teach ai modal

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -24,20 +24,26 @@
   "geminiApiKeyNotConfigured": "Gemini API key is not configured.",
   "noResponse": "No response.",
   "geminiError": "Gemini error: {error}",
-  "geminiError@placeholders": {
-    "error": {}
+  "@geminiError": {
+    "placeholders": {
+      "error": {}
+    }
   },
   "errorWithMessage": "Error: {error}",
-  "errorWithMessage@placeholders": {
-    "error": {}
+  "@errorWithMessage": {
+    "placeholders": {
+      "error": {}
+    }
   },
   "networkError": "Network error. Please try again.",
   "noInternetConnection": "No internet connection.",
   "microphonePermissionMessage": "Microphone permission is required. Please enable it in Settings.",
   "readNote": "Read Note",
   "scheduleForDate": "Schedule for {date}",
-  "scheduleForDate@placeholders": {
-    "date": {}
+  "@scheduleForDate": {
+    "placeholders": {
+      "date": {}
+    }
   },
   "noNotesForDay": "No notes/reminders for this day",
   "addNoteTooltip": "Add note",
@@ -63,8 +69,10 @@
   "repeatDaily": "Daily",
   "repeatWeekly": "Weekly",
   "snoozeLabel": "Snooze: {minutes} min",
-  "snoozeLabel@placeholders": {
-    "minutes": {}
+  "@snoozeLabel": {
+    "placeholders": {
+      "minutes": {}
+    }
   },
   "imageLabel": "Image",
   "audioLabel": "Audio",
@@ -89,8 +97,10 @@
   "speak": "Speak",
   "convertToNote": "Convert to note",
   "convertSpeechPrompt": "Convert the following speech into a note: {recognized}",
-  "convertSpeechPrompt@placeholders": {
-    "recognized": {}
+  "@convertSpeechPrompt": {
+    "placeholders": {
+      "recognized": {}
+    }
   },
   "offlineMode": "Offline Mode",
 
@@ -126,5 +136,15 @@
   "backupNow": "Backup now",
   "syncStatusIdle": "Synced",
   "syncStatusSyncing": "Syncing...",
-  "syncStatusError": "Sync error"
+  "syncStatusError": "Sync error",
+  "showNotes": "Show Notes",
+  "showVoiceToNote": "Show Voice to Note",
+  "openSettings": "Open Settings",
+  "primary": "Primary",
+  "secondary": "Secondary",
+  "themeUpdated": "Theme updated",
+  "thanksForTeaching": "Thanks for teaching!",
+  "notes": "Notes",
+  "reminders": "Reminders",
+  "palette": "Palette"
 }

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -24,20 +24,26 @@
   "geminiApiKeyNotConfigured": "Chưa cấu hình khóa API Gemini.",
   "noResponse": "Không có phản hồi.",
   "geminiError": "Lỗi Gemini: {error}",
-  "geminiError@placeholders": {
-    "error": {}
+  "@geminiError": {
+    "placeholders": {
+      "error": {}
+    }
   },
   "errorWithMessage": "Lỗi: {error}",
-  "errorWithMessage@placeholders": {
-    "error": {}
+  "@errorWithMessage": {
+    "placeholders": {
+      "error": {}
+    }
   },
   "networkError": "Lỗi mạng. Vui lòng thử lại.",
   "noInternetConnection": "Mất kết nối mạng.",
   "microphonePermissionMessage": "Yêu cầu quyền micro. Vui lòng bật trong Cài đặt.",
   "readNote": "Đọc Note",
   "scheduleForDate": "Lịch ngày {date}",
-  "scheduleForDate@placeholders": {
-    "date": {}
+  "@scheduleForDate": {
+    "placeholders": {
+      "date": {}
+    }
   },
   "noNotesForDay": "Không có ghi chú/nhắc lịch cho ngày này",
   "addNoteTooltip": "Thêm ghi chú",
@@ -63,8 +69,10 @@
   "repeatDaily": "Hàng ngày",
   "repeatWeekly": "Hàng tuần",
   "snoozeLabel": "Báo lại: {minutes} phút",
-  "snoozeLabel@placeholders": {
-    "minutes": {}
+  "@snoozeLabel": {
+    "placeholders": {
+      "minutes": {}
+    }
   },
   "imageLabel": "Ảnh",
   "audioLabel": "Âm thanh",
@@ -89,8 +97,10 @@
   "speak": "Nói",
   "convertToNote": "Chuyển thành ghi chú",
   "convertSpeechPrompt": "Chuyển đoạn nói sau thành ghi chú: {recognized}",
-  "convertSpeechPrompt@placeholders": {
-    "recognized": {}
+  "@convertSpeechPrompt": {
+    "placeholders": {
+      "recognized": {}
+    }
   },
   "offlineMode": "Chế độ ngoại tuyến",
 
@@ -126,5 +136,15 @@
   "backupNow": "Sao lưu ngay",
   "syncStatusIdle": "Đã đồng bộ",
   "syncStatusSyncing": "Đang đồng bộ...",
-  "syncStatusError": "Lỗi đồng bộ"
+  "syncStatusError": "Lỗi đồng bộ",
+  "showNotes": "Hiển thị ghi chú",
+  "showVoiceToNote": "Hiển thị Giọng nói thành ghi chú",
+  "openSettings": "Mở cài đặt",
+  "primary": "Màu chính",
+  "secondary": "Màu phụ",
+  "themeUpdated": "Đã cập nhật chủ đề",
+  "thanksForTeaching": "Cảm ơn bạn đã dạy!",
+  "notes": "Ghi chú",
+  "reminders": "Nhắc nhở",
+  "palette": "Bảng màu"
 }

--- a/lib/pandora_ui/pandora_snackbar.dart
+++ b/lib/pandora_ui/pandora_snackbar.dart
@@ -68,6 +68,7 @@ class _PandoraSnackbarState extends State<PandoraSnackbar>
   @override
   Widget build(BuildContext context) {
 
+    final l10n = AppLocalizations.of(context);
     final tokens = Theme.of(context).extension<Tokens>()!;
     Color iconColor;
     if (widget.kind == SnackbarKind.success) {
@@ -103,7 +104,7 @@ class _PandoraSnackbarState extends State<PandoraSnackbar>
               if (widget.onUndo != null)
                 TextButton(
                   onPressed: widget.onUndo,
-                  child: Text(AppLocalizations.of(context)!.undo),
+                  child: Text(l10n?.undo ?? 'Undo'),
                 ),
               IconButton(
                 icon: const Icon(Icons.close),

--- a/lib/pandora_ui/teach_ai_modal.dart
+++ b/lib/pandora_ui/teach_ai_modal.dart
@@ -36,7 +36,7 @@ class _TeachAiModalState extends State<TeachAiModal> {
     return AlertDialog(
 
       contentPadding: EdgeInsets.all(tokens.spacing.m),
-      title: const Text('Teach AI'),
+      title: Text(AppLocalizations.of(context)!.teachAi),
 
       content: TextField(
         controller: _controller,

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -48,6 +48,7 @@ class _HomeScreenState extends State<HomeScreen> {
   @override
   void initState() {
     super.initState();
+    final l10n = AppLocalizations.of(context)!;
     _screens = [
       NotesTab(
         onThemeChanged: widget.onThemeChanged,
@@ -65,15 +66,15 @@ class _HomeScreenState extends State<HomeScreen> {
     ];
     _commands = [
       Command(
-        title: 'Show Notes',
+        title: l10n.showNotes,
         action: () => setState(() => _currentIndex = 0),
       ),
       Command(
-        title: 'Show Voice to Note',
+        title: l10n.showVoiceToNote,
         action: () => setState(() => _currentIndex = 2),
       ),
       Command(
-        title: 'Open Settings',
+        title: l10n.openSettings,
         action: () => setState(() => _currentIndex = 4),
       ),
     ];
@@ -105,6 +106,7 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   void _showPalette() {
+    final l10n = AppLocalizations.of(context)!;
     final tokens = Theme.of(context).extension<Tokens>()!;
     PandoraBottomSheet.show(
       context,
@@ -113,20 +115,20 @@ class _HomeScreenState extends State<HomeScreen> {
         children: [
           PaletteListItem(
             color: tokens.colors.primary,
-            label: 'Primary',
+            label: l10n.primary,
             onTap: () {
               widget.onThemeChanged(tokens.colors.primary);
               Navigator.pop(context);
-              _showSnackbar('Theme updated', SnackbarKind.success);
+              _showSnackbar(l10n.themeUpdated, SnackbarKind.success);
             },
           ),
           PaletteListItem(
             color: tokens.colors.secondary,
-            label: 'Secondary',
+            label: l10n.secondary,
             onTap: () {
               widget.onThemeChanged(tokens.colors.secondary);
               Navigator.pop(context);
-              _showSnackbar('Theme updated', SnackbarKind.success);
+              _showSnackbar(l10n.themeUpdated, SnackbarKind.success);
             },
           ),
         ],
@@ -135,9 +137,10 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   void _openTeachAi() {
+    final l10n = AppLocalizations.of(context)!;
     TeachAiModal.show(
       context,
-      onSubmit: (_) => _showSnackbar('Thanks for teaching!', SnackbarKind.success),
+      onSubmit: (_) => _showSnackbar(l10n.thanksForTeaching, SnackbarKind.success),
     );
   }
 
@@ -162,12 +165,12 @@ class _HomeScreenState extends State<HomeScreen> {
                     children: [
                       ToolbarButton(
                         icon: const Icon(Icons.note),
-                        label: 'Notes',
+                        label: l10n.notes,
                         onPressed: () => setState(() => _currentIndex = 0),
                       ),
                       ToolbarButton(
                         icon: const Icon(Icons.alarm),
-                        label: 'Reminders',
+                        label: l10n.reminders,
                         onPressed: () => setState(() => _currentIndex = 1),
                       ),
                       ToolbarButton(
@@ -187,12 +190,12 @@ class _HomeScreenState extends State<HomeScreen> {
                       ),
                       ToolbarButton(
                         icon: const Icon(Icons.palette),
-                        label: 'Palette',
+                        label: l10n.palette,
                         onPressed: _showPalette,
                       ),
                       ToolbarButton(
                         icon: const Icon(Icons.school),
-                        label: 'Teach AI',
+                        label: l10n.teachAi,
                         onPressed: _openTeachAi,
                       ),
                     ],

--- a/lib/widgets/teach_ai_modal.dart
+++ b/lib/widgets/teach_ai_modal.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import '../models/security_cue.dart';
 
@@ -40,7 +41,7 @@ class _TeachAiModalState extends State<TeachAiModal>
     return ScaleTransition(
       scale: curved,
       child: AlertDialog(
-        title: const Text('Teach AI'),
+        title: Text(AppLocalizations.of(context)!.teachAi),
         content: TextField(controller: _ctrl),
         actions: [
           TextButton(
@@ -48,7 +49,7 @@ class _TeachAiModalState extends State<TeachAiModal>
               widget.securityCue.triggerHaptic();
               Navigator.pop(context, _ctrl.text);
             },
-            child: const Text('Send'),
+            child: Text(AppLocalizations.of(context)!.send),
           ),
         ],
       ),

--- a/test/teach_ai_modal_test.dart
+++ b/test/teach_ai_modal_test.dart
@@ -3,12 +3,14 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:notes_reminder_app/models/security_cue.dart';
 import 'package:notes_reminder_app/widgets/teach_ai_modal.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets('TeachAiModal returns input and triggers haptic', (tester) async {
     int hapticCalls = 0;
+    final l10n = await AppLocalizations.delegate.load(const Locale('en'));
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(SystemChannels.platform, (call) async {
           if (call.method.startsWith('HapticFeedback')) {
@@ -21,6 +23,9 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        locale: const Locale('en'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
         home: Builder(
           builder: (context) {
             return ElevatedButton(
@@ -41,7 +46,7 @@ void main() {
     await tester.pumpAndSettle();
 
     await tester.enterText(find.byType(TextField), 'foo');
-    await tester.tap(find.text('Send'));
+    await tester.tap(find.text(l10n.send));
     await tester.pumpAndSettle();
 
     expect(result, 'foo');


### PR DESCRIPTION
## Summary
- add l10n keys for home screen, palette, and teach AI flow
- replace hardcoded strings with localized values
- update TeachAiModal test for localization

## Testing
- `flutter gen-l10n`
- `flutter test` *(fails: requires Dart SDK >=3.8.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf04f00088333bc26ed479261f4e7