### PR TITLE
refactor connectivity service tests

### DIFF
--- a/test/connectivity_service_test.dart
+++ b/test/connectivity_service_test.dart
@@ -41,7 +41,8 @@ void main() {
       supportedLocales: AppLocalizations.supportedLocales,
       home: Builder(
         builder: (context) {
-          ConnectivityService().initialize(context, messengerKey);
+          final l10n = AppLocalizations.of(context)!;
+          ConnectivityService().initialize(l10n, messengerKey);
           return const Scaffold(body: SizedBox.shrink());
         },
       ),
@@ -68,7 +69,8 @@ void main() {
       supportedLocales: AppLocalizations.supportedLocales,
       home: Builder(
         builder: (context) {
-          ConnectivityService().initialize(context, messengerKey);
+          final l10n = AppLocalizations.of(context)!;
+          ConnectivityService().initialize(l10n, messengerKey);
           return const Scaffold(body: SizedBox.shrink());
         },
       ),


### PR DESCRIPTION
## Summary
- refactor tests to initialize ConnectivityService with localized strings

## Testing
- `flutter test test/connectivity_service_test.dart` (fails: command not found)
- `dart test test/connectivity_service_test.dart` (fails: command not found)
- `apt-get update` (fails: Invalid response from proxy: 403)


------
https://chatgpt.com/codex/tasks/task_e_68bd48cf8884833388ac9ada96fd2ce3