### PR TITLE
docs: add English architecture translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Flutter application to manage notes, schedule reminders, transcribe speech, play text aloud, and chat with Gemini AI.
 
-For an overview of how the app is structured, see the [architecture documentation](docs/ARCHITECTURE.md) including the [AuthService flow](docs/ARCHITECTURE.md#authservice-flow) and [ConnectivityService strategy](docs/ARCHITECTURE.md#connectivityservice-strategy).
+For an overview of how the app is structured, see the architecture documentation in [Vietnamese](docs/ARCHITECTURE.md) or [English](docs/ARCHITECTURE_en.md), including the AuthService flow and ConnectivityService strategy.
 
 ## Features
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,7 @@
 # Kiến trúc
 
+[Read this in English](ARCHITECTURE_en.md).
+
 Ứng dụng được chia thành bốn lớp chính.
 
 ## Models

--- a/docs/ARCHITECTURE_en.md
+++ b/docs/ARCHITECTURE_en.md
@@ -1,0 +1,38 @@
+# Architecture
+
+[Xem bằng tiếng Việt](ARCHITECTURE.md).
+
+The app is divided into four main layers.
+
+## Models
+Data classes such as `Note` and `Reminder`. They map directly to Firestore documents and convert to/from JSON.
+
+## Providers
+Manage state and supply reactive data to widgets. Each provider watches a set of `Model`s and notifies the UI when the data changes.
+
+## Services
+Contain business logic and interact with external systems.
+- **FirebaseService**: saves and reads notes from Cloud Firestore.
+- **NotificationService**: schedules and cancels reminders via local notifications.
+
+## Widgets
+UI components: note list, edit screen, and reminder form. Widgets consume data from providers and send user events back.
+
+## Flow: note → save to Firebase → reminder
+1. The user creates or edits a note in a widget.
+2. The widget calls a provider to update the corresponding `Model`.
+3. The provider uses `FirebaseService` to save the note to Firestore.
+4. After saving, the provider calls `NotificationService` to schedule a reminder.
+5. The user receives a notification at the scheduled time.
+
+<a id="authservice-flow"></a>
+## AuthService flow
+1. The app launches.
+2. `AuthService` checks the current sign-in state.
+3. It routes to the appropriate screen based on that state.
+
+<a id="connectivityservice-strategy"></a>
+## ConnectivityService strategy
+- Monitor network connectivity.
+- When offline, mark data for sync and inform the user.
+- When connectivity returns, sync changes back to the server.


### PR DESCRIPTION
## Summary
- translate architecture docs into English
- cross-link English and Vietnamese versions
- mention both architecture docs in README

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd78e4fb908333a98dd587e08ec414