### PR TITLE
Use NotificationService interface in startup service

### DIFF
--- a/lib/services/app_initializer.dart
+++ b/lib/services/app_initializer.dart
@@ -5,6 +5,7 @@ import 'package:flutter_local_notifications/flutter_local_notifications.dart'
 
 import 'auth_service.dart';
 import '../features/settings/data/settings_service.dart';
+import '../features/note/data/notification_service.dart';
 import 'startup_service.dart';
 
 class AppInitializationData {
@@ -31,8 +32,9 @@ class AppInitializer {
         onDidReceiveNotificationResponse,
   }) async {
     final settings = SettingsService();
+    final notificationService = NotificationServiceImpl();
     final futures = await Future.wait([
-      StartupService().initialize(
+      StartupService(notificationService).initialize(
         onDidReceiveNotificationResponse: onDidReceiveNotificationResponse,
       ),
       settings.loadThemeColor(),

--- a/lib/services/startup_service.dart
+++ b/lib/services/startup_service.dart
@@ -6,7 +6,7 @@ import 'package:flutter_local_notifications/flutter_local_notifications.dart'
     as fln;
 
 import '../firebase_options.dart';
-import '../features/note/data/notification_service.dart';
+import 'package:alarm_domain/alarm_domain.dart';
 
 class StartupResult {
   final bool authFailed;
@@ -19,6 +19,9 @@ class StartupResult {
 }
 
 class StartupService {
+  final NotificationService _notificationService;
+  StartupService(this._notificationService);
+
   Future<StartupResult> initialize({
     Future<void> Function(fln.NotificationResponse)?
         onDidReceiveNotificationResponse,
@@ -31,14 +34,15 @@ class StartupService {
         options: DefaultFirebaseOptions.currentPlatform,
       );
       await FirebaseAuth.instance.signInAnonymously();
-      await FirebaseCrashlytics.instance.setCrashlyticsCollectionEnabled(true);
+      await FirebaseCrashlytics.instance
+          .setCrashlyticsCollectionEnabled(true);
       await FirebaseAnalytics.instance.logAppOpen();
     } catch (_) {
       authFailed = true;
     }
 
     try {
-      await NotificationServiceImpl().init(
+      await _notificationService.init(
         onDidReceiveNotificationResponse: onDidReceiveNotificationResponse,
       );
     } catch (_) {


### PR DESCRIPTION
## Summary
- Inject NotificationService into StartupService via interface
- Pass NotificationServiceImpl at runtime from AppInitializer

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd716c1b04833385484c415e2c64d0