### PR TITLE
test: add connectivity service test

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -258,7 +258,7 @@ packages:
     source: hosted
     version: "6.1.5"
   connectivity_plus_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: connectivity_plus_platform_interface
       sha256: "42657c1715d48b167930d5f34d00222ac100475f73d10162ddf43e714932f204"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -65,6 +65,7 @@ dev_dependencies:
     sdk: flutter
   build_runner: 2.8.0
   json_serializable: 6.11.1
+  connectivity_plus_platform_interface: 2.0.1
 
 flutter:
   generate: true


### PR DESCRIPTION
## Summary
- add dev dependency to connectivity_plus_platform_interface for testing
- cover ConnectivityService to ensure snackbar shows when offline

## Testing
- `flutter test test/connectivity_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2d09a89883338efa1b73b689ea3a