### PR TITLE
Show loader while app initializes

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -50,7 +50,13 @@ void main() {
         ),
         builder: (context, snapshot) {
           if (!snapshot.hasData) {
-            return const SizedBox.shrink();
+            return const MaterialApp(
+              home: Scaffold(
+                body: Center(
+                  child: CircularProgressIndicator(),
+                ),
+              ),
+            );
           }
           final data = snapshot.data!;
           return MyApp(


### PR DESCRIPTION
## Summary
- Replace empty widget with a MaterialApp loader in `FutureBuilder` until initialization completes

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2d08791c833381a24bc83fee47cc