### PR TITLE
Use theme inverse surface colors in snackbar

### DIFF
--- a/lib/pandora_ui/snackbar.dart
+++ b/lib/pandora_ui/snackbar.dart
@@ -46,16 +46,17 @@ class _SimpleSnackBarState extends State<SimpleSnackBar>
 
   @override
   Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
     return SlideTransition(
       position: _offset,
       child: Material(
-        color: Colors.black87,
+        color: scheme.inverseSurface,
         borderRadius: BorderRadius.circular(8),
         child: Padding(
           padding: const EdgeInsets.all(16),
           child: Text(
             widget.message,
-            style: const TextStyle(color: Colors.white),
+            style: TextStyle(color: scheme.onInverseSurface),
           ),
         ),
       ),


### PR DESCRIPTION
## Summary
- Replace hard-coded black/white colors in `SimpleSnackBar` with `ColorScheme.inverseSurface` and `onInverseSurface` for theme compliance

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd44d08dec8333be95bf9668e951fd