### PR TITLE
Localize home screen commands and toolbar

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -109,8 +109,7 @@
   "datesLabel": "Dates",
   "authFailedMessage": "Anonymous sign-in failed. Limited functionality.",
   "notificationFailedMessage": "Notification setup failed.",
-  "saveNoteFailed": "Failed to save note"
-,
+  "saveNoteFailed": "Failed to save note",
   "hintReady": "Ready",
   "hintArmed": "Armed",
   "hintActive": "Active",
@@ -126,5 +125,14 @@
   "backupNow": "Backup now",
   "syncStatusIdle": "Synced",
   "syncStatusSyncing": "Syncing...",
-  "syncStatusError": "Sync error"
+  "syncStatusError": "Sync error",
+  "showNotes": "Show Notes",
+  "showVoiceToNote": "Show Voice to Note",
+  "openSettings": "Open Settings",
+  "primary": "Primary",
+  "secondary": "Secondary",
+  "themeUpdated": "Theme updated",
+  "notes": "Notes",
+  "reminders": "Reminders",
+  "palette": "Palette"
 }

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -109,8 +109,7 @@
   "datesLabel": "Ngày",
   "authFailedMessage": "Đăng nhập ẩn danh thất bại. Chức năng bị hạn chế.",
   "notificationFailedMessage": "Thiết lập thông báo thất bại.",
-  "saveNoteFailed": "Lưu ghi chú thất bại"
-,
+  "saveNoteFailed": "Lưu ghi chú thất bại",
   "hintReady": "Sẵn sàng",
   "hintArmed": "Đã gài",
   "hintActive": "Đang hoạt động",
@@ -126,5 +125,14 @@
   "backupNow": "Sao lưu ngay",
   "syncStatusIdle": "Đã đồng bộ",
   "syncStatusSyncing": "Đang đồng bộ...",
-  "syncStatusError": "Lỗi đồng bộ"
+  "syncStatusError": "Lỗi đồng bộ",
+  "showNotes": "Hiển thị Ghi chú",
+  "showVoiceToNote": "Hiển thị Giọng nói thành ghi chú",
+  "openSettings": "Mở cài đặt",
+  "primary": "Màu chính",
+  "secondary": "Màu phụ",
+  "themeUpdated": "Đã cập nhật chủ đề",
+  "notes": "Ghi chú",
+  "reminders": "Nhắc nhở",
+  "palette": "Bảng màu"
 }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -43,7 +43,7 @@ class _OpenPaletteIntent extends Intent {
 class _HomeScreenState extends State<HomeScreen> {
   int _currentIndex = 0;
   late final List<Widget> _screens;
-  late final List<Command> _commands;
+  late List<Command> _commands;
 
 
   @override
@@ -64,17 +64,23 @@ class _HomeScreenState extends State<HomeScreen> {
         onThemeModeChanged: widget.onThemeModeChanged,
       ),
     ];
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final l10n = AppLocalizations.of(context)!;
     _commands = [
       Command(
-        title: 'Show Notes',
+        title: l10n.showNotes,
         action: () => setState(() => _currentIndex = 0),
       ),
       Command(
-        title: 'Show Voice to Note',
+        title: l10n.showVoiceToNote,
         action: () => setState(() => _currentIndex = 2),
       ),
       Command(
-        title: 'Open Settings',
+        title: l10n.openSettings,
         action: () => setState(() => _currentIndex = 4),
       ),
     ];
@@ -89,6 +95,7 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   void _showPalette() {
+    final l10n = AppLocalizations.of(context)!;
     final tokens = Theme.of(context).extension<Tokens>()!;
     PandoraBottomSheet.show(
       context,
@@ -97,20 +104,20 @@ class _HomeScreenState extends State<HomeScreen> {
         children: [
           PaletteListItem(
             color: tokens.colors.primary,
-            label: 'Primary',
+            label: l10n.primary,
             onTap: () {
               widget.onThemeChanged(tokens.colors.primary);
               Navigator.pop(context);
-              _showSnackbar('Theme updated');
+              _showSnackbar(l10n.themeUpdated);
             },
           ),
           PaletteListItem(
             color: tokens.colors.secondary,
-            label: 'Secondary',
+            label: l10n.secondary,
             onTap: () {
               widget.onThemeChanged(tokens.colors.secondary);
               Navigator.pop(context);
-              _showSnackbar('Theme updated');
+              _showSnackbar(l10n.themeUpdated);
             },
           ),
         ],
@@ -146,12 +153,12 @@ class _HomeScreenState extends State<HomeScreen> {
                     children: [
                       ToolbarButton(
                         icon: const Icon(Icons.note),
-                        label: 'Notes',
+                        label: l10n.notes,
                         onPressed: () => setState(() => _currentIndex = 0),
                       ),
                       ToolbarButton(
                         icon: const Icon(Icons.alarm),
-                        label: 'Reminders',
+                        label: l10n.reminders,
                         onPressed: () => setState(() => _currentIndex = 1),
                       ),
                       ToolbarButton(
@@ -171,12 +178,12 @@ class _HomeScreenState extends State<HomeScreen> {
                       ),
                       ToolbarButton(
                         icon: const Icon(Icons.palette),
-                        label: 'Palette',
+                        label: l10n.palette,
                         onPressed: _showPalette,
                       ),
                       ToolbarButton(
                         icon: const Icon(Icons.school),
-                        label: 'Teach AI',
+                        label: l10n.teachAi,
                         onPressed: _openTeachAi,
                       ),
                     ],


### PR DESCRIPTION
## Summary
- Replace hard-coded strings on the home screen with `AppLocalizations` entries.
- Add localization keys for commands, palette options, and toolbar labels in English and Vietnamese ARB files.
- Ensure palette and toolbar use localized labels and update snackbar messages.

## Testing
- `flutter gen-l10n` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf9cdea68833381e2a6e92395998a