### PR TITLE
feat: bootstrap app with initializer and connectivity service

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,14 +1,11 @@
-import 'dart:async';
-
-import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 
 import 'screens/home_screen.dart';
 import 'screens/onboarding_screen.dart';
 import 'services/settings_service.dart';
+import 'services/connectivity_service.dart';
 import 'theme/tokens.dart';
 
 final messengerKey = GlobalKey<ScaffoldMessengerState>();
@@ -20,12 +17,14 @@ class MyApp extends StatefulWidget {
   final bool authFailed;
   final bool notificationFailed;
   final bool hasSeenOnboarding;
+  final ConnectivityService connectivityService;
   const MyApp({
     super.key,
     required this.themeColor,
     required this.fontScale,
     required this.themeMode,
     required this.hasSeenOnboarding,
+    required this.connectivityService,
     this.authFailed = false,
     this.notificationFailed = false,
   });
@@ -38,7 +37,6 @@ class _MyAppState extends State<MyApp> {
   Color _themeColor = Colors.blue;
   double _fontScale = 1.0;
   ThemeMode _themeMode = ThemeMode.system;
-  StreamSubscription<ConnectivityResult>? _connSub;
   bool _hasSeenOnboarding = true;
 
   @override
@@ -66,20 +64,7 @@ class _MyAppState extends State<MyApp> {
         );
       }
     });
-    try {
-      _connSub = Connectivity().onConnectivityChanged.listen((result) {
-        if (result == ConnectivityResult.none) {
-          final l10n = AppLocalizations.of(context)!;
-          messengerKey.currentState?.showSnackBar(
-            SnackBar(
-              content: Text(l10n.noInternetConnection),
-            ),
-          );
-        }
-      });
-    } on MissingPluginException {
-      // Ignore if connectivity plugin is not available (e.g., tests)
-    }
+    widget.connectivityService.initialize(context, messengerKey);
   }
 
   void updateTheme(Color newColor) async {
@@ -103,7 +88,7 @@ class _MyAppState extends State<MyApp> {
 
   @override
   void dispose() {
-    _connSub?.cancel();
+    widget.connectivityService.dispose();
     super.dispose();
   }
 

--- a/lib/services/app_initializer.dart
+++ b/lib/services/app_initializer.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+import 'auth_service.dart';
+import 'settings_service.dart';
+import 'startup_service.dart';
+
+class AppInitializationData {
+  final Color themeColor;
+  final double fontScale;
+  final ThemeMode themeMode;
+  final bool hasSeenOnboarding;
+  final bool authFailed;
+  final bool notificationFailed;
+
+  const AppInitializationData({
+    required this.themeColor,
+    required this.fontScale,
+    required this.themeMode,
+    required this.hasSeenOnboarding,
+    this.authFailed = false,
+    this.notificationFailed = false,
+  });
+}
+
+class AppInitializer {
+  Future<AppInitializationData?> initialize({
+    Future<void> Function(NotificationResponse)? onDidReceiveNotificationResponse,
+  }) async {
+    final startupResult = await StartupService().initialize(
+      onDidReceiveNotificationResponse: onDidReceiveNotificationResponse,
+    );
+
+    final settings = SettingsService();
+    final requireAuth = await settings.loadRequireAuth();
+    if (requireAuth) {
+      final locale = WidgetsBinding.instance.platformDispatcher.locale;
+      final l10n = await AppLocalizations.delegate.load(locale);
+      final ok = await AuthService().authenticate(l10n);
+      if (!ok) return null;
+    }
+    final themeColor = await settings.loadThemeColor();
+    final fontScale = await settings.loadFontScale();
+    final themeMode = await settings.loadThemeMode();
+    final hasSeenOnboarding = await settings.loadHasSeenOnboarding();
+
+    return AppInitializationData(
+      themeColor: themeColor,
+      fontScale: fontScale,
+      themeMode: themeMode,
+      hasSeenOnboarding: hasSeenOnboarding,
+      authFailed: startupResult.authFailed,
+      notificationFailed: startupResult.notificationFailed,
+    );
+  }
+}

--- a/lib/services/connectivity_service.dart
+++ b/lib/services/connectivity_service.dart
@@ -1,0 +1,31 @@
+import 'dart:async';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+class ConnectivityService {
+  StreamSubscription<ConnectivityResult>? _subscription;
+
+  void initialize(BuildContext context, GlobalKey<ScaffoldMessengerState> messengerKey) {
+    try {
+      _subscription = Connectivity().onConnectivityChanged.listen((result) {
+        if (result == ConnectivityResult.none) {
+          final l10n = AppLocalizations.of(context)!;
+          messengerKey.currentState?.showSnackBar(
+            SnackBar(
+              content: Text(l10n.noInternetConnection),
+            ),
+          );
+        }
+      });
+    } on MissingPluginException {
+      // Ignore if connectivity plugin is not available (e.g., tests)
+    }
+  }
+
+  void dispose() {
+    _subscription?.cancel();
+  }
+}

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -93,4 +93,14 @@ class SettingsService {
       orElse: () => ThemeMode.system,
     );
   }
+
+  Future<void> saveHasSeenOnboarding(bool value) async {
+    final sp = await _sp;
+    await sp.setBool(_kHasSeenOnboarding, value);
+  }
+
+  Future<bool> loadHasSeenOnboarding() async {
+    final sp = await _sp;
+    return sp.getBool(_kHasSeenOnboarding) ?? false;
+  }
 }


### PR DESCRIPTION
## Summary
- add `AppInitializer` to centralize startup, auth, and settings loading
- move connectivity monitoring into `ConnectivityService` and inject into `MyApp`
- load onboarding state via `SettingsService`
- initialize app using `FutureBuilder` before showing `MyApp`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd217d3f148333983a105fb0d28abd