### PR TITLE
chore: remove google_sign_in_platform_interface override

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -77,7 +77,6 @@ dev_dependencies:
   build_runner: ^2.8.0
   json_serializable: ^6.11.1
   connectivity_plus_platform_interface: ^2.0.1
-  google_sign_in_platform_interface: ^3.0.0
 flutter:
   generate: true
   uses-material-design: true


### PR DESCRIPTION
## Summary
- remove direct google_sign_in_platform_interface dev dependency to rely on google_sign_in's required version

## Testing
- `flutter pub upgrade`
- `flutter clean`
- `flutter build apk --debug` *(fails: command halted in container)*
- `flutter test` *(fails: command halted in container)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8624499c83338ef4060ec7997e80