### PR TITLE
Log TTS API key read errors

### DIFF
--- a/lib/services/tts_service.dart
+++ b/lib/services/tts_service.dart
@@ -42,7 +42,9 @@ class TTSService {
     if (!kIsWeb) {
       try {
         return Platform.environment['TTS_API_KEY'] ?? '';
-      } catch (_) {}
+      } catch (e, st) {
+        debugPrint('Failed to read TTS_API_KEY from environment: $e\n$st');
+      }
     }
     return '';
   }


### PR DESCRIPTION
## Summary
- log errors when reading TTS_API_KEY from environment variables

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9d8b399c8333bbde50e30e8afef0