### PR TITLE
Refactor provider wiring to use domain use cases

### DIFF
--- a/alarm_domain/lib/alarm_domain.dart
+++ b/alarm_domain/lib/alarm_domain.dart
@@ -8,9 +8,11 @@ export 'src/repositories/note_repository.dart';
 export 'src/usecases/get_notes.dart';
 export 'src/usecases/save_notes.dart';
 export 'src/usecases/update_note.dart';
+export 'src/usecases/auto_backup.dart';
 export 'src/services/notification_service.dart';
 export 'src/services/calendar_service.dart';
 export 'src/services/home_widget_service.dart';
 
 export 'src/services/backup_service.dart';
+export 'src/services/note_sync_service.dart';
 

--- a/alarm_domain/lib/src/usecases/auto_backup.dart
+++ b/alarm_domain/lib/src/usecases/auto_backup.dart
@@ -1,0 +1,12 @@
+import '../repositories/note_repository.dart';
+
+/// Triggers an automatic backup of notes via the repository.
+class AutoBackup {
+  final NoteRepository repository;
+
+  AutoBackup(this.repository);
+
+  Future<bool> call() {
+    return repository.autoBackup();
+  }
+}

--- a/integration_test/sync_and_notification_test.dart
+++ b/integration_test/sync_and_notification_test.dart
@@ -115,7 +115,10 @@ void main() {
     });
 
     final provider = NoteProvider(
-      repository: repo,
+      getNotes: GetNotes(repo),
+      saveNotes: SaveNotes(repo),
+      updateNote: UpdateNote(repo),
+      autoBackup: AutoBackup(repo),
       calendarService: calendar,
       notificationService: notification,
       homeWidgetService: DummyHomeWidget(),

--- a/test/note_provider_test.dart
+++ b/test/note_provider_test.dart
@@ -66,7 +66,10 @@ void main() {
     when(() => homeWidget.update(any())).thenAnswer((_) async {});
 
     final provider = NoteProvider(
-      repository: repo,
+      getNotes: GetNotes(repo),
+      saveNotes: SaveNotes(repo),
+      updateNote: UpdateNote(repo),
+      autoBackup: AutoBackup(repo),
       calendarService: calendar,
       notificationService: notification,
       syncService: sync,
@@ -113,7 +116,10 @@ void main() {
     when(() => homeWidget.update(any())).thenAnswer((_) async {});
 
     final provider = NoteProvider(
-      repository: repo,
+      getNotes: GetNotes(repo),
+      saveNotes: SaveNotes(repo),
+      updateNote: UpdateNote(repo),
+      autoBackup: AutoBackup(repo),
       calendarService: calendar,
       notificationService: notification,
       syncService: sync,
@@ -178,7 +184,10 @@ void main() {
       when(() => sync.syncNote(any())).thenAnswer((_) async {});
 
       final provider = NoteProvider(
-        repository: repo,
+        getNotes: GetNotes(repo),
+        saveNotes: SaveNotes(repo),
+        updateNote: UpdateNote(repo),
+        autoBackup: AutoBackup(repo),
         calendarService: calendar,
         notificationService: notification,
         syncService: sync,
@@ -237,7 +246,10 @@ void main() {
     when(() => homeWidget.update(any())).thenAnswer((_) async {});
 
     final provider = NoteProvider(
-      repository: repo,
+      getNotes: GetNotes(repo),
+      saveNotes: SaveNotes(repo),
+      updateNote: UpdateNote(repo),
+      autoBackup: AutoBackup(repo),
       calendarService: MockCalendar(),
       notificationService: MockNotification(),
       syncService: sync,
@@ -293,7 +305,10 @@ void main() {
     when(() => homeWidget.update(any())).thenAnswer((_) async {});
 
     final provider = NoteProvider(
-      repository: repo,
+      getNotes: GetNotes(repo),
+      saveNotes: SaveNotes(repo),
+      updateNote: UpdateNote(repo),
+      autoBackup: AutoBackup(repo),
       calendarService: calendar,
       notificationService: notification,
       syncService: sync,

--- a/test/notes_list_unsynced_test.dart
+++ b/test/notes_list_unsynced_test.dart
@@ -8,8 +8,17 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:notes_reminder_app/features/note/presentation/note_provider.dart';
 import 'package:notes_reminder_app/widgets/notes_list.dart';
 import 'package:notes_reminder_app/features/note/note.dart';
+import 'package:notes_reminder_app/features/note/data/calendar_service.dart';
+import 'package:notes_reminder_app/features/note/data/notification_service.dart';
+import 'package:notes_reminder_app/features/note/data/home_widget_service.dart';
+import 'package:notes_reminder_app/features/backup/data/note_sync_service.dart';
+import 'package:alarm_domain/alarm_domain.dart';
 
 class MockRepo extends Mock implements NoteRepository {}
+class MockCalendar extends Mock implements CalendarService {}
+class MockNotification extends Mock implements NotificationService {}
+class MockHomeWidget extends Mock implements HomeWidgetService {}
+class MockSyncService extends Mock implements NoteSyncService {}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -17,8 +26,25 @@ void main() {
   testWidgets('displays sync problem icon for unsynced notes', (tester) async {
     SharedPreferences.setMockInitialValues({});
     final repo = MockRepo();
+    final calendar = MockCalendar();
+    final notification = MockNotification();
+    final homeWidget = MockHomeWidget();
+    final sync = MockSyncService();
     when(() => repo.saveNotes(any())).thenAnswer((_) async {});
-    final provider = NoteProvider(repository: repo);
+    when(() => sync.init(any())).thenAnswer((_) async {});
+    when(() => sync.syncStatus).thenReturn(ValueNotifier(SyncStatus.idle));
+    when(() => sync.loadFromRemote(any())).thenAnswer((_) async => true);
+    when(() => homeWidget.update(any())).thenAnswer((_) async {});
+    final provider = NoteProvider(
+      getNotes: GetNotes(repo),
+      saveNotes: SaveNotes(repo),
+      updateNote: UpdateNote(repo),
+      autoBackup: AutoBackup(repo),
+      calendarService: calendar,
+      notificationService: notification,
+      homeWidgetService: homeWidget,
+      syncService: sync,
+    );
     await Future.delayed(Duration.zero);
 
     const note = Note(


### PR DESCRIPTION
## Summary
- wire data sources, repository, use cases and sync service in `AppProviders`
- expose new `AutoBackup` use case and `NoteSyncService` from `alarm_domain`
- update `NoteProvider` to depend on injected use cases instead of repository
- adjust tests and integration setup for new constructor

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bd7dacc8a08333809ccab714f82aa3