### PR TITLE
Refactor tests to import alarm_data package

### DIFF
--- a/test/backup_service_test.dart
+++ b/test/backup_service_test.dart
@@ -7,7 +7,8 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:notes_reminder_app/features/note/note.dart';
+import 'package:alarm_domain/alarm_domain.dart';
+import 'package:alarm_data/alarm_data.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 const MethodChannel _channel = MethodChannel(

--- a/test/db_service_test.dart
+++ b/test/db_service_test.dart
@@ -3,7 +3,8 @@ import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:notes_reminder_app/features/note/note.dart';
+import 'package:alarm_domain/alarm_domain.dart';
+import 'package:alarm_data/alarm_data.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/note_repository_test.dart
+++ b/test/note_repository_test.dart
@@ -3,7 +3,8 @@ import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:notes_reminder_app/features/note/note.dart';
+import 'package:alarm_domain/alarm_domain.dart';
+import 'package:alarm_data/alarm_data.dart';
 import 'package:uuid/uuid.dart';
 
 void main() {


### PR DESCRIPTION
## Summary
- Replace feature-level imports in tests with direct `alarm_data` and `alarm_domain` imports

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd61f6b5c48333839d8719358370ea