### PR TITLE
chore: strengthen lint rules

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -26,6 +26,9 @@ linter:
     - prefer_final_fields
     - avoid_print
     - unused_import
+    - always_use_package_imports
+    - prefer_const_literals_to_create_immutables
+    - avoid_unused_constructor_parameters
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options


### PR DESCRIPTION
## Summary
- enforce package imports, const literals, and constructor parameter usage via new lint rules

## Testing
- `flutter analyze` *(fails: command hung after downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bd78e8420c8333a700c4416a986a72