### PR TITLE
Handle connectivity restoration

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -38,6 +38,7 @@
   },
   "networkError": "Network error. Please try again.",
   "noInternetConnection": "No internet connection.",
+  "internetConnectionRestored": "Connection restored.",
   "microphonePermissionMessage": "Microphone permission is required. Please enable it in Settings.",
   "speechNotRecognizedMessage": "No speech detected. Please try again.",
   "readNote": "Read Note",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -38,6 +38,7 @@
   },
   "networkError": "Lỗi mạng. Vui lòng thử lại.",
   "noInternetConnection": "Mất kết nối mạng.",
+  "internetConnectionRestored": "Đã kết nối lại.",
   "microphonePermissionMessage": "Yêu cầu quyền micro. Vui lòng bật trong Cài đặt.",
   "speechNotRecognizedMessage": "Không nhận được giọng nói. Vui lòng thử lại.",
   "readNote": "Đọc Note",

--- a/lib/services/connectivity_service.dart
+++ b/lib/services/connectivity_service.dart
@@ -11,11 +11,17 @@ class ConnectivityService {
   void initialize(BuildContext context, GlobalKey<ScaffoldMessengerState> messengerKey) {
     try {
       _subscription = Connectivity().onConnectivityChanged.listen((result) {
+        final l10n = AppLocalizations.of(context)!;
         if (result == ConnectivityResult.none) {
-          final l10n = AppLocalizations.of(context)!;
           messengerKey.currentState?.showSnackBar(
             SnackBar(
               content: Text(l10n.noInternetConnection),
+            ),
+          );
+        } else {
+          messengerKey.currentState?.showSnackBar(
+            SnackBar(
+              content: Text(l10n.internetConnectionRestored),
             ),
           );
         }

--- a/test/connectivity_service_test.dart
+++ b/test/connectivity_service_test.dart
@@ -51,4 +51,36 @@ void main() {
 
     expect(find.text(l10n.noInternetConnection), findsOneWidget);
   });
+
+  testWidgets('shows SnackBar when connection restored', (tester) async {
+    final fake = FakeConnectivity();
+    ConnectivityPlatform.instance = fake;
+
+    final messengerKey = GlobalKey<ScaffoldMessengerState>();
+
+    await tester.pumpWidget(MaterialApp(
+      locale: const Locale('en'),
+      scaffoldMessengerKey: messengerKey,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Builder(
+        builder: (context) {
+          ConnectivityService().initialize(context, messengerKey);
+          return const Scaffold(body: SizedBox.shrink());
+        },
+      ),
+    ));
+
+    final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+
+    fake.emit(ConnectivityResult.none);
+    await tester.pump();
+
+    messengerKey.currentState!.clearSnackBars();
+
+    fake.emit(ConnectivityResult.wifi);
+    await tester.pump();
+
+    expect(find.text(l10n.internetConnectionRestored), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## Summary
- show SnackBar when device reconnects to the internet
- add English and Vietnamese strings for reconnection notification
- test connectivity restoration SnackBar

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd31ed630083339afedb8099d2b274