### PR TITLE
Use theme colors in TagFilteredNotesList

### DIFF
--- a/lib/widgets/tag_filtered_notes_list.dart
+++ b/lib/widgets/tag_filtered_notes_list.dart
@@ -59,6 +59,7 @@ class _TagFilteredNotesListState extends State<TagFilteredNotesList> {
             itemBuilder: (context, i) {
               final d = weekDays[i];
               final hasNotes = _notesForDay(d, filteredNotes).isNotEmpty;
+              final theme = Theme.of(context);
               return GestureDetector(
                 onTap: () {
                   Navigator.push(
@@ -86,8 +87,10 @@ class _TagFilteredNotesListState extends State<TagFilteredNotesList> {
                   width: 60,
                   margin: const EdgeInsets.all(4),
                   decoration: BoxDecoration(
-                    color: hasNotes ? Colors.orange : Colors.white,
-                    border: Border.all(color: Colors.black),
+                    color: hasNotes
+                        ? theme.colorScheme.secondary
+                        : theme.colorScheme.surface,
+                    border: Border.all(color: theme.colorScheme.onSurface),
                     borderRadius: BorderRadius.circular(8),
                   ),
                   child: Column(

--- a/test/tag_filtered_notes_list_test.dart
+++ b/test/tag_filtered_notes_list_test.dart
@@ -56,4 +56,94 @@ void main() {
     expect(find.text('n1'), findsOneWidget);
     expect(find.text('n2'), findsNothing);
   });
+
+  testWidgets('uses theme colors for day indicators in light theme',
+      (tester) async {
+    final provider = NoteProvider();
+    final now = DateTime.now();
+    await tester.pumpWidget(
+      ChangeNotifierProvider.value(
+        value: provider,
+        child: MaterialApp(
+          locale: const Locale('vi'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          theme: ThemeData.light(),
+          home: const Scaffold(body: TagFilteredNotesList()),
+        ),
+      ),
+    );
+
+    await provider.addNote(
+      Note(
+        id: '1',
+        title: 'n1',
+        content: 'c1',
+        summary: '',
+        actionItems: const [],
+        dates: const [],
+        alarmTime: now,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final ctx = tester.element(find.byType(TagFilteredNotesList));
+    final colorScheme = Theme.of(ctx).colorScheme;
+    final containers = tester
+        .widgetList<Container>(find.byType(Container))
+        .where((c) => c.width == 60 && c.decoration is BoxDecoration)
+        .toList();
+
+    final todayBox = containers.first.decoration as BoxDecoration;
+    final nextDayBox = containers[1].decoration as BoxDecoration;
+
+    expect(todayBox.color, colorScheme.secondary);
+    expect((todayBox.border as Border).top.color, colorScheme.onSurface);
+    expect(nextDayBox.color, colorScheme.surface);
+  });
+
+  testWidgets('uses theme colors for day indicators in dark theme',
+      (tester) async {
+    final provider = NoteProvider();
+    final now = DateTime.now();
+    await tester.pumpWidget(
+      ChangeNotifierProvider.value(
+        value: provider,
+        child: MaterialApp(
+          locale: const Locale('vi'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          theme: ThemeData.dark(),
+          home: const Scaffold(body: TagFilteredNotesList()),
+        ),
+      ),
+    );
+
+    await provider.addNote(
+      Note(
+        id: '1',
+        title: 'n1',
+        content: 'c1',
+        summary: '',
+        actionItems: const [],
+        dates: const [],
+        alarmTime: now,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final ctx = tester.element(find.byType(TagFilteredNotesList));
+    final colorScheme = Theme.of(ctx).colorScheme;
+    final containers = tester
+        .widgetList<Container>(find.byType(Container))
+        .where((c) => c.width == 60 && c.decoration is BoxDecoration)
+        .toList();
+
+    final todayBox = containers.first.decoration as BoxDecoration;
+    final nextDayBox = containers[1].decoration as BoxDecoration;
+
+    expect(todayBox.color, colorScheme.secondary);
+    expect((todayBox.border as Border).top.color, colorScheme.onSurface);
+    expect(nextDayBox.color, colorScheme.surface);
+  });
 }


### PR DESCRIPTION
## Summary
- Replace hardcoded Colors.orange/white/black with Theme colorScheme in TagFilteredNotesList
- Add widget tests validating day indicator colors in light and dark themes

## Testing
- `flutter test test/tag_filtered_notes_list_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd27df831c83338aea36cc3fd852c2