### PR TITLE
Use caret versions and remove overrides

### DIFF
--- a/alarm_data/pubspec.yaml
+++ b/alarm_data/pubspec.yaml
@@ -12,14 +12,14 @@ dependencies:
   alarm_domain:
     path: ../alarm_domain
 
-  file_picker: 6.2.1
-  pdf: 3.11.3
-  path_provider: 2.1.5
-  uuid: 4.5.1
-  encrypt: 5.0.3
-  cryptography: 2.7.0
-  flutter_secure_storage: 9.2.4
-  shared_preferences: 2.5.3
+  file_picker: ^6.2.1
+  pdf: ^3.11.3
+  path_provider: ^2.1.5
+  uuid: ^4.5.1
+  encrypt: ^5.0.3
+  cryptography: ^2.7.0
+  flutter_secure_storage: ^9.2.4
+  shared_preferences: ^2.5.3
 
 dev_dependencies:
   build_runner: ^2.8.0

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -858,6 +858,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.11"
+  logger:
+    dependency: "direct main"
+    description:
+      name: logger
+      sha256: "55d6c23a6c15db14920e037fe7e0dc32e7cdaf3b64b4b25df2d541b5b6b81c0c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
   logging:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,17 +62,6 @@ dependencies:
   alarm_data:
     path: alarm_data
 
-dependency_overrides:
-  file_picker: 6.2.1
-  pdf: 3.11.3
-  path_provider: 2.1.5
-  uuid: 4.5.1
-  encrypt: 5.0.3
-  cryptography: 2.7.0
-  flutter_secure_storage: 9.2.4
-  shared_preferences: 2.5.3
-
-
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## Summary
- use caret constraints for core packages in alarm_data
- remove redundant dependency_overrides block from root pubspec
- update lockfile after resolving dependencies

## Testing
- `flutter pub get` *(produced file_picker plugin warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bd79d5077083338803b0de6bd69f5a