### PR TITLE
refactor: expose note domain use cases and update imports

### DIFF
--- a/lib/features/backup/data/note_sync_service.dart
+++ b/lib/features/backup/data/note_sync_service.dart
@@ -7,7 +7,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-import 'package:alarm_domain/alarm_domain.dart';
+import '../../note/domain/domain.dart';
 import 'package:alarm_data/alarm_data.dart';
 
 enum SyncStatus { idle, syncing, error }

--- a/lib/features/note/data/calendar_service.dart
+++ b/lib/features/note/data/calendar_service.dart
@@ -1,7 +1,7 @@
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:googleapis/calendar/v3.dart' as calendar;
 import 'package:http/http.dart' as http;
-import 'package:alarm_domain/alarm_domain.dart';
+import '../domain/domain.dart';
 
 class CalendarServiceImpl implements CalendarService {
   CalendarServiceImpl._();

--- a/lib/features/note/data/home_widget_service.dart
+++ b/lib/features/note/data/home_widget_service.dart
@@ -1,6 +1,6 @@
 import 'package:home_widget/home_widget.dart';
 
-import 'package:alarm_domain/alarm_domain.dart';
+import '../domain/domain.dart';
 
 /// Service to update the native home screen widget with the next upcoming note.
 class HomeWidgetServiceImpl implements HomeWidgetService {

--- a/lib/features/note/data/notification_service.dart
+++ b/lib/features/note/data/notification_service.dart
@@ -5,7 +5,7 @@ import 'package:timezone/data/latest.dart' as tzdata;
 import 'package:timezone/timezone.dart' as tz;
 import 'package:flutter/foundation.dart';
 
-import 'package:alarm_domain/alarm_domain.dart';
+import '../domain/domain.dart';
 
 class NotificationServiceImpl implements NotificationService {
   static final NotificationServiceImpl _instance =

--- a/lib/features/note/domain/delete_note.dart
+++ b/lib/features/note/domain/delete_note.dart
@@ -1,0 +1,20 @@
+import '../domain/domain.dart';
+
+/// Deletes a [Note] by id.
+///
+/// Uses [GetNotes] and [SaveNotes] from the repository to remove
+/// the note and persist the updated collection.
+class DeleteNote {
+  final GetNotes _getNotes;
+  final SaveNotes _saveNotes;
+
+  DeleteNote(NoteRepository repository)
+      : _getNotes = GetNotes(repository),
+        _saveNotes = SaveNotes(repository);
+
+  Future<void> call(String id) async {
+    final notes = await _getNotes();
+    notes.removeWhere((n) => n.id == id);
+    await _saveNotes(notes);
+  }
+}

--- a/lib/features/note/domain/domain.dart
+++ b/lib/features/note/domain/domain.dart
@@ -1,1 +1,4 @@
 export 'package:alarm_domain/alarm_domain.dart';
+
+export 'get_note_by_id.dart';
+export 'delete_note.dart';

--- a/lib/features/note/domain/get_note_by_id.dart
+++ b/lib/features/note/domain/get_note_by_id.dart
@@ -1,0 +1,18 @@
+import '../domain/domain.dart';
+
+/// Retrieves a single [Note] by id using the [NoteRepository].
+class GetNoteById {
+  final GetNotes _getNotes;
+
+  GetNoteById(NoteRepository repository)
+      : _getNotes = GetNotes(repository);
+
+  Future<Note?> call(String id) async {
+    final notes = await _getNotes();
+    try {
+      return notes.firstWhere((n) => n.id == id);
+    } catch (_) {
+      return null;
+    }
+  }
+}

--- a/lib/features/note/presentation/note_detail_screen.dart
+++ b/lib/features/note/presentation/note_detail_screen.dart
@@ -5,7 +5,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 import 'package:share_plus/share_plus.dart';
 
-import 'package:alarm_domain/alarm_domain.dart';
+import '../domain/domain.dart';
 import 'note_provider.dart';
 import '../../services/tts_service.dart';
 import '../../widgets/tag_selector.dart';

--- a/lib/features/note/presentation/note_list_for_day_screen.dart
+++ b/lib/features/note/presentation/note_list_for_day_screen.dart
@@ -3,7 +3,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
-import 'package:alarm_domain/alarm_domain.dart';
+import '../domain/domain.dart';
 import 'note_provider.dart';
 import '../../services/auth_service.dart';
 import 'note_detail_screen.dart';

--- a/lib/features/note/presentation/note_provider.dart
+++ b/lib/features/note/presentation/note_provider.dart
@@ -6,7 +6,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart'
     show Time;
 
-import 'package:alarm_domain/alarm_domain.dart';
+import '../domain/domain.dart';
 import 'package:alarm_data/alarm_data.dart';
 import '../data/calendar_service.dart';
 import '../data/notification_service.dart';

--- a/lib/features/note/presentation/note_search_delegate.dart
+++ b/lib/features/note/presentation/note_search_delegate.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:alarm_domain/alarm_domain.dart';
+import '../domain/domain.dart';
 import 'note_detail_screen.dart';
 import '../../services/auth_service.dart';
 import '../../widgets/route_transitions.dart';

--- a/lib/features/settings/presentation/settings_screen.dart
+++ b/lib/features/settings/presentation/settings_screen.dart
@@ -7,7 +7,7 @@ import 'dart:math' as math;
 
 import '../domain/settings_service.dart';
 import 'package:alarm_data/alarm_data.dart';
-import 'package:alarm_domain/alarm_domain.dart';
+import '../../note/domain/domain.dart';
 import 'package:provider/provider.dart';
 import '../../note/presentation/note_provider.dart';
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,7 +8,7 @@ import 'package:provider/provider.dart';
 
 import 'app.dart';
 import 'app_providers.dart';
-import 'package:alarm_domain/alarm_domain.dart';
+import 'features/note/domain/domain.dart';
 import 'features/note/presentation/note_provider.dart';
 import 'services/app_initializer.dart';
 import 'services/connectivity_service.dart';

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -8,7 +8,6 @@ import '../features/note/presentation/note_list_for_day_screen.dart';
 import '../features/settings/presentation/settings_screen.dart';
 import '../features/note/presentation/voice_to_note_screen.dart';
 import '../features/settings/data/settings_service.dart';
-import 'package:alarm_domain/alarm_domain.dart';
 import '../pandora_ui/palette_bottom_sheet.dart';
 import '../pandora_ui/teach_ai_modal.dart';
 

--- a/lib/widgets/notes_list.dart
+++ b/lib/widgets/notes_list.dart
@@ -5,7 +5,7 @@ import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:share_plus/share_plus.dart';
 
-import 'package:alarm_domain/alarm_domain.dart';
+import '../features/note/domain/domain.dart';
 
 import '../features/note/presentation/note_provider.dart';
 import '../features/note/presentation/note_detail_screen.dart';

--- a/lib/widgets/notes_tab.dart
+++ b/lib/widgets/notes_tab.dart
@@ -13,7 +13,7 @@ import '../features/note/presentation/voice_to_note_screen.dart';
 import '../features/settings/presentation/settings_screen.dart';
 import '../pandora_ui/palette_bottom_sheet.dart';
 import '../pandora_ui/teach_ai_modal.dart';
-import 'package:alarm_domain/alarm_domain.dart';
+import '../features/note/domain/domain.dart';
 import 'add_note_dialog.dart';
 import 'tag_filtered_notes_list.dart';
 import 'route_transitions.dart';

--- a/lib/widgets/reminder_controls.dart
+++ b/lib/widgets/reminder_controls.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:alarm_domain/alarm_domain.dart';
+import '../features/note/domain/domain.dart';
 
 class ReminderControls extends StatelessWidget {
   final DateTime? alarmTime;

--- a/lib/widgets/tag_filtered_notes_list.dart
+++ b/lib/widgets/tag_filtered_notes_list.dart
@@ -3,7 +3,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
-import 'package:alarm_domain/alarm_domain.dart';
+import '../features/note/domain/domain.dart';
 import '../features/note/presentation/note_provider.dart';
 import '../features/note/presentation/note_list_for_day_screen.dart';
 import 'notes_list.dart';


### PR DESCRIPTION
## Summary
- add GetNoteById and DeleteNote use cases in note domain
- re-export new use cases and route note feature imports through domain layer
- clean up unused alarm_domain imports

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd71693b008333b8be70ced6ddf31a