### PR TITLE
feat: add backup service interface and inject into settings

### DIFF
--- a/alarm_data/lib/src/repositories/note_repository_impl.dart
+++ b/alarm_data/lib/src/repositories/note_repository_impl.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
-import 'package:alarm_domain/alarm_domain.dart';
+import 'package:alarm_domain/alarm_domain.dart' hide BackupService;
 import '../datasources/db_service.dart';
 import '../datasources/backup_service.dart';
 

--- a/alarm_domain/lib/alarm_domain.dart
+++ b/alarm_domain/lib/alarm_domain.dart
@@ -11,3 +11,4 @@ export 'src/usecases/update_note.dart';
 export 'src/services/notification_service.dart';
 export 'src/services/calendar_service.dart';
 export 'src/services/home_widget_service.dart';
+export 'src/services/backup_service.dart';

--- a/alarm_domain/lib/src/services/backup_service.dart
+++ b/alarm_domain/lib/src/services/backup_service.dart
@@ -1,0 +1,23 @@
+import '../entities/note.dart';
+
+enum BackupFormat { json, pdf, md }
+
+abstract class BackupService {
+  Future<bool> exportNotes(
+    List<Note> notes,
+    dynamic l10n, {
+    String? password,
+    BackupFormat format = BackupFormat.json,
+  });
+
+  Future<List<Note>> importNotes(
+    dynamic l10n, {
+    String? password,
+    BackupFormat format = BackupFormat.json,
+  });
+
+  Future<bool> autoBackup(
+    List<Note> notes, {
+    String fileName = 'notes_autobackup.json',
+  });
+}

--- a/lib/features/backup/backup.dart
+++ b/lib/features/backup/backup.dart
@@ -1,3 +1,4 @@
 library backup_feature;
 
 export 'data/note_sync_service.dart';
+export 'data/backup_service.dart';

--- a/lib/features/backup/data/backup_service.dart
+++ b/lib/features/backup/data/backup_service.dart
@@ -1,0 +1,45 @@
+import 'package:alarm_domain/alarm_domain.dart';
+import 'package:alarm_data/alarm_data.dart' as data;
+
+class BackupServiceImpl implements BackupService {
+  final data.BackupService _service;
+
+  BackupServiceImpl({data.BackupService? service})
+      : _service = service ?? data.BackupService();
+
+  @override
+  Future<bool> exportNotes(
+    List<Note> notes,
+    dynamic l10n, {
+    String? password,
+    BackupFormat format = BackupFormat.json,
+  }) {
+    return _service.exportNotes(
+      notes,
+      l10n,
+      password: password,
+      format: format,
+    );
+  }
+
+  @override
+  Future<List<Note>> importNotes(
+    dynamic l10n, {
+    String? password,
+    BackupFormat format = BackupFormat.json,
+  }) {
+    return _service.importNotes(
+      l10n,
+      password: password,
+      format: format,
+    );
+  }
+
+  @override
+  Future<bool> autoBackup(
+    List<Note> notes, {
+    String fileName = 'notes_autobackup.json',
+  }) {
+    return _service.autoBackup(notes, fileName: fileName);
+  }
+}

--- a/lib/features/settings/data/settings_service.dart
+++ b/lib/features/settings/data/settings_service.dart
@@ -1,12 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
 import '../../../theme/tokens.dart';
-import 'package:alarm_data/alarm_data.dart';
+import 'package:alarm_domain/alarm_domain.dart';
 import '../domain/settings_service.dart';
 
 class SettingsServiceImpl implements SettingsService {
-  SettingsServiceImpl({SharedPreferences? sharedPreferences})
-      : _preferences = sharedPreferences;
+  SettingsServiceImpl({
+    SharedPreferences? sharedPreferences,
+    required BackupService backupService,
+  })  : _preferences = sharedPreferences,
+        _backupService = backupService;
 
   static const _kThemeColor = 'theme_color';
   static const _kMascotPath = 'mascot_path';
@@ -18,6 +22,7 @@ class SettingsServiceImpl implements SettingsService {
   static const _kHasSeenOnboarding = 'has_seen_onboarding';
 
   SharedPreferences? _preferences;
+  final BackupService _backupService; // ignore: unused_field
 
   Future<SharedPreferences> get _sp async {
     _preferences ??= await SharedPreferences.getInstance();

--- a/lib/features/settings/domain/settings_service.dart
+++ b/lib/features/settings/domain/settings_service.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:alarm_data/alarm_data.dart';
+import 'package:alarm_domain/alarm_domain.dart';
 
 abstract class SettingsService {
   Future<void> saveThemeColor(Color color);

--- a/lib/features/settings/presentation/settings_screen.dart
+++ b/lib/features/settings/presentation/settings_screen.dart
@@ -6,7 +6,6 @@ import 'dart:math' as math;
 
 
 import '../domain/settings_service.dart';
-import 'package:alarm_data/alarm_data.dart';
 import 'package:alarm_domain/alarm_domain.dart';
 import 'package:provider/provider.dart';
 import '../../note/presentation/note_provider.dart';

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -8,6 +8,7 @@ import '../features/note/presentation/note_list_for_day_screen.dart';
 import '../features/settings/presentation/settings_screen.dart';
 import '../features/note/presentation/voice_to_note_screen.dart';
 import '../features/settings/data/settings_service.dart';
+import '../features/backup/data/backup_service.dart';
 import 'package:alarm_domain/alarm_domain.dart';
 import '../pandora_ui/palette_bottom_sheet.dart';
 import '../pandora_ui/teach_ai_modal.dart';
@@ -47,7 +48,8 @@ class _HomeScreenState extends State<HomeScreen> {
           onThemeChanged: widget.onThemeChanged,
           onFontScaleChanged: widget.onFontScaleChanged,
           onThemeModeChanged: widget.onThemeModeChanged,
-          settingsService: SettingsServiceImpl(),
+          settingsService:
+              SettingsServiceImpl(backupService: BackupServiceImpl()),
         ),
       ];
   }

--- a/lib/widgets/notes_tab.dart
+++ b/lib/widgets/notes_tab.dart
@@ -7,6 +7,7 @@ import 'package:flutter/services.dart';
 
 import '../features/note/presentation/note_provider.dart';
 import '../features/settings/data/settings_service.dart';
+import '../features/backup/data/backup_service.dart';
 
 import '../features/note/presentation/note_search_delegate.dart';
 import '../features/note/presentation/voice_to_note_screen.dart';
@@ -54,7 +55,8 @@ class _NotesTabState extends State<NotesTab> {
     });
   }
 
-  Future<String> _loadMascot() => SettingsServiceImpl().loadMascotPath();
+  Future<String> _loadMascot() =>
+      SettingsServiceImpl(backupService: BackupServiceImpl()).loadMascotPath();
 
   void _addNote() {
     showDialog(context: context, builder: (_) => const AddNoteDialog());
@@ -125,7 +127,8 @@ class _NotesTabState extends State<NotesTab> {
                         onThemeChanged: widget.onThemeChanged,
                         onFontScaleChanged: widget.onFontScaleChanged,
                         onThemeModeChanged: widget.onThemeModeChanged,
-                        settingsService: SettingsServiceImpl(),
+                        settingsService: SettingsServiceImpl(
+                            backupService: BackupServiceImpl()),
                       ),
                     ),
                   );
@@ -169,7 +172,8 @@ class _NotesTabState extends State<NotesTab> {
                                 onThemeChanged: widget.onThemeChanged,
                                 onFontScaleChanged: widget.onFontScaleChanged,
                                 onThemeModeChanged: widget.onThemeModeChanged,
-                                settingsService: SettingsServiceImpl(),
+                                settingsService: SettingsServiceImpl(
+                                    backupService: BackupServiceImpl()),
                               ),
                             ),
                           ),

--- a/test/backup_service_test.dart
+++ b/test/backup_service_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:alarm_domain/alarm_domain.dart';
+import 'package:alarm_domain/alarm_domain.dart' as domain;
 import 'package:alarm_data/alarm_data.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
@@ -97,7 +97,7 @@ void main() {
         (call) async => call.method == 'saveFile' ? path : null,
       );
       final l10n = await AppLocalizations.delegate.load(const Locale('en'));
-      const note = Note(id: '1', title: 't', content: 'c');
+      const note = domain.Note(id: '1', title: 't', content: 'c');
       final ok = await BackupService().exportNotes([note], l10n);
       expect(ok, true);
       final data = jsonDecode(await File(path).readAsString()) as List<dynamic>;
@@ -113,7 +113,7 @@ void main() {
         (call) async => call.method == 'saveFile' ? path : null,
       );
       final l10n = await AppLocalizations.delegate.load(const Locale('en'));
-      const note = Note(id: '1', title: 't', content: 'c');
+      const note = domain.Note(id: '1', title: 't', content: 'c');
       final ok = await BackupService().exportNotes(
         [note],
         l10n,
@@ -129,7 +129,7 @@ void main() {
 
     test('importNotes reads back data with password', () async {
       final db = DbService();
-      const note = Note(id: '1', title: 't', content: 'c');
+      const note = domain.Note(id: '1', title: 't', content: 'c');
       final enc = await db.encryptNote(note, password: 'pw');
       final path = '${tempDir.path}/notes.json';
       await File(path).writeAsString(jsonEncode([enc]));
@@ -158,7 +158,7 @@ void main() {
 
     test('importNotes returns empty on wrong password', () async {
       final db = DbService();
-      const note = Note(id: '1', title: 't', content: 'c');
+      const note = domain.Note(id: '1', title: 't', content: 'c');
       final enc = await db.encryptNote(note, password: 'pw');
       final path = '${tempDir.path}/notes.json';
       await File(path).writeAsString(jsonEncode([enc]));
@@ -213,11 +213,11 @@ void main() {
         (call) async => call.method == 'saveFile' ? path : null,
       );
       final l10n = await AppLocalizations.delegate.load(const Locale('en'));
-      const note = Note(id: '1', title: 't', content: 'c');
+      const note = domain.Note(id: '1', title: 't', content: 'c');
       final ok = await BackupService().exportNotes(
         [note],
         l10n,
-        format: BackupFormat.md,
+        format: domain.BackupFormat.md,
       );
       expect(ok, true);
       final data = await File(path).readAsString();
@@ -246,7 +246,7 @@ void main() {
       final l10n = await AppLocalizations.delegate.load(const Locale('en'));
       final notes = await BackupService().importNotes(
         l10n,
-        format: BackupFormat.md,
+        format: domain.BackupFormat.md,
       );
       expect(notes.length, 1);
       expect(notes.first.title, 't');
@@ -259,11 +259,11 @@ void main() {
         (call) async => call.method == 'saveFile' ? path : null,
       );
       final l10n = await AppLocalizations.delegate.load(const Locale('en'));
-      const note = Note(id: '1', title: 't', content: 'c');
+      const note = domain.Note(id: '1', title: 't', content: 'c');
       final ok = await BackupService().exportNotes(
         [note],
         l10n,
-        format: BackupFormat.pdf,
+        format: domain.BackupFormat.pdf,
       );
       expect(ok, true);
       final bytes = await File(path).readAsBytes();

--- a/test/db_service_test.dart
+++ b/test/db_service_test.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:alarm_domain/alarm_domain.dart';
+import 'package:alarm_domain/alarm_domain.dart' as domain;
 import 'package:alarm_data/alarm_data.dart';
 
 void main() {
@@ -17,8 +17,8 @@ void main() {
   test('getNotes reports corrupted entries', () async {
     final db = DbService();
     final notes = const [
-      Note(id: 'good', title: 't', content: 'c'),
-      Note(id: 'bad', title: 't2', content: 'c2'),
+      domain.Note(id: 'good', title: 't', content: 'c'),
+      domain.Note(id: 'bad', title: 't2', content: 'c2'),
     ];
     await db.saveNotes(notes);
 

--- a/test/note_repository_test.dart
+++ b/test/note_repository_test.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:alarm_domain/alarm_domain.dart';
+import 'package:alarm_domain/alarm_domain.dart' as domain;
 import 'package:alarm_data/alarm_data.dart';
 import 'package:uuid/uuid.dart';
 
@@ -25,7 +25,7 @@ void main() {
     test('saveNotes and getNotes persist data', () async {
       final repo = NoteRepositoryImpl();
       final id = const Uuid().v4();
-      final note = Note(
+      final note = domain.Note(
         id: id,
         title: 't',
         content: 'c',
@@ -56,7 +56,7 @@ void main() {
     test('updateNote persists changes', () async {
       final repo = NoteRepositoryImpl();
       final id = const Uuid().v4();
-      final note = Note(
+      final note = domain.Note(
         id: id,
         title: 't',
         content: 'c',
@@ -67,7 +67,7 @@ void main() {
         snoozeMinutes: 5,
       );
       await repo.saveNotes([note]);
-      final updated = Note(
+      final updated = domain.Note(
         id: id,
         title: 't2',
         content: 'c2',

--- a/test/settings_service_test.dart
+++ b/test/settings_service_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:notes_reminder_app/features/settings/data/settings_service.dart';
+import 'package:notes_reminder_app/features/backup/data/backup_service.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -11,28 +12,32 @@ void main() {
   });
 
   test('save and load theme color', () async {
-    final service = SettingsServiceImpl();
+    final service =
+        SettingsServiceImpl(backupService: BackupServiceImpl());
     await service.saveThemeColor(Colors.red);
     final color = await service.loadThemeColor();
     expect(color, Colors.red);
   });
 
   test('save and load mascot path', () async {
-    final service = SettingsServiceImpl();
+    final service =
+        SettingsServiceImpl(backupService: BackupServiceImpl());
     await service.saveMascotPath('path.json');
     final path = await service.loadMascotPath();
     expect(path, 'path.json');
   });
 
   test('save and load font scale', () async {
-    final service = SettingsServiceImpl();
+    final service =
+        SettingsServiceImpl(backupService: BackupServiceImpl());
     await service.saveFontScale(1.5);
     final scale = await service.loadFontScale();
     expect(scale, 1.5);
   });
 
   test('save and load require auth', () async {
-    final service = SettingsServiceImpl();
+    final service =
+        SettingsServiceImpl(backupService: BackupServiceImpl());
     await service.saveRequireAuth(true);
     final value = await service.loadRequireAuth();
     expect(value, true);
@@ -40,7 +45,8 @@ void main() {
 
 
   test('save and load has seen onboarding', () async {
-    final service = SettingsServiceImpl();
+    final service =
+        SettingsServiceImpl(backupService: BackupServiceImpl());
     await service.saveHasSeenOnboarding(true);
     final value = await service.loadHasSeenOnboarding();
     expect(value, true);
@@ -48,7 +54,8 @@ void main() {
   });
 
   test('default values returned when not set', () async {
-    final service = SettingsServiceImpl();
+    final service =
+        SettingsServiceImpl(backupService: BackupServiceImpl());
     final color = await service.loadThemeColor();
     final path = await service.loadMascotPath();
     final scale = await service.loadFontScale();


### PR DESCRIPTION
## Summary
- define BackupService interface with BackupFormat in alarm_domain
- wrap existing backup functionality to implement new interface
- inject BackupService into SettingsService and adjust callers

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd716babac8333a1c933067101eb97