### PR TITLE
refactor: use feature imports in tests

### DIFF
--- a/lib/features/note/note.dart
+++ b/lib/features/note/note.dart
@@ -1,0 +1,4 @@
+library note_feature;
+
+export 'package:alarm_domain/alarm_domain.dart';
+export 'package:alarm_data/alarm_data.dart';

--- a/lib/features/settings/settings.dart
+++ b/lib/features/settings/settings.dart
@@ -1,0 +1,3 @@
+library settings_feature;
+
+export '../../services/settings_service.dart';

--- a/test/backup_service_test.dart
+++ b/test/backup_service_test.dart
@@ -7,8 +7,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:alarm_domain/alarm_domain.dart';
-import 'package:alarm_data/alarm_data.dart';
+import 'package:notes_reminder_app/features/note/note.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 const MethodChannel _channel = MethodChannel(

--- a/test/db_service_test.dart
+++ b/test/db_service_test.dart
@@ -3,8 +3,7 @@ import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:alarm_data/alarm_data.dart';
-import 'package:alarm_domain/alarm_domain.dart';
+import 'package:notes_reminder_app/features/note/note.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/note_provider_test.dart
+++ b/test/note_provider_test.dart
@@ -1,8 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:alarm_domain/alarm_domain.dart';
+import 'package:notes_reminder_app/features/note/note.dart';
 import 'package:notes_reminder_app/providers/note_provider.dart';
-import 'package:alarm_data/alarm_data.dart';
 import 'package:notes_reminder_app/services/calendar_service.dart';
 import 'package:notes_reminder_app/services/notification_service.dart';
 import 'package:notes_reminder_app/services/note_sync_service.dart';

--- a/test/note_repository_test.dart
+++ b/test/note_repository_test.dart
@@ -3,8 +3,7 @@ import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:alarm_data/alarm_data.dart';
-import 'package:alarm_domain/alarm_domain.dart';
+import 'package:notes_reminder_app/features/note/note.dart';
 import 'package:uuid/uuid.dart';
 
 void main() {

--- a/test/note_sync_service_test.dart
+++ b/test/note_sync_service_test.dart
@@ -1,7 +1,6 @@
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:alarm_domain/alarm_domain.dart';
-import 'package:alarm_data/alarm_data.dart';
+import 'package:notes_reminder_app/features/note/note.dart';
 import 'package:notes_reminder_app/services/note_sync_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 

--- a/test/notes_list_unsynced_test.dart
+++ b/test/notes_list_unsynced_test.dart
@@ -7,8 +7,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:notes_reminder_app/providers/note_provider.dart';
 import 'package:notes_reminder_app/widgets/notes_list.dart';
-import 'package:alarm_domain/alarm_domain.dart';
-import 'package:alarm_data/alarm_data.dart';
+import 'package:notes_reminder_app/features/note/note.dart';
 
 class MockRepo extends Mock implements NoteRepository {}
 


### PR DESCRIPTION
## Summary
- add feature entrypoints for notes and settings
- update tests to import features instead of legacy packages

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd574f842883338a06ae78be7cad4b