### PR TITLE
Handle auth failure during app initialization

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -50,13 +50,6 @@ class _MyAppState extends State<MyApp> {
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final l10n = AppLocalizations.of(context)!;
-      if (widget.authFailed) {
-        messengerKey.currentState?.showSnackBar(
-          SnackBar(
-            content: Text(l10n.authFailedMessage),
-          ),
-        );
-      }
       if (widget.notificationFailed) {
         messengerKey.currentState?.showSnackBar(
           SnackBar(
@@ -151,13 +144,20 @@ class _MyAppState extends State<MyApp> {
         data: MediaQuery.of(context).copyWith(textScaleFactor: _fontScale),
         child: child!,
       ),
-      home: _hasSeenOnboarding
-          ? HomeScreen(
-              onThemeChanged: updateTheme,
-              onFontScaleChanged: updateFontScale,
-              onThemeModeChanged: updateThemeMode,
+      home: widget.authFailed
+          ? Scaffold(
+              body: Center(
+                child:
+                    Text(AppLocalizations.of(context)!.authFailedMessage),
+              ),
             )
-          : OnboardingScreen(onFinished: _completeOnboarding),
+          : _hasSeenOnboarding
+              ? HomeScreen(
+                  onThemeChanged: updateTheme,
+                  onFontScaleChanged: updateFontScale,
+                  onThemeModeChanged: updateThemeMode,
+                )
+              : OnboardingScreen(onFinished: _completeOnboarding),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -43,7 +43,7 @@ void main() {
   runApp(
     ChangeNotifierProvider.value(
       value: noteProvider,
-      child: FutureBuilder<AppInitializationData?>(
+      child: FutureBuilder<AppInitializationData>(
         future: AppInitializer().initialize(
           onDidReceiveNotificationResponse: (response) =>
               _onNotificationResponse(response, noteProvider),

--- a/lib/services/app_initializer.dart
+++ b/lib/services/app_initializer.dart
@@ -25,7 +25,7 @@ class AppInitializationData {
 }
 
 class AppInitializer {
-  Future<AppInitializationData?> initialize({
+  Future<AppInitializationData> initialize({
     Future<void> Function(NotificationResponse)? onDidReceiveNotificationResponse,
   }) async {
     final startupResult = await StartupService().initialize(
@@ -38,7 +38,20 @@ class AppInitializer {
       final locale = WidgetsBinding.instance.platformDispatcher.locale;
       final l10n = await AppLocalizations.delegate.load(locale);
       final ok = await AuthService().authenticate(l10n);
-      if (!ok) return null;
+      if (!ok) {
+        final themeColor = await settings.loadThemeColor();
+        final fontScale = await settings.loadFontScale();
+        final themeMode = await settings.loadThemeMode();
+        final hasSeenOnboarding = await settings.loadHasSeenOnboarding();
+        return AppInitializationData(
+          themeColor: themeColor,
+          fontScale: fontScale,
+          themeMode: themeMode,
+          hasSeenOnboarding: hasSeenOnboarding,
+          authFailed: true,
+          notificationFailed: startupResult.notificationFailed,
+        );
+      }
     }
     final themeColor = await settings.loadThemeColor();
     final fontScale = await settings.loadFontScale();


### PR DESCRIPTION
## Summary
- Return `AppInitializationData` with `authFailed: true` when user authentication fails and remove nullable initialization
- Expect non-null initialization in `main.dart` and pass auth failure flag to `MyApp`
- Display an authentication failure screen instead of app content when authentication is required and fails

## Testing
- `dart format lib/services/app_initializer.dart lib/main.dart lib/app.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2d092304833394e3da8bdc1af6d0