### PR TITLE
chore: add platform interface dev deps

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -71,6 +71,8 @@ dev_dependencies:
     sdk: flutter
   build_runner: ^2.8.0
   json_serializable: ^6.11.1
+  connectivity_plus_platform_interface: ^2.0.1
+  google_sign_in_platform_interface: ^3.0.0
 flutter:
   generate: true
   uses-material-design: true


### PR DESCRIPTION
## Summary
- add connectivity_plus_platform_interface and google_sign_in_platform_interface as dev dependencies

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd81afe8788333b098d41154756bbb