### PR TITLE
refactor: move settings screen to feature module

### DIFF
--- a/lib/features/settings/presentation/settings_screen.dart
+++ b/lib/features/settings/presentation/settings_screen.dart
@@ -4,11 +4,11 @@ import 'package:lottie/lottie.dart';
 import 'package:flutter_colorpicker/flutter_colorpicker.dart';
 import 'dart:math' as math;
 
-import '../services/settings_service.dart';
+import '../../../services/settings_service.dart';
 import 'package:alarm_data/alarm_data.dart';
 import 'package:alarm_domain/alarm_domain.dart';
 import 'package:provider/provider.dart';
-import '../providers/note_provider.dart';
+import '../../../providers/note_provider.dart';
 
 class SettingsScreen extends StatefulWidget {
   final Function(Color) onThemeChanged;

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -4,7 +4,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import '../widgets/notes_tab.dart';
 import 'chat_screen.dart';
 import 'note_list_for_day_screen.dart';
-import 'settings_screen.dart';
+import '../features/settings/presentation/settings_screen.dart';
 import 'voice_to_note_screen.dart';
 import 'package:alarm_domain/alarm_domain.dart';
 import '../pandora_ui/palette_bottom_sheet.dart';

--- a/lib/widgets/notes_tab.dart
+++ b/lib/widgets/notes_tab.dart
@@ -8,7 +8,7 @@ import '../providers/note_provider.dart';
 import '../services/settings_service.dart';
 import '../screens/note_search_delegate.dart';
 import '../screens/voice_to_note_screen.dart';
-import '../screens/settings_screen.dart';
+import '../features/settings/presentation/settings_screen.dart';
 import '../pandora_ui/palette_bottom_sheet.dart';
 import '../pandora_ui/teach_ai_modal.dart';
 import 'package:alarm_domain/alarm_domain.dart';


### PR DESCRIPTION
## Summary
- move `SettingsScreen` into feature module
- update imports referencing the relocated screen

## Testing
- `flutter analyze lib/features/settings/presentation/settings_screen.dart` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68bd574c00ac83339889d25e95dfba28