### PR TITLE
Enhance voice-to-note UX with mic indicator and validation

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -38,6 +38,7 @@
   "networkError": "Network error. Please try again.",
   "noInternetConnection": "No internet connection.",
   "microphonePermissionMessage": "Microphone permission is required. Please enable it in Settings.",
+  "speechNotRecognizedMessage": "No speech detected. Please try again.",
   "readNote": "Read Note",
   "scheduleForDate": "Schedule for {date}",
   "@scheduleForDate": {

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -38,6 +38,7 @@
   "networkError": "Lỗi mạng. Vui lòng thử lại.",
   "noInternetConnection": "Mất kết nối mạng.",
   "microphonePermissionMessage": "Yêu cầu quyền micro. Vui lòng bật trong Cài đặt.",
+  "speechNotRecognizedMessage": "Không nhận được giọng nói. Vui lòng thử lại.",
   "readNote": "Đọc Note",
   "scheduleForDate": "Lịch ngày {date}",
   "@scheduleForDate": {

--- a/lib/screens/voice_to_note_screen.dart
+++ b/lib/screens/voice_to_note_screen.dart
@@ -55,6 +55,15 @@ class _VoiceToNoteScreenState extends State<VoiceToNoteScreen> {
     } else {
       await widget.speech.stop();
       setState(() => _isListening = false);
+      if (_recognized.isEmpty) {
+        if (!mounted) return;
+        final l10n = AppLocalizations.of(context)!;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(l10n.speechNotRecognizedMessage),
+          ),
+        );
+      }
     }
   }
 
@@ -92,15 +101,25 @@ class _VoiceToNoteScreenState extends State<VoiceToNoteScreen> {
             if (_isProcessing) const CircularProgressIndicator(),
             Row(
               children: [
-                ElevatedButton(
+                ElevatedButton.icon(
                   onPressed: _toggleListening,
-                  child: Text(_isListening
+                  icon: AnimatedSwitcher(
+                    duration: const Duration(milliseconds: 300),
+                    child: Icon(
+                      _isListening ? Icons.mic : Icons.mic_none,
+                      key: ValueKey(_isListening),
+                      color: _isListening ? Colors.red : null,
+                    ),
+                  ),
+                  label: Text(_isListening
                       ? AppLocalizations.of(context)!.stop
                       : AppLocalizations.of(context)!.speak),
                 ),
                 const SizedBox(width: 8),
                 ElevatedButton(
-                  onPressed: _isProcessing ? null : _convertToNote,
+                  onPressed: _isProcessing || _recognized.isEmpty
+                      ? null
+                      : _convertToNote,
                   child: Text(AppLocalizations.of(context)!.convertToNote),
                 ),
               ],

--- a/test/voice_to_note_screen_test.dart
+++ b/test/voice_to_note_screen_test.dart
@@ -40,11 +40,48 @@ void main() {
       );
 
       final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+
+      final convertButtonBefore = tester.widget<ElevatedButton>(
+        find.widgetWithText(ElevatedButton, l10n.convertToNote),
+      );
+      expect(convertButtonBefore.onPressed, isNull);
+
       await tester.tap(find.text(l10n.speak));
       await tester.pump();
 
       expect(find.text('hello'), findsOneWidget);
+
+      final convertButtonAfter = tester.widget<ElevatedButton>(
+        find.widgetWithText(ElevatedButton, l10n.convertToNote),
+      );
+      expect(convertButtonAfter.onPressed, isNotNull);
+
       verify(() => speech.listen(onResult: any(named: 'onResult'))).called(1);
+    });
+
+    testWidgets('shows snackbar when no speech recognized', (tester) async {
+      final speech = MockSpeechToText();
+      when(() => speech.initialize()).thenAnswer((_) async => true);
+      when(() => speech.listen(onResult: any(named: 'onResult')))
+          .thenAnswer((_) async {});
+      when(() => speech.stop()).thenAnswer((_) async {});
+
+      await tester.pumpWidget(
+        MaterialApp(
+          locale: const Locale('en'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: VoiceToNoteScreen(speech: speech),
+        ),
+      );
+
+      final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+      await tester.tap(find.text(l10n.speak));
+      await tester.pump();
+      await tester.tap(find.text(l10n.stop));
+      await tester.pump();
+
+      expect(find.text(l10n.speechNotRecognizedMessage), findsOneWidget);
     });
 
     testWidgets('shows snackbar when permission denied', (tester) async {


### PR DESCRIPTION
## Summary
- Animate microphone icon and change color based on listening state
- Disable convert button when no speech is recognized and notify on empty input
- Add localized strings and tests for new voice recognition behaviors

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd295de10c833394247eda8bfca355