### PR TITLE
chore: remove connectivity platform interface dev dep

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -272,7 +272,7 @@ packages:
     source: hosted
     version: "6.1.5"
   connectivity_plus_platform_interface:
-    dependency: "direct dev"
+    dependency: transitive
     description:
       name: connectivity_plus_platform_interface
       sha256: "42657c1715d48b167930d5f34d00222ac100475f73d10162ddf43e714932f204"
@@ -858,6 +858,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.11"
+  logger:
+    dependency: "direct main"
+    description:
+      name: logger
+      sha256: "55d6c23a6c15db14920e037fe7e0dc32e7cdaf3b64b4b25df2d541b5b6b81c0c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
   logging:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -82,10 +82,6 @@ dev_dependencies:
     sdk: flutter
   build_runner: ^2.8.0
   json_serializable: ^6.11.1
-
-  connectivity_plus_platform_interface: 2.0.1
-
-
 flutter:
   generate: true
   uses-material-design: true


### PR DESCRIPTION
## Summary
- remove connectivity_plus_platform_interface from dev dependencies

## Testing
- `flutter pub get`
- `flutter test` *(fails: couldn't resolve package 'flutter_gen')*

------
https://chatgpt.com/codex/tasks/task_e_68bd79e3a0988333a369bcd668abd0e9