### PR TITLE
refactor: add app providers

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/widgets.dart';
+import 'package:provider/provider.dart';
+
+import 'providers/note_provider.dart';
+
+/// Wraps the given [child] with all application level providers.
+class AppProviders extends StatelessWidget {
+  final Widget child;
+  const AppProviders({super.key, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider<NoteProvider>(
+          create: (_) => NoteProvider(),
+        ),
+        // Additional providers can be added here.
+      ],
+      child: child,
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:provider/provider.dart';
 
 import 'app.dart';
+import 'app_providers.dart';
 import 'models/note.dart';
 import 'providers/note_provider.dart';
 import 'services/app_initializer.dart';
@@ -13,10 +14,12 @@ import 'services/connectivity_service.dart';
 
 Future<void> _onNotificationResponse(
   NotificationResponse response,
-  NoteProvider noteProvider,
 ) async {
   final id = response.payload;
   if (id == null) return;
+  final context = messengerKey.currentContext;
+  if (context == null) return;
+  final noteProvider = context.read<NoteProvider>();
   Note? note;
   try {
     note = noteProvider.notes.firstWhere((n) => n.id == id);
@@ -38,15 +41,11 @@ Future<void> _onNotificationResponse(
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
-  final noteProvider = NoteProvider();
-
   runApp(
-    ChangeNotifierProvider.value(
-      value: noteProvider,
+    AppProviders(
       child: FutureBuilder<AppInitializationData>(
         future: AppInitializer().initialize(
-          onDidReceiveNotificationResponse: (response) =>
-              _onNotificationResponse(response, noteProvider),
+          onDidReceiveNotificationResponse: _onNotificationResponse,
         ),
         builder: (context, snapshot) {
           if (!snapshot.hasData) {


### PR DESCRIPTION
## Summary
- add `AppProviders` widget to centralize provider initialization
- use `AppProviders` in `main.dart` and fetch `NoteProvider` from context

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd31ef19ec8333805ece4c81bb7fd9