### PR TITLE
chore: cache Flutter dependencies in CI

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -14,6 +14,12 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.pub-cache
+            build
+          key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
       - run: flutter pub get
       - run: flutter analyze
       - run: flutter test


### PR DESCRIPTION
## Summary
- cache pub cache and build outputs in flutter workflow to speed builds

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68bd21805254833384b45f1a26936135