### PR TITLE
refactor: relocate settings service into feature module

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -4,7 +4,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 
 import 'screens/home_screen.dart';
 import 'screens/onboarding_screen.dart';
-import 'services/settings_service.dart';
+import 'features/settings/data/settings_service.dart';
 import 'services/connectivity_service.dart';
 import 'theme/tokens.dart';
 import 'widgets/route_transitions.dart';

--- a/lib/features/settings/data/settings_service.dart
+++ b/lib/features/settings/data/settings_service.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import '../theme/tokens.dart';
+import '../../../theme/tokens.dart';
 import 'package:alarm_data/alarm_data.dart';
 
 class SettingsService {

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import '../services/settings_service.dart';
+import '../features/settings/data/settings_service.dart';
 
 class OnboardingScreen extends StatefulWidget {
   final VoidCallback onFinished;

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -4,7 +4,7 @@ import 'package:lottie/lottie.dart';
 import 'package:flutter_colorpicker/flutter_colorpicker.dart';
 import 'dart:math' as math;
 
-import '../services/settings_service.dart';
+import '../features/settings/data/settings_service.dart';
 import 'package:alarm_data/alarm_data.dart';
 import 'package:alarm_domain/alarm_domain.dart';
 import 'package:provider/provider.dart';

--- a/lib/services/app_initializer.dart
+++ b/lib/services/app_initializer.dart
@@ -4,7 +4,7 @@ import 'package:flutter_local_notifications/flutter_local_notifications.dart'
     as fln;
 
 import 'auth_service.dart';
-import 'settings_service.dart';
+import '../features/settings/data/settings_service.dart';
 import 'startup_service.dart';
 
 class AppInitializationData {

--- a/lib/widgets/notes_tab.dart
+++ b/lib/widgets/notes_tab.dart
@@ -5,7 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:flutter/services.dart';
 
 import '../providers/note_provider.dart';
-import '../services/settings_service.dart';
+import '../features/settings/data/settings_service.dart';
 import '../screens/note_search_delegate.dart';
 import '../screens/voice_to_note_screen.dart';
 import '../screens/settings_screen.dart';

--- a/test/settings_service_test.dart
+++ b/test/settings_service_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:notes_reminder_app/services/settings_service.dart';
+import 'package:notes_reminder_app/features/settings/data/settings_service.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();


### PR DESCRIPTION
## Summary
- move `SettingsService` into `lib/features/settings/data`
- drop legacy `lib/services/settings_service.dart`
- update imports across app

## Testing
- `flutter analyze lib/features/settings/data/settings_service.dart` *(fails: SDK version solving failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd574f3c448333a676bda8763a5465