### PR TITLE
Use structured logging in AuthService

### DIFF
--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,11 +1,15 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:local_auth/local_auth.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:logger/logger.dart';
 
 class AuthService {
   final LocalAuthentication _auth;
-  AuthService({LocalAuthentication? auth}) : _auth = auth ?? LocalAuthentication();
+  final Logger _logger;
+
+  AuthService({LocalAuthentication? auth, Logger? logger})
+      : _auth = auth ?? LocalAuthentication(),
+        _logger = logger ?? Logger();
 
   Future<bool> authenticate(AppLocalizations l10n) async {
     try {
@@ -14,12 +18,20 @@ class AuthService {
         options: const AuthenticationOptions(stickyAuth: true),
       );
     } on PlatformException catch (e, st) {
-      debugPrint(l10n.errorWithMessage('${e.message ?? e.toString()}\n$st'));
+      _logger.e(
+        l10n.errorWithMessage(e.message ?? e.toString()),
+        error: e,
+        stackTrace: st,
+      );
       return false;
     } catch (e, st) {
       // Catch any other unexpected errors and fail gracefully instead of
       // bubbling the exception up to the caller which could crash the app.
-      debugPrint(l10n.errorWithMessage('${e.toString()}\n$st'));
+      _logger.e(
+        l10n.errorWithMessage(e.toString()),
+        error: e,
+        stackTrace: st,
+      );
       return false;
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,8 @@ dependencies:
 
   local_auth: ^2.3.0
 
+  logger: ^2.0.2
+
   cryptography: ^2.7.0
   encrypt: ^5.0.3
   flutter_secure_storage: ^9.2.4

--- a/test/auth_service_test.dart
+++ b/test/auth_service_test.dart
@@ -5,19 +5,23 @@ import 'package:mocktail/mocktail.dart';
 import 'package:local_auth/local_auth.dart';
 import 'package:notes_reminder_app/services/auth_service.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:logger/logger.dart';
 
 class MockLocalAuth extends Mock implements LocalAuthentication {}
+class MockLogger extends Mock implements Logger {}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late MockLocalAuth mock;
   late AuthService service;
+  late MockLogger logger;
   late AppLocalizations l10n;
 
   setUp(() async {
     mock = MockLocalAuth();
-    service = AuthService(auth: mock);
+    logger = MockLogger();
+    service = AuthService(auth: mock, logger: logger);
     l10n = await AppLocalizations.delegate.load(const Locale('en'));
   });
 
@@ -39,6 +43,7 @@ void main() {
 
     final ok = await service.authenticate(l10n);
     expect(ok, isFalse);
+    verify(() => logger.e(any(), error: any(named: 'error'), stackTrace: any(named: 'stackTrace'))).called(1);
   });
 
   test('authenticate returns false on generic exception', () async {
@@ -49,5 +54,6 @@ void main() {
 
     final ok = await service.authenticate(l10n);
     expect(ok, isFalse);
+    verify(() => logger.e(any(), error: any(named: 'error'), stackTrace: any(named: 'stackTrace'))).called(1);
   });
 }


### PR DESCRIPTION
## Summary
- replace `debugPrint` with `logger` in `AuthService`
- inject a `Logger` instance for easier testing
- add tests verifying errors are logged
- add `logger` dependency

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd78d67dc483339d75750e03e7fa60