### PR TITLE
Refactor note provider to depend on domain interfaces

### DIFF
--- a/alarm_domain/lib/alarm_domain.dart
+++ b/alarm_domain/lib/alarm_domain.dart
@@ -11,3 +11,4 @@ export 'src/usecases/update_note.dart';
 export 'src/services/notification_service.dart';
 export 'src/services/calendar_service.dart';
 export 'src/services/home_widget_service.dart';
+export 'src/services/note_sync_service.dart';

--- a/alarm_domain/lib/src/services/note_sync_service.dart
+++ b/alarm_domain/lib/src/services/note_sync_service.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/foundation.dart';
+
+import '../entities/note.dart';
+
+/// Represents the current synchronization status.
+enum SyncStatus { idle, syncing, error }
+
+/// Function signature for retrieving a [Note] by its id.
+typedef NoteGetter = Note? Function(String id);
+
+/// Contract for synchronizing notes with a remote backend.
+abstract class NoteSyncService {
+  ValueNotifier<SyncStatus> get syncStatus;
+  Set<String> get unsyncedNoteIds;
+  bool isSynced(String id);
+
+  Future<void> init(NoteGetter noteGetter);
+  Future<void> dispose();
+
+  Future<void> markUnsynced(String id);
+  Future<void> syncNote(Note note);
+  Future<void> deleteNote(String id);
+  Future<void> syncUnsyncedNotes();
+  Future<bool> loadFromRemote(Set<Note> notes);
+}

--- a/alarm_domain/pubspec.yaml
+++ b/alarm_domain/pubspec.yaml
@@ -7,6 +7,8 @@ environment:
   sdk: ">=3.3.0 <4.0.0"
 
 dependencies:
+  flutter:
+    sdk: flutter
   json_annotation: ^4.9.0
 
 dev_dependencies:

--- a/integration_test/sync_and_notification_test.dart
+++ b/integration_test/sync_and_notification_test.dart
@@ -10,6 +10,7 @@ import 'package:mocktail/mocktail.dart';
 
 import 'package:alarm_domain/alarm_domain.dart' hide Note;
 import 'package:notes_reminder_app/features/note/note.dart';
+import 'package:notes_reminder_app/features/backup/data/note_sync_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:timezone/data/latest.dart' as tzdata;
@@ -19,6 +20,11 @@ class MockRepo extends Mock implements NoteRepository {}
 class MockCalendar extends Mock implements CalendarService {}
 
 class MockNotification extends Mock implements NotificationService {}
+
+class DummyHomeWidget extends Fake implements HomeWidgetService {
+  @override
+  Future<void> update(List<Note> notes) async {}
+}
 
 class FakeConnectivityPlatform extends Fake implements ConnectivityPlatform {
   final _controller = StreamController<ConnectivityResult>.broadcast();
@@ -112,6 +118,8 @@ void main() {
       repository: repo,
       calendarService: calendar,
       notificationService: notification,
+      homeWidgetService: DummyHomeWidget(),
+      syncService: NoteSyncServiceImpl(repository: repo),
     );
 
     await provider.loadNotes();

--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -2,6 +2,11 @@ import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
 
 import 'features/note/presentation/note_provider.dart';
+import 'features/note/data/calendar_service.dart';
+import 'features/note/data/notification_service.dart';
+import 'features/note/data/home_widget_service.dart';
+import 'features/backup/data/note_sync_service.dart';
+import 'package:alarm_data/alarm_data.dart';
 
 /// Wraps the given [child] with all application level providers.
 class AppProviders extends StatelessWidget {
@@ -12,7 +17,18 @@ class AppProviders extends StatelessWidget {
   Widget build(BuildContext context) {
     return MultiProvider(
       providers: [
-        ChangeNotifierProvider<NoteProvider>(create: (_) => NoteProvider()),
+        ChangeNotifierProvider<NoteProvider>(
+          create: (_) {
+            final repo = NoteRepositoryImpl();
+            return NoteProvider(
+              repository: repo,
+              calendarService: CalendarServiceImpl.instance,
+              notificationService: NotificationServiceImpl(),
+              homeWidgetService: const HomeWidgetServiceImpl(),
+              syncService: NoteSyncServiceImpl(repository: repo),
+            );
+          },
+        ),
         // Additional providers can be added here.
       ],
       child: child,

--- a/lib/features/backup/data/note_sync_service.dart
+++ b/lib/features/backup/data/note_sync_service.dart
@@ -10,11 +10,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:alarm_domain/alarm_domain.dart';
 import 'package:alarm_data/alarm_data.dart';
 
-enum SyncStatus { idle, syncing, error }
-
-typedef NoteGetter = Note? Function(String id);
-
-class NoteSyncService {
+class NoteSyncServiceImpl implements NoteSyncService {
   final NoteRepository _repository;
   final FirebaseFirestore _firestore;
   final FirebaseAuth _auth;
@@ -26,12 +22,13 @@ class NoteSyncService {
   static const _unsyncedKey = 'unsyncedNoteIds';
 
   final Set<String> _unsyncedNoteIds = {};
+  @override
   final ValueNotifier<SyncStatus> syncStatus =
       ValueNotifier<SyncStatus>(SyncStatus.idle);
 
   NoteGetter? _noteGetter;
 
-  NoteSyncService({
+  NoteSyncServiceImpl({
     NoteRepository? repository,
     FirebaseFirestore? firestore,
     FirebaseAuth? auth,
@@ -41,9 +38,12 @@ class NoteSyncService {
         _auth = auth ?? FirebaseAuth.instance,
         _connectivity = connectivity ?? Connectivity();
 
+  @override
   Set<String> get unsyncedNoteIds => Set.unmodifiable(_unsyncedNoteIds);
+  @override
   bool isSynced(String id) => !_unsyncedNoteIds.contains(id);
 
+  @override
   Future<void> init(NoteGetter noteGetter) async {
     _noteGetter = noteGetter;
     _prefs = await SharedPreferences.getInstance();
@@ -60,6 +60,7 @@ class NoteSyncService {
     });
   }
 
+  @override
   Future<void> dispose() async {
     await _connectivitySubscription?.cancel();
   }
@@ -68,11 +69,13 @@ class NoteSyncService {
     await _prefs!.setStringList(_unsyncedKey, _unsyncedNoteIds.toList());
   }
 
+  @override
   Future<void> markUnsynced(String id) async {
     _unsyncedNoteIds.add(id);
     await _saveUnsyncedNoteIds();
   }
 
+  @override
   Future<void> syncNote(Note note) async {
     if (Firebase.apps.isEmpty) {
       await markUnsynced(note.id);
@@ -90,6 +93,7 @@ class NoteSyncService {
     }
   }
 
+  @override
   Future<void> deleteNote(String id) async {
     if (Firebase.apps.isEmpty) {
       await markUnsynced(id);
@@ -104,6 +108,7 @@ class NoteSyncService {
     }
   }
 
+  @override
   Future<void> syncUnsyncedNotes() async {
     if (_unsyncedNoteIds.isEmpty || Firebase.apps.isEmpty) return;
     syncStatus.value = SyncStatus.syncing;
@@ -131,6 +136,7 @@ class NoteSyncService {
     }
   }
 
+  @override
   Future<bool> loadFromRemote(Set<Note> notes) async {
     final existingUnsynced = Set<String>.from(_unsyncedNoteIds);
     _unsyncedNoteIds.clear();

--- a/lib/features/note/presentation/note_provider.dart
+++ b/lib/features/note/presentation/note_provider.dart
@@ -7,11 +7,6 @@ import 'package:flutter_local_notifications/flutter_local_notifications.dart'
     show Time;
 
 import 'package:alarm_domain/alarm_domain.dart';
-import 'package:alarm_data/alarm_data.dart';
-import '../data/calendar_service.dart';
-import '../data/notification_service.dart';
-import '../data/home_widget_service.dart';
-import '../../backup/data/note_sync_service.dart';
 
 int _noteComparator(Note a, Note b) {
   if (a.pinned != b.pinned) {
@@ -38,21 +33,16 @@ class NoteProvider extends ChangeNotifier {
   bool isSynced(String id) => _syncService.isSynced(id);
 
   NoteProvider({
-    NoteRepository? repository,
-    CalendarService? calendarService,
-    NotificationService? notificationService,
-    HomeWidgetService? homeWidgetService,
-    NoteSyncService? syncService,
-  }) : _repository = repository ?? NoteRepositoryImpl(),
-       _calendarService =
-            calendarService ?? CalendarServiceImpl.instance,
-       _notificationService =
-            notificationService ?? NotificationServiceImpl(),
-       _homeWidgetService =
-            homeWidgetService ?? const HomeWidgetServiceImpl(),
-       _syncService =
-           syncService ??
-           NoteSyncService(repository: repository ?? NoteRepositoryImpl()) {
+    required NoteRepository repository,
+    required CalendarService calendarService,
+    required NotificationService notificationService,
+    required HomeWidgetService homeWidgetService,
+    required NoteSyncService syncService,
+  })  : _repository = repository,
+        _calendarService = calendarService,
+        _notificationService = notificationService,
+        _homeWidgetService = homeWidgetService,
+        _syncService = syncService {
     unawaited(
       _init().catchError((e) {
         /* log or set error state */

--- a/test/note_provider_test.dart
+++ b/test/note_provider_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
 import 'package:notes_reminder_app/features/note/note.dart';
-import 'package:notes_reminder_app/features/backup/backup.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class MockRepo extends Mock implements NoteRepository {}
@@ -12,6 +11,8 @@ class MockCalendar extends Mock implements CalendarService {}
 class MockNotification extends Mock implements NotificationService {}
 
 class MockSyncService extends Mock implements NoteSyncService {}
+
+class MockHomeWidget extends Mock implements HomeWidgetService {}
 
 class FakeL10n extends Fake implements AppLocalizations {}
 
@@ -40,6 +41,7 @@ void main() {
     final calendar = MockCalendar();
     final notification = MockNotification();
     final sync = MockSyncService();
+    final homeWidget = MockHomeWidget();
     when(() => repo.getNotes()).thenAnswer(
       (_) async => [
         const Note(
@@ -61,12 +63,14 @@ void main() {
     when(() => sync.syncStatus).thenReturn(ValueNotifier(SyncStatus.idle));
     when(() => sync.loadFromRemote(any())).thenAnswer((_) async => true);
     when(() => sync.deleteNote(any())).thenAnswer((_) async {});
+    when(() => homeWidget.update(any())).thenAnswer((_) async {});
 
     final provider = NoteProvider(
       repository: repo,
       calendarService: calendar,
       notificationService: notification,
       syncService: sync,
+      homeWidgetService: homeWidget,
     );
 
     await provider.loadNotes();
@@ -82,6 +86,7 @@ void main() {
     final calendar = MockCalendar();
     final notification = MockNotification();
     final sync = MockSyncService();
+    final homeWidget = MockHomeWidget();
     final l10n = FakeL10n();
     when(() => repo.saveNotes(any())).thenAnswer((_) async {});
     when(
@@ -105,12 +110,14 @@ void main() {
     when(() => sync.syncStatus).thenReturn(ValueNotifier(SyncStatus.idle));
     when(() => sync.loadFromRemote(any())).thenAnswer((_) async => true);
     when(() => sync.syncNote(any())).thenAnswer((_) async {});
+    when(() => homeWidget.update(any())).thenAnswer((_) async {});
 
     final provider = NoteProvider(
       repository: repo,
       calendarService: calendar,
       notificationService: notification,
       syncService: sync,
+      homeWidgetService: homeWidget,
     );
 
     final ok = await provider.createNote(
@@ -200,6 +207,7 @@ void main() {
   test('fetchNotesPage paginates using stored order', () async {
     final repo = MockRepo();
     final sync = MockSyncService();
+    final homeWidget = MockHomeWidget();
     when(() => repo.getNotes()).thenAnswer(
       (_) async => [
         Note(
@@ -226,12 +234,14 @@ void main() {
     when(() => sync.init(any())).thenAnswer((_) async {});
     when(() => sync.syncStatus).thenReturn(ValueNotifier(SyncStatus.idle));
     when(() => sync.loadFromRemote(any())).thenAnswer((_) async => true);
+    when(() => homeWidget.update(any())).thenAnswer((_) async {});
 
     final provider = NoteProvider(
       repository: repo,
       calendarService: MockCalendar(),
       notificationService: MockNotification(),
       syncService: sync,
+      homeWidgetService: homeWidget,
     );
 
     final firstPage = await provider.fetchNotesPage(null, 2);
@@ -250,6 +260,7 @@ void main() {
     final calendar = MockCalendar();
     final notification = MockNotification();
     final sync = MockSyncService();
+    final homeWidget = MockHomeWidget();
     final l10n = FakeL10n();
     when(() => repo.getNotes()).thenAnswer(
       (_) async => [
@@ -279,12 +290,14 @@ void main() {
     when(() => sync.init(any())).thenAnswer((_) async {});
     when(() => sync.syncStatus).thenReturn(ValueNotifier(SyncStatus.idle));
     when(() => sync.loadFromRemote(any())).thenAnswer((_) async => true);
+    when(() => homeWidget.update(any())).thenAnswer((_) async {});
 
     final provider = NoteProvider(
       repository: repo,
       calendarService: calendar,
       notificationService: notification,
       syncService: sync,
+      homeWidgetService: homeWidget,
     );
 
     await provider.loadNotes();

--- a/test/note_sync_service_test.dart
+++ b/test/note_sync_service_test.dart
@@ -16,7 +16,7 @@ void main() {
 
   test('syncNote marks unsynced when offline', () async {
     SharedPreferences.setMockInitialValues({});
-    final service = NoteSyncService(
+    final service = NoteSyncServiceImpl(
       repository: DummyRepo(),
       connectivity: FakeConnectivity(),
     );


### PR DESCRIPTION
## Summary
- add NoteSyncService interface and expose it from `alarm_domain`
- inject calendar, notification, widget, and sync services through NoteProvider constructor
- wire concrete implementations in `AppProviders` and rename sync service implementation

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: invalid response from proxy)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68bd71671b508333b689cfe3637de94c