### PR TITLE
refactor: share locale mapping in TTS service

### DIFF
--- a/lib/services/tts_service.dart
+++ b/lib/services/tts_service.dart
@@ -14,17 +14,18 @@ class TTSService {
   final AudioPlayer _player;
   final http.Client _client;
 
+  static const Map<String, String> _localeMapping = {
+    'en': 'en-US',
+    'vi': 'vi-VN',
+  };
+
   TTSService({FlutterTts? tts, AudioPlayer? player, http.Client? client})
       : _tts = tts ?? FlutterTts(),
         _player = player ?? AudioPlayer(),
         _client = client ?? http.Client();
 
   String _ttsCodeForLocale(Locale locale) {
-    const mapping = {
-      'en': 'en-US',
-      'vi': 'vi-VN',
-    };
-    return mapping[locale.languageCode] ?? locale.toLanguageTag();
+    return _localeMapping[locale.languageCode] ?? locale.toLanguageTag();
   }
 
   Future<void> speak(String text, {Locale? locale}) async {
@@ -58,11 +59,7 @@ class TTSService {
   }
 
   String _voiceIdForLocale(Locale locale) {
-    const mapping = {
-      'en': 'en-US',
-      'vi': 'vi-VN',
-    };
-    return mapping[locale.languageCode] ?? 'en-US';
+    return _localeMapping[locale.languageCode] ?? 'en-US';
   }
 
   Future<void> speakWithApi(String text,


### PR DESCRIPTION
## Summary
- reuse locale mapping for TTS codes and voice IDs

## Testing
- `flutter analyze` *(fails: Package file_picker default plugin warnings, 648 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9d85a9dc833389650cf96922876d