### PR TITLE
Move palette and teach AI to app bar

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -10,8 +10,6 @@ import '../models/command.dart';
 import '../pandora_ui/palette_bottom_sheet.dart';
 import '../pandora_ui/teach_ai_modal.dart';
 
-enum _MenuAction { palette, teachAi }
-
 class HomeScreen extends StatefulWidget {
   final Function(Color) onThemeChanged;
   final Function(double) onFontScaleChanged;
@@ -66,27 +64,15 @@ class _HomeScreenState extends State<HomeScreen> {
           return Scaffold(
             appBar: AppBar(
               actions: [
-                PopupMenuButton<_MenuAction>(
-                  onSelected: (value) {
-                    switch (value) {
-                      case _MenuAction.palette:
-                        _showPalette();
-                        break;
-                      case _MenuAction.teachAi:
-                        _openTeachAi();
-                        break;
-                    }
-                  },
-                  itemBuilder: (context) => [
-                    PopupMenuItem(
-                      value: _MenuAction.palette,
-                      child: Text(l10n.palette),
-                    ),
-                    PopupMenuItem(
-                      value: _MenuAction.teachAi,
-                      child: Text(l10n.teachAi),
-                    ),
-                  ],
+                IconButton(
+                  onPressed: _showPalette,
+                  tooltip: l10n.palette,
+                  icon: const Icon(Icons.color_lens),
+                ),
+                IconButton(
+                  onPressed: _openTeachAi,
+                  tooltip: l10n.teachAi,
+                  icon: const Icon(Icons.psychology),
                 ),
               ],
             ),
@@ -137,27 +123,15 @@ class _HomeScreenState extends State<HomeScreen> {
         return Scaffold(
           appBar: AppBar(
             actions: [
-              PopupMenuButton<_MenuAction>(
-                onSelected: (value) {
-                  switch (value) {
-                    case _MenuAction.palette:
-                      _showPalette();
-                      break;
-                    case _MenuAction.teachAi:
-                      _openTeachAi();
-                      break;
-                  }
-                },
-                itemBuilder: (context) => [
-                  PopupMenuItem(
-                    value: _MenuAction.palette,
-                    child: Text(l10n.palette),
-                  ),
-                  PopupMenuItem(
-                    value: _MenuAction.teachAi,
-                    child: Text(l10n.teachAi),
-                  ),
-                ],
+              IconButton(
+                onPressed: _showPalette,
+                tooltip: l10n.palette,
+                icon: const Icon(Icons.color_lens),
+              ),
+              IconButton(
+                onPressed: _openTeachAi,
+                tooltip: l10n.teachAi,
+                icon: const Icon(Icons.psychology),
               ),
             ],
           ),


### PR DESCRIPTION
## Summary
- replace popup menu with Palette and Teach AI icon buttons in HomeScreen app bars
- ensure bottom navigation bar contains only five primary tabs

## Testing
- `dart format lib/screens/home_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bd3ef8c5fc833393ef12a3785707f3