### PR TITLE
chore: align build_runner and json_serializable versions

### DIFF
--- a/alarm_data/pubspec.yaml
+++ b/alarm_data/pubspec.yaml
@@ -19,3 +19,7 @@ dependencies:
   cryptography: 2.7.0
   flutter_secure_storage: 9.2.4
   shared_preferences: 2.5.3
+
+dev_dependencies:
+  build_runner: ^2.8.0
+  json_serializable: ^6.11.1

--- a/alarm_domain/lib/src/entities/note.g.dart
+++ b/alarm_domain/lib/src/entities/note.g.dart
@@ -7,70 +7,66 @@ part of 'note.dart';
 // **************************************************************************
 
 Note _$NoteFromJson(Map<String, dynamic> json) => Note(
-
-  id: json['id'] as String,
-  title: json['title'] as String,
-  content: json['content'] as String,
-  summary: json['summary'] as String? ?? '',
-  actionItems:
-      (json['actionItems'] as List<dynamic>?)
-          ?.map((e) => e as String)
-          .toList() ??
-      [],
-  dates:
-      (json['dates'] as List<dynamic>?)
-          ?.map((e) => DateTime.parse(e as String))
-          .toList() ??
-      [],
-  alarmTime: json['alarmTime'] == null
-      ? null
-      : DateTime.parse(json['alarmTime'] as String),
-  repeatInterval: $enumDecodeNullable(
-    _$RepeatIntervalEnumMap,
-    json['repeatInterval'],
-  ),
-  daily: json['daily'] as bool? ?? false,
-  active: json['active'] as bool? ?? false,
-  tags:
-      (json['tags'] as List<dynamic>?)?.map((e) => e as String).toList() ?? [],
-  attachments:
-      (json['attachments'] as List<dynamic>?)
-          ?.map((e) => e as String)
-          .toList() ??
-      [],
-  color: (json['color'] as num?)?.toInt() ?? 4294967295,
-  pinned: json['pinned'] as bool? ?? false,
-  locked: json['locked'] as bool? ?? false,
-  snoozeMinutes: (json['snoozeMinutes'] as num?)?.toInt() ?? 0,
-  updatedAt: json['updatedAt'] == null
-      ? null
-      : DateTime.parse(json['updatedAt'] as String),
-  notificationId: (json['notificationId'] as num?)?.toInt(),
-  eventId: json['eventId'] as String?,
-);
+      id: json['id'] as String,
+      title: json['title'] as String,
+      content: json['content'] as String,
+      summary: json['summary'] as String? ?? '',
+      actionItems: (json['actionItems'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          [],
+      dates: (json['dates'] as List<dynamic>?)
+              ?.map((e) => DateTime.parse(e as String))
+              .toList() ??
+          [],
+      alarmTime: json['alarmTime'] == null
+          ? null
+          : DateTime.parse(json['alarmTime'] as String),
+      repeatInterval:
+          $enumDecodeNullable(_$RepeatIntervalEnumMap, json['repeatInterval']),
+      daily: json['daily'] as bool? ?? false,
+      active: json['active'] as bool? ?? false,
+      tags:
+          (json['tags'] as List<dynamic>?)?.map((e) => e as String).toList() ??
+              [],
+      attachments: (json['attachments'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          [],
+      color: (json['color'] as num?)?.toInt() ?? 4294967295,
+      pinned: json['pinned'] as bool? ?? false,
+      locked: json['locked'] as bool? ?? false,
+      snoozeMinutes: (json['snoozeMinutes'] as num?)?.toInt() ?? 0,
+      done: json['done'] as bool? ?? false,
+      updatedAt: json['updatedAt'] == null
+          ? null
+          : DateTime.parse(json['updatedAt'] as String),
+      notificationId: (json['notificationId'] as num?)?.toInt(),
+      eventId: json['eventId'] as String?,
+    );
 
 Map<String, dynamic> _$NoteToJson(Note instance) => <String, dynamic>{
-  'id': instance.id,
-  'title': instance.title,
-  'content': instance.content,
-  'summary': instance.summary,
-  'actionItems': instance.actionItems,
-  'dates': instance.dates.map((e) => e.toIso8601String()).toList(),
-  'alarmTime': instance.alarmTime?.toIso8601String(),
-  'repeatInterval': _$RepeatIntervalEnumMap[instance.repeatInterval],
-  'daily': instance.daily,
-  'active': instance.active,
-  'tags': instance.tags,
-  'attachments': instance.attachments,
-  'color': instance.color,
-  'pinned': instance.pinned,
-  'locked': instance.locked,
-  'snoozeMinutes': instance.snoozeMinutes,
-  'updatedAt': instance.updatedAt?.toIso8601String(),
-  'notificationId': instance.notificationId,
-  'eventId': instance.eventId,
-};
-
+      'id': instance.id,
+      'title': instance.title,
+      'content': instance.content,
+      'summary': instance.summary,
+      'actionItems': instance.actionItems,
+      'dates': instance.dates.map((e) => e.toIso8601String()).toList(),
+      'alarmTime': instance.alarmTime?.toIso8601String(),
+      'repeatInterval': _$RepeatIntervalEnumMap[instance.repeatInterval],
+      'daily': instance.daily,
+      'active': instance.active,
+      'tags': instance.tags,
+      'attachments': instance.attachments,
+      'color': instance.color,
+      'pinned': instance.pinned,
+      'locked': instance.locked,
+      'snoozeMinutes': instance.snoozeMinutes,
+      'done': instance.done,
+      'updatedAt': instance.updatedAt?.toIso8601String(),
+      'notificationId': instance.notificationId,
+      'eventId': instance.eventId,
+    };
 
 const _$RepeatIntervalEnumMap = {
   RepeatInterval.everyMinute: 'everyMinute',

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -894,10 +894,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
@@ -1315,10 +1315,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.6"
   timezone:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,8 +68,8 @@ dev_dependencies:
   mocktail: 1.0.4
   integration_test:
     sdk: flutter
-  build_runner: 2.8.0
-  json_serializable: 6.11.1
+  build_runner: ^2.8.0
+  json_serializable: ^6.11.1
   connectivity_plus_platform_interface: 2.0.1
 
 flutter:


### PR DESCRIPTION
## Summary
- use caret syntax to align build_runner and json_serializable versions
- add build_runner and json_serializable dev dependencies to alarm_data
- regenerate domain note serialization

## Testing
- `flutter pub run build_runner build --delete-conflicting-outputs`
- `cd alarm_domain && flutter pub run build_runner build --delete-conflicting-outputs`
- `cd alarm_data && flutter pub run build_runner build --delete-conflicting-outputs`


------
https://chatgpt.com/codex/tasks/task_e_68bd76076cf08333a74a72a5d570c3f1