### PR TITLE
Embed messenger key in app state

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -9,8 +9,6 @@ import 'services/connectivity_service.dart';
 import 'theme/tokens.dart';
 import 'widgets/route_transitions.dart';
 
-final messengerKey = GlobalKey<ScaffoldMessengerState>();
-
 class MyApp extends StatefulWidget {
   final Color themeColor;
   final double fontScale;
@@ -35,6 +33,7 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
+  final messengerKey = GlobalKey<ScaffoldMessengerState>();
   Color _themeColor = Colors.blue;
   double _fontScale = 1.0;
   ThemeMode _themeMode = ThemeMode.system;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,11 +15,10 @@ import 'screens/error_screen.dart';
 
 Future<void> _onNotificationResponse(
   NotificationResponse response,
+  BuildContext context,
 ) async {
   final id = response.payload;
-  if (id == null) return;
-  final context = messengerKey.currentContext;
-  if (context == null) return;
+  if (id == null || !context.mounted) return;
   final noteProvider = context.read<NoteProvider>();
   Note? note;
   try {
@@ -46,7 +45,8 @@ void main() {
     AppProviders(
       child: FutureBuilder<AppInitializationData>(
         future: AppInitializer().initialize(
-          onDidReceiveNotificationResponse: _onNotificationResponse,
+          onDidReceiveNotificationResponse: (response) =>
+              _onNotificationResponse(response, context),
         ),
         builder: (context, snapshot) {
           if (snapshot.hasError) {

--- a/lib/services/connectivity_service.dart
+++ b/lib/services/connectivity_service.dart
@@ -11,6 +11,7 @@ class ConnectivityService {
   void initialize(BuildContext context, GlobalKey<ScaffoldMessengerState> messengerKey) {
     try {
       _subscription = Connectivity().onConnectivityChanged.listen((result) {
+        if (!context.mounted) return;
         final l10n = AppLocalizations.of(context)!;
         if (result == ConnectivityResult.none) {
           messengerKey.currentState?.showSnackBar(


### PR DESCRIPTION
## Summary
- Move scaffold messenger key into MyApp state
- Pass build context to notification response handler
- Guard connectivity updates with context.mounted

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3732dfdc8333b7308f8227f73daf