### PR TITLE
ci: check pub dependencies on PRs

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -21,6 +21,10 @@ jobs:
             build
           key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
       - run: flutter pub get
+      - name: Check for outdated dependencies
+        run: flutter pub outdated
+      - name: Enforce null-safety dependency constraints
+        run: flutter pub outdated --mode=null-safety --exit-code
       - run: flutter analyze
       - run: flutter test
       - run: flutter test --coverage

--- a/README.md
+++ b/README.md
@@ -138,6 +138,17 @@ will replace the existing ones on the device.
 
 
 
+## Contributing
+
+CI runs dependency checks on every pull request. Before submitting your changes, make sure the following commands complete without conflicts or incompatible constraints:
+
+```bash
+flutter pub outdated
+flutter pub outdated --mode=null-safety --exit-code
+```
+
+Resolve any reported issues so the automated workflow can pass before your PR is merged.
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Summary
- run `flutter pub outdated` for pull requests
- enforce `flutter pub outdated --mode=null-safety --exit-code`
- document dependency checks for contributors

## Testing
- `flutter pub outdated --mode=null-safety --exit-code` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8624a9d88333b4cfec32e0680aed