### PR TITLE
Initialize connectivity service after frame

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -56,8 +56,8 @@ class _MyAppState extends State<MyApp> {
           ),
         );
       }
+      widget.connectivityService.initialize(l10n, messengerKey);
     });
-    widget.connectivityService.initialize(AppLocalizations.of(context)!, messengerKey);
   }
 
   void updateTheme(Color newColor) async {


### PR DESCRIPTION
## Summary
- ensure connectivity service initializes after first frame to allow access to localized strings

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd48d09fa08333a4b2538d3791274e