### PR TITLE
Use onError color for dismiss icon

### DIFF
--- a/lib/pandora_ui/dismissible_wrapper.dart
+++ b/lib/pandora_ui/dismissible_wrapper.dart
@@ -17,7 +17,8 @@ class DismissibleWrapper extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final tokens = Theme.of(context).extension<Tokens>()!;
+    final theme = Theme.of(context);
+    final tokens = theme.extension<Tokens>()!;
     return Dismissible(
       key: dismissibleKey ?? ValueKey(child.hashCode),
       direction: DismissDirection.endToStart,
@@ -25,9 +26,11 @@ class DismissibleWrapper extends StatelessWidget {
       background: Container(
         color: tokens.colors.error,
         alignment: Alignment.centerRight,
-        padding:
-            EdgeInsets.symmetric(horizontal: tokens.spacing.m),
-        child: const Icon(Icons.delete, color: Colors.white),
+        padding: EdgeInsets.symmetric(horizontal: tokens.spacing.m),
+        child: Icon(
+          Icons.delete,
+          color: theme.colorScheme.onError,
+        ),
       ),
       child: child,
     );


### PR DESCRIPTION
## Summary
- Use `Theme.of(context).colorScheme.onError` for the dismiss icon color
- Keep `tokens.colors.error` as the dismiss background color

## Testing
- `flutter test` *(fails: command not found)*
- `dart format lib/pandora_ui/dismissible_wrapper.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd44d347488333af6d77265e00503f