### PR TITLE
Refactor security cue colors to use theme tokens

### DIFF
--- a/lib/pandora_ui/security_cue.dart
+++ b/lib/pandora_ui/security_cue.dart
@@ -26,8 +26,9 @@ class SecurityCue extends StatelessWidget {
     };
 
     final tokens = Theme.of(context).extension<Tokens>()!;
+    final colorScheme = Theme.of(context).colorScheme;
     final color = switch (mode) {
-      SecurityMode.onDevice => Colors.green,
+      SecurityMode.onDevice => colorScheme.primary,
       SecurityMode.hybrid => tokens.colors.warning,
       SecurityMode.cloud => tokens.colors.info,
     };


### PR DESCRIPTION
## Summary
- use ColorScheme or Tokens colors for SecurityCue modes

## Testing
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68bd44d30d1883338aaa214592c4111c