### PR TITLE
fix: fallback to default locale for auth

### DIFF
--- a/lib/services/app_initializer.dart
+++ b/lib/services/app_initializer.dart
@@ -36,7 +36,9 @@ class AppInitializer {
     final requireAuth = await settings.loadRequireAuth();
     if (requireAuth) {
       final locale = WidgetsBinding.instance.platformDispatcher.locale;
-      final l10n = await AppLocalizations.delegate.load(locale);
+      final supported = AppLocalizations.delegate.isSupported(locale);
+      final effectiveLocale = supported ? locale : const Locale('en');
+      final l10n = await AppLocalizations.delegate.load(effectiveLocale);
       final ok = await AuthService().authenticate(l10n);
       if (!ok) {
         final themeColor = await settings.loadThemeColor();


### PR DESCRIPTION
## Summary
- guard localization loading with supported locale check

## Testing
- `flutter analyze` *(fails: Building flutter tool... Resolving dependencies...)*
- `flutter test` *(fails: Building flutter tool... Resolving dependencies...)*

------
https://chatgpt.com/codex/tasks/task_e_68bd31ee94d08333ac1184c7da5aaa80