### PR TITLE
Use theme colors for tag-filtered day labels

### DIFF
--- a/lib/widgets/tag_filtered_notes_list.dart
+++ b/lib/widgets/tag_filtered_notes_list.dart
@@ -63,6 +63,9 @@ class _TagFilteredNotesListState extends State<TagFilteredNotesList> {
               final d = weekDays[i];
               final hasNotes = _notesForDay(d, filteredNotes).isNotEmpty;
               final theme = Theme.of(context);
+              final textColor = hasNotes
+                  ? theme.colorScheme.onSecondary
+                  : theme.colorScheme.onSurface;
               return GestureDetector(
                 onTap: () {
                   Navigator.push(
@@ -79,7 +82,7 @@ class _TagFilteredNotesListState extends State<TagFilteredNotesList> {
                     color: hasNotes
                         ? theme.colorScheme.secondary
                         : theme.colorScheme.surface,
-                    border: Border.all(color: theme.colorScheme.onSurface),
+                    border: Border.all(color: textColor),
                     borderRadius: BorderRadius.circular(8),
                   ),
                   child: Column(
@@ -89,8 +92,12 @@ class _TagFilteredNotesListState extends State<TagFilteredNotesList> {
                         DateFormat.E(
                           Localizations.localeOf(context).toString(),
                         ).format(d),
+                        style: TextStyle(color: textColor),
                       ),
-                      Text('${d.day}'),
+                      Text(
+                        '${d.day}',
+                        style: TextStyle(color: textColor),
+                      ),
                     ],
                   ),
                 ),


### PR DESCRIPTION
## Summary
- use Theme color scheme for tag-filtered notes list day labels to adapt to light/dark themes

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd34b93fe48333830a985685e79426