### PR TITLE
Refactor TagSelector color palette

### DIFF
--- a/lib/widgets/tag_selector.dart
+++ b/lib/widgets/tag_selector.dart
@@ -44,7 +44,7 @@ class _TagSelectorState extends State<TagSelector> {
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
+    final scheme = Theme.of(context).colorScheme;
     final chips = widget.availableTags.map((t) {
       final selected = widget.selectedTags.contains(t);
       return Padding(
@@ -66,18 +66,15 @@ class _TagSelectorState extends State<TagSelector> {
     }).toList();
 
     final tokens = Theme.of(context).extension<Tokens>()!;
-    final scheme = Theme.of(context).colorScheme;
     final colorOptions = <Color>[
-
-      Colors.white,
-      colorScheme.error,
-      colorScheme.tertiary,
-      Colors.yellow,
-      Colors.green,
-      Colors.blue,
-      Colors.purple,
-      Colors.brown,
-
+      scheme.primary,
+      scheme.secondary,
+      scheme.tertiary,
+      scheme.error,
+      tokens.colors.warning,
+      tokens.colors.info,
+      tokens.colors.neutral700,
+      tokens.colors.neutral300,
     ];
     final colorChips = colorOptions.map((c) {
       final selected = widget.selectedColor == c.value;


### PR DESCRIPTION
## Summary
- derive TagSelector color options from `ColorScheme` and `Tokens` instead of hard-coded `Colors.*`

## Testing
- `dart format lib/widgets/tag_selector.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd40de44cc8333bb2e2ab44dfd8b4c