### PR TITLE
fix: rebuild commands with localization

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -24,20 +24,26 @@
   "geminiApiKeyNotConfigured": "Gemini API key is not configured.",
   "noResponse": "No response.",
   "geminiError": "Gemini error: {error}",
-  "geminiError@placeholders": {
-    "error": {}
+  "@geminiError": {
+    "placeholders": {
+      "error": {}
+    }
   },
   "errorWithMessage": "Error: {error}",
-  "errorWithMessage@placeholders": {
-    "error": {}
+  "@errorWithMessage": {
+    "placeholders": {
+      "error": {}
+    }
   },
   "networkError": "Network error. Please try again.",
   "noInternetConnection": "No internet connection.",
   "microphonePermissionMessage": "Microphone permission is required. Please enable it in Settings.",
   "readNote": "Read Note",
   "scheduleForDate": "Schedule for {date}",
-  "scheduleForDate@placeholders": {
-    "date": {}
+  "@scheduleForDate": {
+    "placeholders": {
+      "date": {}
+    }
   },
   "noNotesForDay": "No notes/reminders for this day",
   "addNoteTooltip": "Add note",
@@ -63,8 +69,10 @@
   "repeatDaily": "Daily",
   "repeatWeekly": "Weekly",
   "snoozeLabel": "Snooze: {minutes} min",
-  "snoozeLabel@placeholders": {
-    "minutes": {}
+  "@snoozeLabel": {
+    "placeholders": {
+      "minutes": {}
+    }
   },
   "imageLabel": "Image",
   "audioLabel": "Audio",
@@ -89,8 +97,10 @@
   "speak": "Speak",
   "convertToNote": "Convert to note",
   "convertSpeechPrompt": "Convert the following speech into a note: {recognized}",
-  "convertSpeechPrompt@placeholders": {
-    "recognized": {}
+  "@convertSpeechPrompt": {
+    "placeholders": {
+      "recognized": {}
+    }
   },
   "offlineMode": "Offline Mode",
 

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -24,20 +24,26 @@
   "geminiApiKeyNotConfigured": "Chưa cấu hình khóa API Gemini.",
   "noResponse": "Không có phản hồi.",
   "geminiError": "Lỗi Gemini: {error}",
-  "geminiError@placeholders": {
-    "error": {}
+  "@geminiError": {
+    "placeholders": {
+      "error": {}
+    }
   },
   "errorWithMessage": "Lỗi: {error}",
-  "errorWithMessage@placeholders": {
-    "error": {}
+  "@errorWithMessage": {
+    "placeholders": {
+      "error": {}
+    }
   },
   "networkError": "Lỗi mạng. Vui lòng thử lại.",
   "noInternetConnection": "Mất kết nối mạng.",
   "microphonePermissionMessage": "Yêu cầu quyền micro. Vui lòng bật trong Cài đặt.",
   "readNote": "Đọc Note",
   "scheduleForDate": "Lịch ngày {date}",
-  "scheduleForDate@placeholders": {
-    "date": {}
+  "@scheduleForDate": {
+    "placeholders": {
+      "date": {}
+    }
   },
   "noNotesForDay": "Không có ghi chú/nhắc lịch cho ngày này",
   "addNoteTooltip": "Thêm ghi chú",
@@ -63,8 +69,10 @@
   "repeatDaily": "Hàng ngày",
   "repeatWeekly": "Hàng tuần",
   "snoozeLabel": "Báo lại: {minutes} phút",
-  "snoozeLabel@placeholders": {
-    "minutes": {}
+  "@snoozeLabel": {
+    "placeholders": {
+      "minutes": {}
+    }
   },
   "imageLabel": "Ảnh",
   "audioLabel": "Âm thanh",
@@ -89,8 +97,10 @@
   "speak": "Nói",
   "convertToNote": "Chuyển thành ghi chú",
   "convertSpeechPrompt": "Chuyển đoạn nói sau thành ghi chú: {recognized}",
-  "convertSpeechPrompt@placeholders": {
-    "recognized": {}
+  "@convertSpeechPrompt": {
+    "placeholders": {
+      "recognized": {}
+    }
   },
   "offlineMode": "Chế độ ngoại tuyến",
 

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -45,6 +45,23 @@ class _HomeScreenState extends State<HomeScreen> {
   late final List<Widget> _screens;
   late List<Command> _commands;
 
+  List<Command> _buildCommands(AppLocalizations l10n) {
+    return [
+      Command(
+        title: l10n.showNotes,
+        action: () => setState(() => _currentIndex = 0),
+      ),
+      Command(
+        title: l10n.showVoiceToNote,
+        action: () => setState(() => _currentIndex = 2),
+      ),
+      Command(
+        title: l10n.openSettings,
+        action: () => setState(() => _currentIndex = 4),
+      ),
+    ];
+  }
+
 
   @override
   void initState() {
@@ -70,20 +87,7 @@ class _HomeScreenState extends State<HomeScreen> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     final l10n = AppLocalizations.of(context)!;
-    _commands = [
-      Command(
-        title: l10n.showNotes,
-        action: () => setState(() => _currentIndex = 0),
-      ),
-      Command(
-        title: l10n.showVoiceToNote,
-        action: () => setState(() => _currentIndex = 2),
-      ),
-      Command(
-        title: l10n.openSettings,
-        action: () => setState(() => _currentIndex = 4),
-      ),
-    ];
+    _commands = _buildCommands(l10n);
   }
 
   void _openPalette() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,15 +54,15 @@ dependencies:
   fuse: ^0.0.99
 
 
-  dev_dependencies:
-    flutter_test:
-      sdk: flutter
-    flutter_lints: ^2.0.0
-    mocktail: ^1.0.4
-    integration_test:
-      sdk: flutter
-    build_runner: ^2.4.6
-    json_serializable: ^6.7.1
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^2.0.0
+  mocktail: ^1.0.4
+  integration_test:
+    sdk: flutter
+  build_runner: ^2.4.6
+  json_serializable: ^6.7.1
 
 flutter:
   generate: true


### PR DESCRIPTION
## Summary
- rebuild `_commands` in `didChangeDependencies` using localized strings
- fix ARB placeholder metadata to use @-prefixed keys
- correct `pubspec.yaml` so dev dependencies are parsed correctly

## Testing
- `flutter gen-l10n --arb-dir=lib/l10n --output-dir=.dart_tool/flutter_gen/gen_l10n`
- `flutter test` *(fails: Couldn't resolve the package 'flutter_gen')*

------
https://chatgpt.com/codex/tasks/task_e_68bd14fdc4cc8333941ef08c05fe2c98