### PR TITLE
Fix ToolbarButton style duplication and add accessibility

### DIFF
--- a/lib/pandora_ui/toolbar_button.dart
+++ b/lib/pandora_ui/toolbar_button.dart
@@ -8,23 +8,6 @@ class _ToolbarButtonStyle {
   final Color foreground;
   final bool enabled;
 
-
-  const _ToolbarButtonStyle({
-    required this.background,
-    required this.foreground,
-    required this.enabled,
-  });
-}
-
-const _touchTarget = 48.0;
-
-class ToolbarButton extends StatelessWidget {
-  final Widget icon;
-  final String label;
-  final VoidCallback onPressed;
-  final String state;
-
-
   const _ToolbarButtonStyle({
     required this.background,
     required this.foreground,
@@ -52,7 +35,7 @@ class ToolbarButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final tokens = Theme.of(context).extension<Tokens>()!;
-    final toolbarStyles = {
+    final toolbarStyles = <String, _ToolbarButtonStyle>{
       'default': _ToolbarButtonStyle(
         background: tokens.colors.primary,
         foreground: tokens.colors.neutral100,
@@ -72,58 +55,42 @@ class ToolbarButton extends StatelessWidget {
 
     final style = toolbarStyles[state] ?? toolbarStyles['default']!;
 
-
-    final toolbarStyles = {
-      'default': _ToolbarButtonStyle(
-        background: tokens.colors.primary,
-        foreground: tokens.colors.neutral100,
-        enabled: true,
-      ),
-      'active': _ToolbarButtonStyle(
-        background: tokens.colors.secondary,
-        foreground: tokens.colors.neutral100,
-        enabled: true,
-      ),
-      'disabled': _ToolbarButtonStyle(
-        background: tokens.colors.neutral300,
-        foreground: tokens.colors.neutral100,
-        enabled: false,
-      ),
-    };
-
-    final style = toolbarStyles[state] ?? toolbarStyles['default']!;
-
-
-    return ConstrainedBox(
-      constraints: const BoxConstraints(
-        minHeight: _touchTarget,
-        minWidth: _touchTarget,
-      ),
-      child: ElevatedButton.icon(
-        onPressed: style.enabled
-            ? () {
-                HapticFeedback.selectionClick();
-                onPressed();
-              }
-            : null,
-        icon: icon,
-
-        label: Text(label),
-
-        style: ElevatedButton.styleFrom(
-          backgroundColor: style.background,
-          foregroundColor: style.foreground,
-          padding: EdgeInsets.symmetric(
-            vertical: tokens.spacing.s,
-            horizontal: tokens.spacing.m,
+    return Semantics(
+      button: true,
+      enabled: style.enabled,
+      label: label,
+      child: Tooltip(
+        message: label,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(
+            minHeight: _touchTarget,
+            minWidth: _touchTarget,
           ),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(tokens.radii.m),
+          child: ElevatedButton.icon(
+            onPressed: style.enabled
+                ? () {
+                    HapticFeedback.selectionClick();
+                    onPressed();
+                  }
+                : null,
+            icon: icon,
+            label: Text(label),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: style.background,
+              foregroundColor: style.foreground,
+              padding: EdgeInsets.symmetric(
+                vertical: tokens.spacing.s,
+                horizontal: tokens.spacing.m,
+              ),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(tokens.radii.m),
+              ),
+              elevation: tokens.elevation.low,
+            ),
           ),
-          elevation: tokens.elevation.low,
-
         ),
       ),
     );
   }
 }
+

--- a/test/pandora_ui/toolbar_button_test.dart
+++ b/test/pandora_ui/toolbar_button_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/rendering.dart';
 
 import 'package:notes_reminder_app/pandora_ui/toolbar_button.dart';
 import 'package:notes_reminder_app/theme/tokens.dart';
@@ -64,5 +65,33 @@ void main() {
       SystemChannels.platform,
       null,
     );
+  });
+
+  testWidgets('ToolbarButton shows tooltip and disabled state prevents taps',
+      (WidgetTester tester) async {
+    var pressed = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(extensions: const [Tokens.light]),
+        home: Scaffold(
+          body: ToolbarButton(
+            icon: const Icon(Icons.add),
+            label: 'Add',
+            onPressed: () {
+              pressed = true;
+            },
+            state: 'disabled',
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    expect(find.byTooltip('Add'), findsOneWidget);
+
+    await tester.tap(find.byType(ToolbarButton));
+    expect(pressed, isFalse);
+
+    final semantics = tester.getSemantics(find.byType(ToolbarButton));
+    expect(semantics.hasFlag(SemanticsFlag.isEnabled), isFalse);
   });
 }


### PR DESCRIPTION
## Summary
- consolidate ToolbarButton style definitions into a single map
- wrap ToolbarButton with semantics and tooltip for screen reader support
- add widget test for disabled state and tooltip

## Testing
- `flutter test test/pandora_ui/toolbar_button_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd295b4828833380c92dbad7d13587