### PR TITLE
feat: localize palette search hint

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -148,6 +148,7 @@
   "notes": "Notes",
   "reminders": "Reminders",
   "palette": "Palette",
+  "searchCommandHint": "Type a command...",
   "onboardingTakeNotes": "Take Notes",
   "onboardingTakeNotesDesc": "Write down your thoughts and ideas.",
   "onboardingSetReminders": "Set Reminders",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -148,6 +148,7 @@
   "notes": "Ghi chú",
   "reminders": "Nhắc nhở",
   "palette": "Bảng màu",
+  "searchCommandHint": "Nhập lệnh...",
   "onboardingTakeNotes": "Ghi chú",
   "onboardingTakeNotesDesc": "Ghi lại suy nghĩ và ý tưởng của bạn.",
   "onboardingSetReminders": "Đặt nhắc nhở",

--- a/lib/pandora_ui/palette_bottom_sheet.dart
+++ b/lib/pandora_ui/palette_bottom_sheet.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:fuse/fuse.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import '../models/command.dart';
 
@@ -49,6 +50,7 @@ class _PaletteBottomSheetState extends State<_PaletteBottomSheet> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
     return SafeArea(
       child: Padding(
         padding: EdgeInsets.only(
@@ -62,8 +64,8 @@ class _PaletteBottomSheetState extends State<_PaletteBottomSheet> {
               child: TextField(
                 autofocus: true,
                 onChanged: _onQueryChanged,
-                decoration: const InputDecoration(
-                  hintText: 'Type a command...',
+                decoration: InputDecoration(
+                  hintText: l10n.searchCommandHint,
                 ),
               ),
             ),


### PR DESCRIPTION
## Summary
- localize palette search hint using AppLocalizations
- add English and Vietnamese translations

## Testing
- `dart format lib/pandora_ui/palette_bottom_sheet.dart` *(fails: command not found: dart)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3ef93c8c8333a6c7fe12f1642db9