### PR TITLE
chore: add common lint rules

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -22,6 +22,10 @@ linter:
   # producing the lint.
   rules:
     - file_names
+    - prefer_const_constructors
+    - prefer_final_fields
+    - avoid_print
+    - unused_import
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options


### PR DESCRIPTION
## Summary
- enable prefer_const_constructors, prefer_final_fields, avoid_print, unused_import lint rules

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd217fce5c8333a3b2a6f6dfb4bd06