### PR TITLE
Use design tokens as default theme color

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -34,7 +34,7 @@ class MyApp extends StatefulWidget {
 
 class _MyAppState extends State<MyApp> {
   final messengerKey = GlobalKey<ScaffoldMessengerState>();
-  Color _themeColor = Colors.blue;
+  Color _themeColor = Tokens.light.colors.primary;
   double _fontScale = 1.0;
   ThemeMode _themeMode = ThemeMode.system;
   bool _hasSeenOnboarding = true;

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import '../theme/tokens.dart';
 import 'backup_service.dart';
 
 class SettingsService {
@@ -31,7 +32,7 @@ class SettingsService {
   Future<Color> loadThemeColor() async {
     final sp = await _sp;
     final v = sp.getInt(_kThemeColor);
-    return v != null ? Color(v) : Colors.blue;
+    return v != null ? Color(v) : Tokens.light.colors.primary;
   }
 
   Future<void> saveMascotPath(String path) async {


### PR DESCRIPTION
## Summary
- Default theme color now uses `Tokens.light.colors.primary`
- Settings service falls back to design token primary color and imports Tokens

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4a7c3ecc8333a61b1907bde8753f