### PR TITLE
Adapt lock icon color for note background

### DIFF
--- a/lib/widgets/notes_list.dart
+++ b/lib/widgets/notes_list.dart
@@ -128,6 +128,11 @@ class _NotesListState extends State<NotesList> {
     final subtitle = note.alarmTime != null
         ? '${note.content}\n⏰ ${DateFormat.yMd(locale).add_Hm().format(note.alarmTime!)}'
         : note.content;
+    final noteColor = Color(note.color);
+    final lockIconColor =
+        ThemeData.estimateBrightnessForColor(noteColor) == Brightness.dark
+            ? Theme.of(context).colorScheme.onPrimary
+            : Theme.of(context).colorScheme.onSurface;
 
     return NoteCard(
       endActionPane: ActionPane(
@@ -154,10 +159,14 @@ class _NotesListState extends State<NotesList> {
           height: 24,
           decoration: BoxDecoration(
             shape: BoxShape.circle,
-            color: Color(note.color),
+            color: noteColor,
           ),
           child: note.locked
-              ? const Icon(Icons.lock, size: 16, color: Colors.white)
+              ? Icon(
+                  Icons.lock,
+                  size: 16,
+                  color: lockIconColor,
+                )
               : null,
         ),
         title: Text(note.title),


### PR DESCRIPTION
## Summary
- ensure locked note icon uses a color contrasting with its background via brightness-based detection

## Testing
- `dart format lib/widgets/notes_list.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bd40dfa8d0833390f5653a35de97be