### PR TITLE
chore: pin dependency versions

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -113,6 +113,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.2.1"
+  barcode:
+    dependency: transitive
+    description:
+      name: barcode
+      sha256: "7b6729c37e3b7f34233e2318d866e8c48ddb46c1f7ad01ff7bb2a8de1da2b9f4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.9"
+  bidi:
+    dependency: transitive
+    description:
+      name: bidi
+      sha256: "77f475165e94b261745cf1032c751e2032b8ed92ccb2bf5716036db79320637d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.13"
   boolean_selector:
     dependency: transitive
     description:
@@ -337,6 +353,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.2.1"
+  firebase_analytics:
+    dependency: "direct main"
+    description:
+      name: firebase_analytics
+      sha256: dde9d6a7b69b07551a77cfb913c81c64804f7602b07541328322c321e73f2a0e
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.0.1"
+  firebase_analytics_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_analytics_platform_interface
+      sha256: "4008d82a58edcbedec34a7b39f457eed24181cb9c89782c104828c42e4c859b2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.1"
+  firebase_analytics_web:
+    dependency: transitive
+    description:
+      name: firebase_analytics_web
+      sha256: db2a2e8803f5471a5f89b4abacae95ae27e0644f77526879fb81a2c1abc12b5f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0+1"
   firebase_auth:
     dependency: "direct main"
     description:
@@ -385,6 +425,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
+  firebase_crashlytics:
+    dependency: "direct main"
+    description:
+      name: firebase_crashlytics
+      sha256: f2e175a967712ee1f616ab8843390891a315428ba497ce3d256d4c46f32db6f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.1"
+  firebase_crashlytics_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_crashlytics_platform_interface
+      sha256: b49b90af4a1fd8f30b58abd90af88371969bea51b62838a4f4e737c2098b725e
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.8.12"
   fixnum:
     dependency: transitive
     description:
@@ -543,6 +599,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  fuse:
+    dependency: "direct main"
+    description:
+      name: fuse
+      sha256: d4bec57bec0280ce37957ca8f894dd53f3c8757cdd8f6c0a78f73183d9d54c2c
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.99"
   glob:
     dependency: transitive
     description:
@@ -551,6 +615,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  google_fonts:
+    dependency: "direct main"
+    description:
+      name: google_fonts
+      sha256: b1ac0fe2832c9cc95e5e88b57d627c5e68c223b9657f4b96e1487aa9098c7b82
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.2.1"
   google_identity_services_web:
     dependency: transitive
     description:
@@ -607,6 +679,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
+  home_widget:
+    dependency: "direct main"
+    description:
+      name: home_widget
+      sha256: "29565bfee4b32eaf9e7e8b998d504618b779a74b2b1ac62dd4dac7468e66f1a3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   http:
     dependency: "direct main"
     description:
@@ -631,6 +711,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  image:
+    dependency: transitive
+    description:
+      name: image
+      sha256: "4e973fcf4caae1a4be2fa0a13157aa38a8f9cb049db6529aa00b4d71abc4d928"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.4"
   integration_test:
     dependency: "direct dev"
     description: flutter
@@ -836,6 +924,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_parsing:
+    dependency: transitive
+    description:
+      name: path_parsing
+      sha256: "883402936929eac138ee0a45da5b0f2c80f89913e6dc3bf77eb65b84b409c6ca"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   path_provider:
     dependency: "direct main"
     description:
@@ -884,6 +980,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  pdf:
+    dependency: "direct main"
+    description:
+      name: pdf
+      sha256: "28eacad99bffcce2e05bba24e50153890ad0255294f4dd78a17075a2ba5c8416"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.11.3"
   pedantic:
     dependency: transitive
     description:
@@ -972,6 +1076,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  qr:
+    dependency: transitive
+    description:
+      name: qr
+      sha256: "5a1d2586170e172b8a8c8470bbbffd5eb0cd38a66c0d77155ea138d3af3a4445"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
   share_plus:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,58 +11,58 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
-  flutter_local_notifications: ^19.4.1
-  timezone: ^0.10.1
-  flutter_native_timezone: ^2.0.0
-  lottie: ^3.3.1
-  http: ^1.1.0
+  flutter_local_notifications: 19.4.1
+  timezone: 0.10.1
+  flutter_native_timezone: 2.0.0
+  lottie: 3.3.1
+  http: 1.5.0
 
-  shared_preferences: ^2.3.2
-  audioplayers: ^6.5.0
-  intl: ^0.20.2
-  provider: ^6.1.2
-  flutter_tts: ^4.2.3
-  speech_to_text: ^7.3.0
-  share_plus: ^10.0.2
-  connectivity_plus: ^6.1.5
+  shared_preferences: 2.5.3
+  audioplayers: 6.5.0
+  intl: 0.20.2
+  provider: 6.1.5+1
+  flutter_tts: 4.2.3
+  speech_to_text: 7.3.0
+  share_plus: 10.1.4
+  connectivity_plus: 6.1.5
 
-  home_widget: ^0.5.0
+  home_widget: 0.5.0
 
 
-  local_auth: ^2.1.7
+  local_auth: 2.3.0
 
-  cryptography: ^2.7.0
-  encrypt: ^5.0.1
-  flutter_secure_storage: ^9.0.0
-  file_picker: ^6.1.1
-  pdf: ^3.10.5
+  cryptography: 2.7.0
+  encrypt: 5.0.3
+  flutter_secure_storage: 9.2.4
+  file_picker: 6.2.1
+  pdf: 3.11.3
 
-  path_provider: ^2.1.5
+  path_provider: 2.1.5
 
-  json_annotation: ^4.8.1
+  json_annotation: 4.9.0
 
-  firebase_core: ^4.1.0
-  cloud_firestore: ^6.0.1
-  firebase_auth: ^6.0.2
+  firebase_core: 4.1.0
+  cloud_firestore: 6.0.1
+  firebase_auth: 6.0.2
 
-  firebase_crashlytics: ^5.0.1
-  firebase_analytics: ^12.0.1
+  firebase_crashlytics: 5.0.1
+  firebase_analytics: 12.0.1
 
-  google_sign_in: ^6.2.1
-  uuid: ^4.5.1
-  google_fonts: ^6.2.1
-  fuse: ^0.0.99
+  google_sign_in: 6.3.0
+  uuid: 4.5.1
+  google_fonts: 6.2.1
+  fuse: 0.0.99
 
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.0
-  mocktail: ^1.0.4
+  flutter_lints: 2.0.3
+  mocktail: 1.0.4
   integration_test:
     sdk: flutter
-  build_runner: ^2.4.6
-  json_serializable: ^6.7.1
+  build_runner: 2.8.0
+  json_serializable: 6.11.1
 
 flutter:
   generate: true


### PR DESCRIPTION
## Summary
- replace caret versions in `pubspec.yaml` with exact versions and update `pubspec.lock`

## Testing
- `flutter --no-version-check pub get`
- `flutter --no-version-check test` *(fails: compilation errors in db_service.dart & missing googleapis package)*

------
https://chatgpt.com/codex/tasks/task_e_68bd21d6107483338cb20217febea64e