### PR TITLE
Use theme colors for TagSelector chips

### DIFF
--- a/lib/widgets/tag_selector.dart
+++ b/lib/widgets/tag_selector.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import '../theme/tokens.dart';
 
 class TagSelector extends StatefulWidget {
   final List<String> availableTags;
@@ -63,15 +64,17 @@ class _TagSelectorState extends State<TagSelector> {
       );
     }).toList();
 
+    final tokens = Theme.of(context).extension<Tokens>()!;
+    final scheme = Theme.of(context).colorScheme;
     final colorOptions = <Color>[
-      Colors.white,
-      Colors.red,
-      Colors.orange,
-      Colors.yellow,
-      Colors.green,
-      Colors.blue,
-      Colors.purple,
-      Colors.brown,
+      scheme.background,
+      tokens.colors.primary,
+      tokens.colors.secondary,
+      tokens.colors.error,
+      tokens.colors.warning,
+      tokens.colors.info,
+      tokens.colors.neutral700,
+      tokens.colors.neutral900,
     ];
     final colorChips = colorOptions.map((c) {
       final selected = widget.selectedColor == c.value;

--- a/test/widgets/tag_selector_test.dart
+++ b/test/widgets/tag_selector_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:notes_reminder_app/widgets/tag_selector.dart';
+import 'package:notes_reminder_app/theme/tokens.dart';
+
+void main() {
+  testWidgets('TagSelector uses themed colors in light and dark', (
+    WidgetTester tester,
+  ) async {
+    Future<void> pumpTheme(ThemeData theme) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: theme,
+          home: TagSelector(
+            availableTags: const [],
+            selectedTags: const [],
+            onChanged: (_) {},
+            selectedColor: 0,
+            onColorChanged: (_) {},
+          ),
+        ),
+      );
+    }
+
+    await pumpTheme(ThemeData(extensions: const [Tokens.light]));
+    var context = tester.element(find.byType(TagSelector));
+    var tokens = Theme.of(context).extension<Tokens>()!;
+    var scheme = Theme.of(context).colorScheme;
+    var chips = tester.widgetList<ChoiceChip>(find.byType(ChoiceChip)).toList();
+
+    expect(chips.length, 8);
+    expect(chips[0].selectedColor, scheme.background);
+    expect(chips[1].selectedColor, tokens.colors.primary);
+    expect(chips[2].selectedColor, tokens.colors.secondary);
+    expect(chips[3].selectedColor, tokens.colors.error);
+    expect(chips[4].selectedColor, tokens.colors.warning);
+    expect(chips[5].selectedColor, tokens.colors.info);
+    expect(chips[6].selectedColor, tokens.colors.neutral700);
+    expect(chips[7].selectedColor, tokens.colors.neutral900);
+
+    await pumpTheme(
+      ThemeData(brightness: Brightness.dark, extensions: const [Tokens.dark]),
+    );
+    context = tester.element(find.byType(TagSelector));
+    tokens = Theme.of(context).extension<Tokens>()!;
+    scheme = Theme.of(context).colorScheme;
+    chips = tester.widgetList<ChoiceChip>(find.byType(ChoiceChip)).toList();
+
+    expect(chips[0].selectedColor, scheme.background);
+    expect(chips[1].selectedColor, tokens.colors.primary);
+    expect(chips[2].selectedColor, tokens.colors.secondary);
+    expect(chips[3].selectedColor, tokens.colors.error);
+    expect(chips[4].selectedColor, tokens.colors.warning);
+    expect(chips[5].selectedColor, tokens.colors.info);
+    expect(chips[6].selectedColor, tokens.colors.neutral700);
+    expect(chips[7].selectedColor, tokens.colors.neutral900);
+  });
+}


### PR DESCRIPTION
## Summary
- derive TagSelector color options from current theme
- test TagSelector color options in light and dark themes

## Testing
- `flutter test test/widgets/tag_selector_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3b6187e48333943ba941eef5956e