### PR TITLE
feat: add semantics labels to color chips

### DIFF
--- a/lib/widgets/tag_selector.dart
+++ b/lib/widgets/tag_selector.dart
@@ -84,12 +84,15 @@ class _TagSelectorState extends State<TagSelector> {
         padding: const EdgeInsets.symmetric(horizontal: 4),
         child: Tooltip(
           message: label,
-          child: ChoiceChip(
-            label: const SizedBox(width: 24, height: 24),
-            selectedColor: color,
-            backgroundColor: color,
-            selected: selected,
-            onSelected: (_) => widget.onColorChanged(color.value),
+          child: Semantics(
+            label: label,
+            child: ChoiceChip(
+              label: const SizedBox(width: 24, height: 24),
+              selectedColor: color,
+              backgroundColor: color,
+              selected: selected,
+              onSelected: (_) => widget.onColorChanged(color.value),
+            ),
           ),
         ),
       );


### PR DESCRIPTION
## Summary
- improve accessibility of TagSelector color chips by wrapping them with Semantics labels

## Testing
- `flutter format lib/widgets/tag_selector.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6b600928833391fa9bcafd020932