### PR TITLE
Refactor connectivity initialization to use localization

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -57,7 +57,7 @@ class _MyAppState extends State<MyApp> {
         );
       }
     });
-    widget.connectivityService.initialize(context, messengerKey);
+    widget.connectivityService.initialize(AppLocalizations.of(context)!, messengerKey);
   }
 
   void updateTheme(Color newColor) async {

--- a/lib/services/connectivity_service.dart
+++ b/lib/services/connectivity_service.dart
@@ -9,11 +9,12 @@ class ConnectivityService {
   StreamSubscription<ConnectivityResult>? _subscription;
   ConnectivityResult? _lastResult;
 
-  void initialize(BuildContext context, GlobalKey<ScaffoldMessengerState> messengerKey) {
+  void initialize(
+    AppLocalizations l10n,
+    GlobalKey<ScaffoldMessengerState> messengerKey,
+  ) {
     try {
       _subscription = Connectivity().onConnectivityChanged.listen((result) {
-        if (!context.mounted) return;
-        final l10n = AppLocalizations.of(context)!;
         if (_lastResult != null) {
           if (_lastResult == ConnectivityResult.none && result != ConnectivityResult.none) {
             messengerKey.currentState?.showSnackBar(


### PR DESCRIPTION
## Summary
- Remove BuildContext dependency from connectivity initialization by passing AppLocalizations directly
- Update MyApp to provide localizations when initializing the ConnectivityService

## Testing
- `dart format lib/services/connectivity_service.dart lib/app.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found; attempted to install Dart/Flutter but packages were unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68bd43b2fee4833386d53db93e1084f8