### PR TITLE
Remove duplicate note_sync_service export

### DIFF
--- a/alarm_domain/lib/alarm_domain.dart
+++ b/alarm_domain/lib/alarm_domain.dart
@@ -19,5 +19,4 @@ export 'src/services/home_widget_service.dart';
 export 'src/services/note_sync_service.dart';
 
 export 'src/services/backup_service.dart';
-export 'src/services/note_sync_service.dart';
 


### PR DESCRIPTION
## Summary
- remove second note_sync_service export to avoid duplication

## Testing
- `flutter analyze --no-pub` *(fails: 4346 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9d7f3a4083339c8270c452c45e67