### PR TITLE
Handle connectivity status changes

### DIFF
--- a/lib/services/connectivity_service.dart
+++ b/lib/services/connectivity_service.dart
@@ -7,24 +7,28 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class ConnectivityService {
   StreamSubscription<ConnectivityResult>? _subscription;
+  ConnectivityResult? _lastResult;
 
   void initialize(BuildContext context, GlobalKey<ScaffoldMessengerState> messengerKey) {
     try {
       _subscription = Connectivity().onConnectivityChanged.listen((result) {
         final l10n = AppLocalizations.of(context)!;
-        if (result == ConnectivityResult.none) {
-          messengerKey.currentState?.showSnackBar(
-            SnackBar(
-              content: Text(l10n.noInternetConnection),
-            ),
-          );
-        } else {
-          messengerKey.currentState?.showSnackBar(
-            SnackBar(
-              content: Text(l10n.internetConnectionRestored),
-            ),
-          );
+        if (_lastResult != null) {
+          if (_lastResult == ConnectivityResult.none && result != ConnectivityResult.none) {
+            messengerKey.currentState?.showSnackBar(
+              SnackBar(
+                content: Text(l10n.internetConnectionRestored),
+              ),
+            );
+          } else if (_lastResult != ConnectivityResult.none && result == ConnectivityResult.none) {
+            messengerKey.currentState?.showSnackBar(
+              SnackBar(
+                content: Text(l10n.noInternetConnection),
+              ),
+            );
+          }
         }
+        _lastResult = result;
       });
     } on MissingPluginException {
       // Ignore if connectivity plugin is not available (e.g., tests)


### PR DESCRIPTION
## Summary
- track last connectivity status in `ConnectivityService`
- show snackbars only when transitioning between online and offline states

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd372fb8a483338c63e5711975f937