### PR TITLE
chore: centralize shared dependencies

### DIFF
--- a/alarm_data/pubspec.yaml
+++ b/alarm_data/pubspec.yaml
@@ -11,11 +11,11 @@ dependencies:
     sdk: flutter
   alarm_domain:
     path: ../alarm_domain
-  file_picker: 6.2.1
-  pdf: 3.11.3
-  path_provider: 2.1.5
-  uuid: 4.5.1
-  encrypt: 5.0.3
-  cryptography: 2.7.0
-  flutter_secure_storage: 9.2.4
-  shared_preferences: 2.5.3
+  file_picker: ^6.2.1
+  pdf: ^3.11.3
+  path_provider: ^2.1.5
+  uuid: ^4.5.1
+  encrypt: ^5.0.3
+  cryptography: ^2.7.0
+  flutter_secure_storage: ^9.2.4
+  shared_preferences: ^2.5.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -60,6 +60,16 @@ dependencies:
   alarm_data:
     path: alarm_data
 
+dependency_overrides:
+  file_picker: 6.2.1
+  pdf: 3.11.3
+  path_provider: 2.1.5
+  uuid: 4.5.1
+  encrypt: 5.0.3
+  cryptography: 2.7.0
+  flutter_secure_storage: 9.2.4
+  shared_preferences: 2.5.3
+
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- centralize shared dependencies with dependency overrides
- align `alarm_data` dependency constraints with root versions

## Testing
- `flutter pub get` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68bd76073f308333be67d899676eaafe