### PR TITLE
Use theme shadow color for PandoraSnackbar

### DIFF
--- a/lib/pandora_ui/pandora_snackbar.dart
+++ b/lib/pandora_ui/pandora_snackbar.dart
@@ -66,6 +66,7 @@ class _PandoraSnackbarState extends State<PandoraSnackbar>
   @override
   Widget build(BuildContext context) {
     final tokens = Theme.of(context).extension<Tokens>()!;
+    final colorScheme = Theme.of(context).colorScheme;
     Color iconColor;
     if (widget.kind == SnackbarKind.success) {
       iconColor = tokens.colors.secondary;
@@ -85,7 +86,7 @@ class _PandoraSnackbarState extends State<PandoraSnackbar>
             borderRadius: BorderRadius.circular(tokens.radii.m),
             boxShadow: [
               BoxShadow(
-                color: Colors.black.withOpacity(0.2),
+                color: colorScheme.shadow.withOpacity(0.2),
                 blurRadius: 4,
               ),
             ],


### PR DESCRIPTION
## Summary
- use `colorScheme.shadow` for snackbar shadow

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd44d529d48333952c0d259f7290ef