### PR TITLE
Restore ConnectivityPlatform after tests

### DIFF
--- a/test/connectivity_service_test.dart
+++ b/test/connectivity_service_test.dart
@@ -25,6 +25,9 @@ class FakeConnectivity extends ConnectivityPlatform {
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  final original = ConnectivityPlatform.instance;
+  addTearDown(() => ConnectivityPlatform.instance = original);
+
   testWidgets('shows SnackBar when connection lost', (tester) async {
     final fake = FakeConnectivity();
     ConnectivityPlatform.instance = fake;


### PR DESCRIPTION
## Summary
- preserve original `ConnectivityPlatform` instance in connectivity service tests
- reset `ConnectivityPlatform.instance` after each test via `addTearDown`

## Testing
- `flutter test test/connectivity_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3730ad608333951ade7349283b61