### PR TITLE
refactor: replace ResultCard with NoteCard

### DIFF
--- a/lib/widgets/note_card.dart
+++ b/lib/widgets/note_card.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_slidable/flutter_slidable.dart';
+
+/// Simple wrapper for a [Card] that can show slide actions.
+class NoteCard extends StatelessWidget {
+  const NoteCard({
+    super.key,
+    required this.child,
+    this.endActionPane,
+  });
+
+  final Widget child;
+  final ActionPane? endActionPane;
+
+  @override
+  Widget build(BuildContext context) {
+    final card = Card(
+      margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      child: child,
+    );
+    if (endActionPane == null) {
+      return card;
+    }
+    return Slidable(
+      key: key,
+      endActionPane: endActionPane,
+      child: card,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `NoteCard` widget to wrap a `Card` and optional slidable actions
- use `NoteCard` in `NotesList` with share/delete slide actions

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd295c8bf48333b59eabe9cee1875a