### PR TITLE
Add error handling to initialization

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'models/note.dart';
 import 'providers/note_provider.dart';
 import 'services/app_initializer.dart';
 import 'services/connectivity_service.dart';
+import 'screens/error_screen.dart';
 
 Future<void> _onNotificationResponse(
   NotificationResponse response,
@@ -49,6 +50,11 @@ void main() {
               _onNotificationResponse(response, noteProvider),
         ),
         builder: (context, snapshot) {
+          if (snapshot.hasError) {
+            return MaterialApp(
+              home: ErrorScreen(onRetry: main),
+            );
+          }
           if (!snapshot.hasData) {
             return const MaterialApp(
               home: Scaffold(

--- a/lib/screens/error_screen.dart
+++ b/lib/screens/error_screen.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+class ErrorScreen extends StatelessWidget {
+  final VoidCallback onRetry;
+
+  const ErrorScreen({super.key, required this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text('An error occurred'),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: onRetry,
+              child: const Text('Retry'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- show a retryable error screen when app initialization fails
- implement `ErrorScreen` widget to display failure and retry button

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68bd31ebfb0c83339e68f5ed0f5f5305