### PR TITLE
Add PR workflow for debug APK build

### DIFF
--- a/.github/workflows/pr-debug-build.yml
+++ b/.github/workflows/pr-debug-build.yml
@@ -1,0 +1,37 @@
+name: PR Debug Build
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - name: Cache pub packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+      - name: Cache Android SDK
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.android
+            /usr/local/lib/android/sdk
+          key: ${{ runner.os }}-android-${{ hashFiles('android/**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-android-
+      - run: flutter pub get
+      - run: flutter build apk --debug


### PR DESCRIPTION
## Summary
- run flutter pub get and debug APK build on every PR
- cache pub packages and Android SDK to speed CI

## Testing
- `python - <<'PY'
import yaml
with open('.github/workflows/pr-debug-build.yml') as f:
    yaml.safe_load(f)
print('YAML OK')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68bd21d762b483338b31274a3a61a737