### PR TITLE
Use FutureBuilder for mascot loading

### DIFF
--- a/lib/widgets/notes_tab.dart
+++ b/lib/widgets/notes_tab.dart
@@ -30,13 +30,13 @@ class NotesTab extends StatefulWidget {
 }
 
 class _NotesTabState extends State<NotesTab> {
-  String _mascotPath = 'assets/lottie/mascot.json';
+  late Future<String> _mascotFuture;
   static const _platform = MethodChannel('notes_reminder_app/actions');
 
   @override
   void initState() {
     super.initState();
-    _loadMascot();
+    _mascotFuture = _loadMascot();
     _platform.setMethodCallHandler((call) async {
       if (call.method == 'voiceToNote') {
         await Navigator.push(
@@ -49,9 +49,8 @@ class _NotesTabState extends State<NotesTab> {
     });
   }
 
-  Future<void> _loadMascot() async {
-    _mascotPath = await SettingsService().loadMascotPath();
-    if (mounted) setState(() {});
+  Future<String> _loadMascot() async {
+    return SettingsService().loadMascotPath();
   }
 
   void _addNote() {
@@ -147,7 +146,11 @@ class _NotesTabState extends State<NotesTab> {
                   },
                 ),
               );
-              _loadMascot();
+              if (mounted) {
+                setState(() {
+                  _mascotFuture = _loadMascot();
+                });
+              }
             },
           ),
           PopupMenuButton<String>(
@@ -175,7 +178,24 @@ class _NotesTabState extends State<NotesTab> {
       body: Column(
         children: [
           const SizedBox(height: 8),
-          SizedBox(width: 140, height: 140, child: Lottie.asset(_mascotPath)),
+          SizedBox(
+            width: 140,
+            height: 140,
+            child: FutureBuilder<String>(
+              future: _mascotFuture,
+              builder: (context, snapshot) {
+                if (snapshot.connectionState != ConnectionState.done ||
+                    !snapshot.hasData) {
+                  return const SizedBox.shrink();
+                }
+                final path = snapshot.data!;
+                if (!path.endsWith('.json')) {
+                  return Image.asset(path);
+                }
+                return RepaintBoundary(child: Lottie.asset(path));
+              },
+            ),
+          ),
           const SizedBox(height: 8),
           const Expanded(child: TagFilteredNotesList()),
         ],


### PR DESCRIPTION
## Summary
- load mascot path with `Future<String>` and display it via `FutureBuilder` to avoid repeated `setState` calls
- wrap animated mascots in `RepaintBoundary` and fall back to a static image if the path isn't a Lottie animation

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd27e22a6c83339db17985aceed6e4