### PR TITLE
Refactor route transitions with reusable slide-fade builder

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -7,6 +7,7 @@ import 'screens/onboarding_screen.dart';
 import 'services/settings_service.dart';
 import 'services/connectivity_service.dart';
 import 'theme/tokens.dart';
+import 'widgets/route_transitions.dart';
 
 final messengerKey = GlobalKey<ScaffoldMessengerState>();
 
@@ -113,6 +114,16 @@ class _MyAppState extends State<MyApp> {
         fontFamily: Tokens.light.typography.fontFamily,
         useMaterial3: true,
         extensions: const [Tokens.light],
+        pageTransitionsTheme: const PageTransitionsTheme(
+          builders: {
+            TargetPlatform.android: SlideFadePageTransitionsBuilder(),
+            TargetPlatform.iOS: SlideFadePageTransitionsBuilder(),
+            TargetPlatform.linux: SlideFadePageTransitionsBuilder(),
+            TargetPlatform.macOS: SlideFadePageTransitionsBuilder(),
+            TargetPlatform.windows: SlideFadePageTransitionsBuilder(),
+            TargetPlatform.fuchsia: SlideFadePageTransitionsBuilder(),
+          },
+        ),
       ),
       darkTheme: ThemeData(
         colorScheme: ColorScheme.fromSeed(
@@ -124,6 +135,16 @@ class _MyAppState extends State<MyApp> {
         fontFamily: Tokens.dark.typography.fontFamily,
         useMaterial3: true,
         extensions: const [Tokens.dark],
+        pageTransitionsTheme: const PageTransitionsTheme(
+          builders: {
+            TargetPlatform.android: SlideFadePageTransitionsBuilder(),
+            TargetPlatform.iOS: SlideFadePageTransitionsBuilder(),
+            TargetPlatform.linux: SlideFadePageTransitionsBuilder(),
+            TargetPlatform.macOS: SlideFadePageTransitionsBuilder(),
+            TargetPlatform.windows: SlideFadePageTransitionsBuilder(),
+            TargetPlatform.fuchsia: SlideFadePageTransitionsBuilder(),
+          },
+        ),
       ),
       themeMode: _themeMode,
       builder: (context, child) => MediaQuery(

--- a/lib/screens/note_detail_screen.dart
+++ b/lib/screens/note_detail_screen.dart
@@ -16,6 +16,7 @@ import '../widgets/attachment_section.dart';
 import '../widgets/reminder_controls.dart';
 import '../widgets/ai_suggestions_dialog.dart';
 import 'chat_screen.dart';
+import '../widgets/route_transitions.dart';
 
 class NoteDetailScreen extends StatefulWidget {
   final Note note;
@@ -218,22 +219,8 @@ class _NoteDetailScreenState extends State<NoteDetailScreen> {
               onPressed: () {
                 Navigator.push(
                   context,
-                  PageRouteBuilder(
-                    pageBuilder: (_, __, ___) =>
-                        ChatScreen(initialMessage: _contentCtrl.text),
-                    transitionsBuilder: (_, animation, __, child) {
-                      final offsetAnimation = Tween<Offset>(
-                        begin: const Offset(1, 0),
-                        end: Offset.zero,
-                      ).animate(animation);
-                      return FadeTransition(
-                        opacity: animation,
-                        child: SlideTransition(
-                          position: offsetAnimation,
-                          child: child,
-                        ),
-                      );
-                    },
+                  buildSlideFadeRoute(
+                    ChatScreen(initialMessage: _contentCtrl.text),
                   ),
                 );
               },

--- a/lib/screens/note_list_for_day_screen.dart
+++ b/lib/screens/note_list_for_day_screen.dart
@@ -9,6 +9,7 @@ import '../services/auth_service.dart';
 import 'note_detail_screen.dart';
 import '../pandora_ui/hint_chip.dart';
 import '../pandora_ui/result_card.dart';
+import '../widgets/route_transitions.dart';
 
 class NoteListForDayScreen extends StatelessWidget {
   final DateTime date;
@@ -98,22 +99,7 @@ class NoteListForDayScreen extends StatelessWidget {
                 }
                 Navigator.push(
                   context,
-                  PageRouteBuilder(
-                    pageBuilder: (_, __, ___) => NoteDetailScreen(note: note),
-                    transitionsBuilder: (_, animation, __, child) {
-                      final offsetAnimation = Tween<Offset>(
-                        begin: const Offset(1, 0),
-                        end: Offset.zero,
-                      ).animate(animation);
-                      return FadeTransition(
-                        opacity: animation,
-                        child: SlideTransition(
-                          position: offsetAnimation,
-                          child: child,
-                        ),
-                      );
-                    },
-                  ),
+                  buildSlideFadeRoute(NoteDetailScreen(note: note)),
                 );
               },
             ),

--- a/lib/screens/note_search_delegate.dart
+++ b/lib/screens/note_search_delegate.dart
@@ -3,6 +3,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import '../models/note.dart';
 import 'note_detail_screen.dart';
 import '../services/auth_service.dart';
+import '../widgets/route_transitions.dart';
 
 class NoteSearchDelegate extends SearchDelegate {
   final List<Note> notes;
@@ -61,22 +62,7 @@ class NoteSearchDelegate extends SearchDelegate {
                   }
                   Navigator.push(
                     context,
-                    PageRouteBuilder(
-                      pageBuilder: (_, __, ___) => NoteDetailScreen(note: n),
-                      transitionsBuilder: (_, animation, __, child) {
-                        final offsetAnimation = Tween<Offset>(
-                          begin: const Offset(1, 0),
-                          end: Offset.zero,
-                        ).animate(animation);
-                        return FadeTransition(
-                          opacity: animation,
-                          child: SlideTransition(
-                            position: offsetAnimation,
-                            child: child,
-                          ),
-                        );
-                      },
-                    ),
+                    buildSlideFadeRoute(NoteDetailScreen(note: n)),
                   );
                 },
               ))

--- a/lib/widgets/notes_list.dart
+++ b/lib/widgets/notes_list.dart
@@ -7,6 +7,7 @@ import 'package:share_plus/share_plus.dart';
 
 import '../pandora_ui/result_card.dart';
 import '../pandora_ui/toolbar_button.dart';
+import 'route_transitions.dart';
 
 import '../models/note.dart';
 import '../providers/note_provider.dart';
@@ -137,22 +138,7 @@ class _NotesListState extends State<NotesList> {
               }
               Navigator.push(
                 context,
-                PageRouteBuilder(
-                  pageBuilder: (_, __, ___) => NoteDetailScreen(note: note),
-                  transitionsBuilder: (_, animation, __, child) {
-                    final offsetAnimation = Tween<Offset>(
-                      begin: const Offset(1, 0),
-                      end: Offset.zero,
-                    ).animate(animation);
-                    return FadeTransition(
-                      opacity: animation,
-                      child: SlideTransition(
-                        position: offsetAnimation,
-                        child: child,
-                      ),
-                    );
-                  },
-                ),
+                buildSlideFadeRoute(NoteDetailScreen(note: note)),
               );
             },
             trailing: Row(

--- a/lib/widgets/notes_tab.dart
+++ b/lib/widgets/notes_tab.dart
@@ -12,6 +12,7 @@ import '../screens/settings_screen.dart';
 import '../pandora_ui/toolbar_button.dart';
 import 'add_note_dialog.dart';
 import 'tag_filtered_notes_list.dart';
+import 'route_transitions.dart';
 
 class NotesTab extends StatefulWidget {
   final Function(Color) onThemeChanged;
@@ -101,22 +102,7 @@ class _NotesTabState extends State<NotesTab> {
             onPressed: () async {
               await Navigator.push(
                 context,
-                PageRouteBuilder(
-                  pageBuilder: (_, __, ___) => const VoiceToNoteScreen(),
-                  transitionsBuilder: (_, animation, __, child) {
-                    final offsetAnimation = Tween<Offset>(
-                      begin: const Offset(1, 0),
-                      end: Offset.zero,
-                    ).animate(animation);
-                    return FadeTransition(
-                      opacity: animation,
-                      child: SlideTransition(
-                        position: offsetAnimation,
-                        child: child,
-                      ),
-                    );
-                  },
-                ),
+                buildSlideFadeRoute(const VoiceToNoteScreen()),
               );
             },
           ),
@@ -126,25 +112,12 @@ class _NotesTabState extends State<NotesTab> {
             onPressed: () async {
               await Navigator.push(
                 context,
-                PageRouteBuilder(
-                  pageBuilder: (_, __, ___) => SettingsScreen(
+                buildSlideFadeRoute(
+                  SettingsScreen(
                     onThemeChanged: widget.onThemeChanged,
                     onFontScaleChanged: widget.onFontScaleChanged,
                     onThemeModeChanged: widget.onThemeModeChanged,
                   ),
-                  transitionsBuilder: (_, animation, __, child) {
-                    final offsetAnimation = Tween<Offset>(
-                      begin: const Offset(1, 0),
-                      end: Offset.zero,
-                    ).animate(animation);
-                    return FadeTransition(
-                      opacity: animation,
-                      child: SlideTransition(
-                        position: offsetAnimation,
-                        child: child,
-                      ),
-                    );
-                  },
                 ),
               );
               _loadMascot();

--- a/lib/widgets/route_transitions.dart
+++ b/lib/widgets/route_transitions.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+
+Route<T> buildSlideFadeRoute<T>(Widget page) {
+  return PageRouteBuilder<T>(
+    pageBuilder: (_, __, ___) => page,
+    transitionsBuilder: (_, animation, __, child) {
+      final offsetAnimation = Tween<Offset>(
+        begin: const Offset(1, 0),
+        end: Offset.zero,
+      ).animate(animation);
+      return FadeTransition(
+        opacity: animation,
+        child: SlideTransition(
+          position: offsetAnimation,
+          child: child,
+        ),
+      );
+    },
+  );
+}
+
+class SlideFadePageTransitionsBuilder extends PageTransitionsBuilder {
+  const SlideFadePageTransitionsBuilder();
+
+  @override
+  Widget buildTransitions<T>(
+    PageRoute<T> route,
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  ) {
+    final offsetAnimation = Tween<Offset>(
+      begin: const Offset(1, 0),
+      end: Offset.zero,
+    ).animate(animation);
+
+    return FadeTransition(
+      opacity: animation,
+      child: SlideTransition(
+        position: offsetAnimation,
+        child: child,
+      ),
+    );
+  }
+}
+

--- a/lib/widgets/tag_filtered_notes_list.dart
+++ b/lib/widgets/tag_filtered_notes_list.dart
@@ -8,6 +8,7 @@ import '../providers/note_provider.dart';
 import '../screens/note_list_for_day_screen.dart';
 import 'notes_list.dart';
 import 'tag_filter_menu.dart';
+import 'route_transitions.dart';
 
 class TagFilteredNotesList extends StatefulWidget {
   const TagFilteredNotesList({super.key});
@@ -63,22 +64,8 @@ class _TagFilteredNotesListState extends State<TagFilteredNotesList> {
                 onTap: () {
                   Navigator.push(
                     context,
-                    PageRouteBuilder(
-                      pageBuilder: (_, __, ___) =>
-                          NoteListForDayScreen(date: d),
-                      transitionsBuilder: (_, animation, __, child) {
-                        final offsetAnimation = Tween<Offset>(
-                          begin: const Offset(1, 0),
-                          end: Offset.zero,
-                        ).animate(animation);
-                        return FadeTransition(
-                          opacity: animation,
-                          child: SlideTransition(
-                            position: offsetAnimation,
-                            child: child,
-                          ),
-                        );
-                      },
+                    buildSlideFadeRoute(
+                      NoteListForDayScreen(date: d),
                     ),
                   );
                 },


### PR DESCRIPTION
## Summary
- add `buildSlideFadeRoute` helper and `SlideFadePageTransitionsBuilder`
- replace inline `PageRouteBuilder` usages with `buildSlideFadeRoute`
- apply slide-fade page transitions globally via `PageTransitionsTheme`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd27daeba483338874b83859e24b2d