### PR TITLE
chore: lower Dart SDK constraint

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ">=3.8.0 <4.0.0"
+  sdk: ">=3.3.0 <4.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Summary
- relax Dart SDK requirement to >=3.3.0 <4.0.0

## Testing
- `flutter pub get` *(fails: /workspace/flutter/bin/flutter: line 62: /workspace/flutter/bin/internal/shared.sh: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bd21d62ea08333b788254f74227bb0