### PR TITLE
Refactor sync status to Stream and drop Flutter from domain

### DIFF
--- a/alarm_domain/lib/src/services/note_sync_service.dart
+++ b/alarm_domain/lib/src/services/note_sync_service.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/foundation.dart';
-
 import '../entities/note.dart';
 
 /// Represents the current synchronization status.
@@ -10,7 +8,12 @@ typedef NoteGetter = Note? Function(String id);
 
 /// Contract for synchronizing notes with a remote backend.
 abstract class NoteSyncService {
-  ValueNotifier<SyncStatus> get syncStatus;
+  /// Stream of synchronization status updates.
+  Stream<SyncStatus> get syncStatus;
+
+  /// Set a new synchronization status.
+  void setSyncStatus(SyncStatus status);
+
   Set<String> get unsyncedNoteIds;
   bool isSynced(String id);
 

--- a/alarm_domain/pubspec.yaml
+++ b/alarm_domain/pubspec.yaml
@@ -7,8 +7,6 @@ environment:
   sdk: ">=3.3.0 <4.0.0"
 
 dependencies:
-  flutter:
-    sdk: flutter
   json_annotation: ^4.9.0
 
 dev_dependencies:

--- a/lib/features/note/presentation/note_provider.dart
+++ b/lib/features/note/presentation/note_provider.dart
@@ -41,7 +41,7 @@ class NoteProvider extends ChangeNotifier {
   final SplayTreeSet<Note> _notes = SplayTreeSet<Note>(_noteComparator);
   String _draft = '';
 
-  ValueNotifier<SyncStatus> get syncStatus => _syncService.syncStatus;
+  Stream<SyncStatus> get syncStatus => _syncService.syncStatus;
   Set<String> get unsyncedNoteIds => _syncService.unsyncedNoteIds;
   bool isSynced(String id) => _syncService.isSynced(id);
 
@@ -146,15 +146,14 @@ class NoteProvider extends ChangeNotifier {
   }
 
   Future<bool> loadNotes() async {
-    _syncService.syncStatus.value = SyncStatus.syncing;
+    _syncService.setSyncStatus(SyncStatus.syncing);
     _notes..clear();
     _notes.addAll(await _getNotes());
     final success = await _syncService.loadFromRemote(_notes);
     await _homeWidgetService.update(_notes.toList());
     notifyListeners();
-    _syncService.syncStatus.value = success
-        ? SyncStatus.idle
-        : SyncStatus.error;
+    _syncService.setSyncStatus(
+        success ? SyncStatus.idle : SyncStatus.error);
     return success;
   }
 

--- a/lib/widgets/notes_tab.dart
+++ b/lib/widgets/notes_tab.dart
@@ -75,9 +75,11 @@ class _NotesTabState extends State<NotesTab> {
           appBar: AppBar(
             title: Text(AppLocalizations.of(context)!.appTitle),
             actions: [
-              ValueListenableBuilder<SyncStatus>(
-                valueListenable: provider.syncStatus,
-                builder: (context, status, _) {
+              StreamBuilder<SyncStatus>(
+                stream: provider.syncStatus,
+                initialData: SyncStatus.idle,
+                builder: (context, snapshot) {
+                  final status = snapshot.data ?? SyncStatus.idle;
                   final l10n = AppLocalizations.of(context)!;
                   String text;
                   switch (status) {

--- a/test/note_provider_test.dart
+++ b/test/note_provider_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -60,7 +61,11 @@ void main() {
     when(() => calendar.deleteEvent(any())).thenAnswer((_) async {});
     when(() => notification.cancel(any())).thenAnswer((_) async {});
     when(() => sync.init(any())).thenAnswer((_) async {});
-    when(() => sync.syncStatus).thenReturn(ValueNotifier(SyncStatus.idle));
+    final controller1 = StreamController<SyncStatus>.broadcast();
+    when(() => sync.syncStatus).thenAnswer((_) => controller1.stream);
+    when(() => sync.setSyncStatus(any())).thenAnswer((invocation) {
+      controller1.add(invocation.positionalArguments.first as SyncStatus);
+    });
     when(() => sync.loadFromRemote(any())).thenAnswer((_) async => true);
     when(() => sync.deleteNote(any())).thenAnswer((_) async {});
     when(() => homeWidget.update(any())).thenAnswer((_) async {});
@@ -110,7 +115,11 @@ void main() {
       ),
     ).thenAnswer((_) async => 'e1');
     when(() => sync.init(any())).thenAnswer((_) async {});
-    when(() => sync.syncStatus).thenReturn(ValueNotifier(SyncStatus.idle));
+    final controller2 = StreamController<SyncStatus>.broadcast();
+    when(() => sync.syncStatus).thenAnswer((_) => controller2.stream);
+    when(() => sync.setSyncStatus(any())).thenAnswer((invocation) {
+      controller2.add(invocation.positionalArguments.first as SyncStatus);
+    });
     when(() => sync.loadFromRemote(any())).thenAnswer((_) async => true);
     when(() => sync.syncNote(any())).thenAnswer((_) async {});
     when(() => homeWidget.update(any())).thenAnswer((_) async {});
@@ -179,7 +188,11 @@ void main() {
         ),
       ).thenAnswer((_) async => 'e1');
       when(() => sync.init(any())).thenAnswer((_) async {});
-      when(() => sync.syncStatus).thenReturn(ValueNotifier(SyncStatus.idle));
+      final controller3 = StreamController<SyncStatus>.broadcast();
+      when(() => sync.syncStatus).thenAnswer((_) => controller3.stream);
+      when(() => sync.setSyncStatus(any())).thenAnswer((invocation) {
+        controller3.add(invocation.positionalArguments.first as SyncStatus);
+      });
       when(() => sync.loadFromRemote(any())).thenAnswer((_) async => true);
       when(() => sync.syncNote(any())).thenAnswer((_) async {});
 
@@ -241,7 +254,11 @@ void main() {
     );
     when(() => repo.saveNotes(any())).thenAnswer((_) async {});
     when(() => sync.init(any())).thenAnswer((_) async {});
-    when(() => sync.syncStatus).thenReturn(ValueNotifier(SyncStatus.idle));
+    final controller4 = StreamController<SyncStatus>.broadcast();
+    when(() => sync.syncStatus).thenAnswer((_) => controller4.stream);
+    when(() => sync.setSyncStatus(any())).thenAnswer((invocation) {
+      controller4.add(invocation.positionalArguments.first as SyncStatus);
+    });
     when(() => sync.loadFromRemote(any())).thenAnswer((_) async => true);
     when(() => homeWidget.update(any())).thenAnswer((_) async {});
 
@@ -300,7 +317,11 @@ void main() {
       ),
     ).thenAnswer((_) async {});
     when(() => sync.init(any())).thenAnswer((_) async {});
-    when(() => sync.syncStatus).thenReturn(ValueNotifier(SyncStatus.idle));
+    final controller5 = StreamController<SyncStatus>.broadcast();
+    when(() => sync.syncStatus).thenAnswer((_) => controller5.stream);
+    when(() => sync.setSyncStatus(any())).thenAnswer((invocation) {
+      controller5.add(invocation.positionalArguments.first as SyncStatus);
+    });
     when(() => sync.loadFromRemote(any())).thenAnswer((_) async => true);
     when(() => homeWidget.update(any())).thenAnswer((_) async {});
 

--- a/test/notes_list_unsynced_test.dart
+++ b/test/notes_list_unsynced_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
@@ -32,7 +33,11 @@ void main() {
     final sync = MockSyncService();
     when(() => repo.saveNotes(any())).thenAnswer((_) async {});
     when(() => sync.init(any())).thenAnswer((_) async {});
-    when(() => sync.syncStatus).thenReturn(ValueNotifier(SyncStatus.idle));
+    final controller = StreamController<SyncStatus>.broadcast();
+    when(() => sync.syncStatus).thenAnswer((_) => controller.stream);
+    when(() => sync.setSyncStatus(any())).thenAnswer((invocation) {
+      controller.add(invocation.positionalArguments.first as SyncStatus);
+    });
     when(() => sync.loadFromRemote(any())).thenAnswer((_) async => true);
     when(() => homeWidget.update(any())).thenAnswer((_) async {});
     final provider = NoteProvider(


### PR DESCRIPTION
## Summary
- Replace `ValueNotifier` with `Stream<SyncStatus>` in domain service and app implementation
- Update provider and widgets to use stream-based sync status
- Remove Flutter dependency from `alarm_domain`

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd81b0ab588333877c9d3541f500c8