### PR TITLE
test: add use case tests

### DIFF
--- a/alarm_domain/test/get_notes_test.dart
+++ b/alarm_domain/test/get_notes_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:alarm_domain/alarm_domain.dart';
+
+class _MockNoteRepository extends Mock implements NoteRepository {}
+
+void main() {
+  group('GetNotes', () {
+    late NoteRepository repository;
+    late GetNotes usecase;
+
+    setUp(() {
+      repository = _MockNoteRepository();
+      usecase = GetNotes(repository);
+    });
+
+    final notes = [
+      const Note(id: '1', title: 't1', content: 'c1'),
+      const Note(id: '2', title: 't2', content: 'c2'),
+    ];
+
+    test('returns notes from repository', () async {
+      when(() => repository.getNotes(onDecryptFailure: any(named: 'onDecryptFailure')))
+          .thenAnswer((_) async => notes);
+
+      final result = await usecase();
+
+      expect(result, notes);
+      verify(() => repository.getNotes(onDecryptFailure: any(named: 'onDecryptFailure')))
+          .called(1);
+    });
+
+    test('propagates repository errors', () {
+      when(() => repository.getNotes(onDecryptFailure: any(named: 'onDecryptFailure')))
+          .thenThrow(Exception('decryption error'));
+
+      expect(usecase(), throwsA(isA<Exception>()));
+    });
+
+    test('invokes onDecryptFailure callback when provided', () async {
+      when(() => repository.getNotes(onDecryptFailure: any(named: 'onDecryptFailure')))
+          .thenAnswer((invocation) async {
+        final cb = invocation.namedArguments[#onDecryptFailure] as void Function(String)?;
+        cb?.call('bad-id');
+        return [];
+      });
+
+      var capturedId = '';
+      await usecase(onDecryptFailure: (id) => capturedId = id);
+
+      expect(capturedId, 'bad-id');
+    });
+  });
+}

--- a/alarm_domain/test/save_notes_test.dart
+++ b/alarm_domain/test/save_notes_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:alarm_domain/alarm_domain.dart';
+
+class _MockNoteRepository extends Mock implements NoteRepository {}
+
+void main() {
+  group('SaveNotes', () {
+    late NoteRepository repository;
+    late SaveNotes usecase;
+    final notes = [
+      const Note(id: '1', title: 't1', content: 'c1'),
+      const Note(id: '2', title: 't2', content: 'c2'),
+    ];
+
+    setUp(() {
+      repository = _MockNoteRepository();
+      usecase = SaveNotes(repository);
+    });
+
+    test('saves notes using repository', () async {
+      when(() => repository.saveNotes(notes)).thenAnswer((_) async {});
+
+      await usecase(notes);
+
+      verify(() => repository.saveNotes(notes)).called(1);
+    });
+
+    test('propagates repository errors', () {
+      when(() => repository.saveNotes(notes))
+          .thenThrow(Exception('encryption error'));
+
+      expect(usecase(notes), throwsA(isA<Exception>()));
+    });
+  });
+}

--- a/alarm_domain/test/update_note_test.dart
+++ b/alarm_domain/test/update_note_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:alarm_domain/alarm_domain.dart';
+
+class _MockNoteRepository extends Mock implements NoteRepository {}
+
+void main() {
+  group('UpdateNote', () {
+    late NoteRepository repository;
+    late UpdateNote usecase;
+    const note = Note(id: '1', title: 't1', content: 'c1');
+
+    setUp(() {
+      repository = _MockNoteRepository();
+      usecase = UpdateNote(repository);
+    });
+
+    test('updates note via repository', () async {
+      when(() => repository.updateNote(note)).thenAnswer((_) async {});
+
+      await usecase(note);
+
+      verify(() => repository.updateNote(note)).called(1);
+    });
+
+    test('propagates repository errors', () {
+      when(() => repository.updateNote(note))
+          .thenThrow(Exception('encryption error'));
+
+      expect(usecase(note), throwsA(isA<Exception>()));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add GetNotes use case tests for success and failure scenarios
- test SaveNotes and UpdateNote success and error handling

## Testing
- `flutter test alarm_domain/test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: unable to locate package)*
- `apt-get install -y flutter` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7db069088333bf833823f27f0127