### PR TITLE
Use theme colors for chat bubbles

### DIFF
--- a/lib/screens/chat_screen.dart
+++ b/lib/screens/chat_screen.dart
@@ -79,7 +79,9 @@ class _ChatScreenState extends State<ChatScreen> {
                   child: Container(
                     padding: const EdgeInsets.all(10),
                     decoration: BoxDecoration(
-                      color: msg.fromUser ? Colors.blue[100] : Colors.grey[300],
+                      color: msg.fromUser
+                          ? Theme.of(context).colorScheme.secondaryContainer
+                          : Theme.of(context).colorScheme.surfaceVariant,
                       borderRadius: BorderRadius.circular(8),
                     ),
                     child: Text(msg.text),


### PR DESCRIPTION
## Summary
- use `colorScheme.secondaryContainer` and `surfaceVariant` for chat message bubbles

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3b618e2c8333b1319ed407414216