### PR TITLE
refactor: move note sync service to feature module

### DIFF
--- a/lib/providers/note_provider.dart
+++ b/lib/providers/note_provider.dart
@@ -11,7 +11,7 @@ import 'package:alarm_data/alarm_data.dart';
 import '../services/calendar_service.dart';
 import '../services/notification_service.dart';
 import '../services/home_widget_service.dart';
-import '../services/note_sync_service.dart';
+import '../features/note/data/note_sync_service.dart';
 
 int _noteComparator(Note a, Note b) {
   if (a.pinned != b.pinned) {

--- a/test/note_provider_test.dart
+++ b/test/note_provider_test.dart
@@ -5,7 +5,7 @@ import 'package:notes_reminder_app/providers/note_provider.dart';
 import 'package:alarm_data/alarm_data.dart';
 import 'package:notes_reminder_app/services/calendar_service.dart';
 import 'package:notes_reminder_app/services/notification_service.dart';
-import 'package:notes_reminder_app/services/note_sync_service.dart';
+import 'package:notes_reminder_app/features/note/data/note_sync_service.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class MockRepo extends Mock implements NoteRepository {}

--- a/test/note_sync_service_test.dart
+++ b/test/note_sync_service_test.dart
@@ -2,15 +2,16 @@ import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:alarm_domain/alarm_domain.dart';
 import 'package:alarm_data/alarm_data.dart';
-import 'package:notes_reminder_app/services/note_sync_service.dart';
+import 'package:notes_reminder_app/features/note/data/note_sync_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class DummyRepo extends Fake implements NoteRepository {}
 
-class FakeConnectivity extends Connectivity {
-  @override
-  Stream<ConnectivityResult> get onConnectivityChanged => const Stream.empty();
-}
+  class FakeConnectivity extends Connectivity {
+    @override
+    Stream<List<ConnectivityResult>> get onConnectivityChanged =>
+        const Stream.empty();
+  }
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();


### PR DESCRIPTION
## Summary
- move note sync service into `features/note/data` and update for new connectivity and auth APIs
- adjust provider and tests to import from new location
- update connectivity mock in tests

## Testing
- `flutter analyze lib/features/note/data/note_sync_service.dart`


------
https://chatgpt.com/codex/tasks/task_e_68bd574d42b08333ad556f5b47a1ad28