### PR TITLE
Handle unsupported locales when responding to notifications

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,7 +29,9 @@ Future<void> _onNotificationResponse(
   }
   if (note == null) return;
   final locale = WidgetsBinding.instance.platformDispatcher.locale;
-  final l10n = await AppLocalizations.delegate.load(locale);
+  final supported = AppLocalizations.delegate.isSupported(locale);
+  final effectiveLocale = supported ? locale : const Locale('en');
+  final l10n = await AppLocalizations.delegate.load(effectiveLocale);
   if (response.actionId == 'done') {
     await noteProvider.updateNote(
       note.copyWith(alarmTime: null, notificationId: null, active: false),


### PR DESCRIPTION
## Summary
- Guard against unsupported locales when loading localized strings for notification actions

## Testing
- ⚠️ `dart format lib/main.dart` (command not found: dart)
- ⚠️ `flutter test` (command not found: flutter)


------
https://chatgpt.com/codex/tasks/task_e_68bd372fc3c08333896300b8e11ee31d