### PR TITLE
Use caret versions for dependencies

### DIFF
--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,8 +8,10 @@ import Foundation
 import audioplayers_darwin
 import cloud_firestore
 import connectivity_plus
+import firebase_analytics
 import firebase_auth
 import firebase_core
+import firebase_crashlytics
 import flutter_local_notifications
 import flutter_native_timezone
 import flutter_secure_storage_macos
@@ -25,8 +27,10 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioplayersDarwinPlugin.register(with: registry.registrar(forPlugin: "AudioplayersDarwinPlugin"))
   FLTFirebaseFirestorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseFirestorePlugin"))
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
+  FirebaseAnalyticsPlugin.register(with: registry.registrar(forPlugin: "FirebaseAnalyticsPlugin"))
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
+  FLTFirebaseCrashlyticsPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCrashlyticsPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterNativeTimezonePlugin.register(with: registry.registrar(forPlugin: "FlutterNativeTimezonePlugin"))
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -894,10 +894,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
@@ -1315,10 +1315,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.6"
   timezone:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,49 +11,49 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
-  flutter_local_notifications: 19.4.1
-  timezone: 0.10.1
-  flutter_native_timezone: 2.0.0
-  lottie: 3.3.1
-  http: 1.5.0
+  flutter_local_notifications: ^19.4.1
+  timezone: ^0.10.1
+  flutter_native_timezone: ^2.0.0
+  lottie: ^3.3.1
+  http: ^1.5.0
 
   flutter_colorpicker: ^1.1.0
 
-  shared_preferences: 2.5.3
-  audioplayers: 6.5.0
-  intl: 0.20.2
-  provider: 6.1.5+1
-  flutter_tts: 4.2.3
-  speech_to_text: 7.3.0
-  share_plus: 10.1.4
-  connectivity_plus: 6.1.5
+  shared_preferences: ^2.5.3
+  audioplayers: ^6.5.0
+  intl: ^0.20.2
+  provider: ^6.1.5+1
+  flutter_tts: ^4.2.3
+  speech_to_text: ^7.3.0
+  share_plus: ^10.1.4
+  connectivity_plus: ^6.1.5
 
-  home_widget: 0.5.0
+  home_widget: ^0.5.0
 
 
-  local_auth: 2.3.0
+  local_auth: ^2.3.0
 
-  cryptography: 2.7.0
-  encrypt: 5.0.3
-  flutter_secure_storage: 9.2.4
-  file_picker: 6.2.1
-  pdf: 3.11.3
+  cryptography: ^2.7.0
+  encrypt: ^5.0.3
+  flutter_secure_storage: ^9.2.4
+  file_picker: ^6.2.1
+  pdf: ^3.11.3
 
-  path_provider: 2.1.5
+  path_provider: ^2.1.5
 
-  json_annotation: 4.9.0
+  json_annotation: ^4.9.0
 
-  firebase_core: 4.1.0
-  cloud_firestore: 6.0.1
-  firebase_auth: 6.0.2
+  firebase_core: ^4.1.0
+  cloud_firestore: ^6.0.1
+  firebase_auth: ^6.0.2
 
-  firebase_crashlytics: 5.0.1
-  firebase_analytics: 12.0.1
+  firebase_crashlytics: ^5.0.1
+  firebase_analytics: ^12.0.1
 
-  google_sign_in: 6.3.0
-  uuid: 4.5.1
-  google_fonts: 6.2.1
-  fuse: 0.0.99
+  google_sign_in: ^6.3.0
+  uuid: ^4.5.1
+  google_fonts: ^6.2.1
+  fuse: ^0.0.99
 
   alarm_domain:
     path: alarm_domain
@@ -64,13 +64,13 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: 2.0.3
-  mocktail: 1.0.4
+  flutter_lints: ^2.0.3
+  mocktail: ^1.0.4
   integration_test:
     sdk: flutter
-  build_runner: 2.8.0
-  json_serializable: 6.11.1
-  connectivity_plus_platform_interface: 2.0.1
+  build_runner: ^2.8.0
+  json_serializable: ^6.11.1
+  connectivity_plus_platform_interface: ^2.0.1
 
 flutter:
   generate: true


### PR DESCRIPTION
## Summary
- replace pinned package versions in `pubspec.yaml` with caret constraints
- update generated plugin registrant after dependency resolution

## Testing
- `flutter pub get`
- `flutter test` *(fails: Couldn't resolve the package 'flutter_slidable')*

------
https://chatgpt.com/codex/tasks/task_e_68bd75e35fcc833389028129385b7f6b