### PR TITLE
chore(ci): add codecov coverage reporting

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -23,4 +23,9 @@ jobs:
       - run: flutter pub get
       - run: flutter analyze
       - run: flutter test
+      - run: flutter test --coverage
+      - uses: codecov/codecov-action@v3
+        with:
+          file: coverage/lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
       - run: flutter build apk


### PR DESCRIPTION
## Summary
- run tests with coverage and upload report to Codecov

## Testing
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2699db388333a45d0929966fa65b