### PR TITLE
Use theme colors and simplify note deletion

### DIFF
--- a/lib/screens/voice_to_note_screen.dart
+++ b/lib/screens/voice_to_note_screen.dart
@@ -108,7 +108,9 @@ class _VoiceToNoteScreenState extends State<VoiceToNoteScreen> {
                     child: Icon(
                       _isListening ? Icons.mic : Icons.mic_none,
                       key: ValueKey(_isListening),
-                      color: _isListening ? Colors.red : null,
+                      color: _isListening
+                          ? Theme.of(context).colorScheme.error
+                          : null,
                     ),
                   ),
                   label: Text(_isListening

--- a/lib/widgets/notes_list.dart
+++ b/lib/widgets/notes_list.dart
@@ -10,7 +10,6 @@ import '../models/note.dart';
 import '../providers/note_provider.dart';
 import '../screens/note_detail_screen.dart';
 import '../services/auth_service.dart';
-import '../pandora_ui/toolbar_button.dart';
 import 'note_card.dart';
 
 
@@ -96,6 +95,23 @@ class _NotesListState extends State<NotesList> {
     super.dispose();
   }
 
+  void _deleteNote(
+      BuildContext context, Note note, NoteProvider provider, AppLocalizations l10n) {
+    final idx = provider.notes.indexWhere((n) => n.id == note.id);
+    if (idx != -1) {
+      provider.removeNoteAt(idx);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(l10n.noteDeleted),
+          action: SnackBarAction(
+            label: l10n.undo,
+            onPressed: () => provider.addNote(note),
+          ),
+        ),
+      );
+    }
+  }
+
   Widget _buildNoteTile(
       BuildContext context, Note note, NoteProvider provider) {
     final l10n = AppLocalizations.of(context)!;
@@ -116,22 +132,8 @@ class _NotesListState extends State<NotesList> {
             label: l10n.share,
           ),
           SlidableAction(
-            backgroundColor: Colors.red,
-            onPressed: (_) {
-              final idx = provider.notes.indexWhere((n) => n.id == note.id);
-              if (idx != -1) {
-                provider.removeNoteAt(idx);
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(
-                    content: Text(l10n.noteDeleted),
-                    action: SnackBarAction(
-                      label: l10n.undo,
-                      onPressed: () => provider.addNote(note),
-                    ),
-                  ),
-                );
-              }
-            },
+            backgroundColor: Theme.of(context).colorScheme.error,
+            onPressed: (_) => _deleteNote(context, note, provider, l10n),
             icon: Icons.delete,
             label: l10n.delete,
           ),
@@ -221,6 +223,17 @@ class _NotesListState extends State<NotesList> {
                       Share.share('${note.title}\n${note.content}');
                     },
                   ),
+                  ListTile(
+                    leading: Icon(
+                      Icons.delete,
+                      color: Theme.of(context).colorScheme.error,
+                    ),
+                    title: Text(l10n.delete),
+                    onTap: () {
+                      Navigator.pop(ctx);
+                      _deleteNote(context, note, provider, l10n);
+                    },
+                  ),
                 ],
               ),
             ),
@@ -232,20 +245,10 @@ class _NotesListState extends State<NotesList> {
           children: [
             if (note.pinned) const Icon(Icons.push_pin, size: 20),
             if (!provider.isSynced(note.id))
-              const Icon(Icons.sync_problem, color: Colors.orange),
-            ToolbarButton(
-              icon: const Icon(Icons.delete),
-              label: l10n.delete,
-              onPressed: () {
-
-                final idx =
-                    provider.notes.indexWhere((n) => n.id == note.id);
-
-                if (idx != -1) {
-                  provider.removeNoteAt(idx);
-                }
-              },
-            ),
+              Icon(
+                Icons.sync_problem,
+                color: Theme.of(context).colorScheme.tertiary,
+              ),
           ],
         ),
 

--- a/lib/widgets/tag_selector.dart
+++ b/lib/widgets/tag_selector.dart
@@ -43,6 +43,7 @@ class _TagSelectorState extends State<TagSelector> {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     final chips = widget.availableTags.map((t) {
       final selected = widget.selectedTags.contains(t);
       return Padding(
@@ -65,8 +66,8 @@ class _TagSelectorState extends State<TagSelector> {
 
     final colorOptions = <Color>[
       Colors.white,
-      Colors.red,
-      Colors.orange,
+      colorScheme.error,
+      colorScheme.tertiary,
       Colors.yellow,
       Colors.green,
       Colors.blue,


### PR DESCRIPTION
## Summary
- replace hard-coded red and orange with themed error and tertiary colors
- remove trailing delete button from notes list and add delete option to long-press menu
- ensure deletion uses snackbar undo

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3b658a008333bbcecc2a8d877fc1