### PR TITLE
chore: remove direct connectivity_plus_platform_interface dev dep

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1022,10 +1022,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1443,10 +1443,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   timezone:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -76,7 +76,6 @@ dev_dependencies:
     sdk: flutter
   build_runner: ^2.8.0
   json_serializable: ^6.11.1
-  connectivity_plus_platform_interface: ^2.0.1
 flutter:
   generate: true
   uses-material-design: true


### PR DESCRIPTION
## Summary
- remove explicit connectivity_plus_platform_interface dev dependency
- refresh dependencies with `flutter pub get`

## Testing
- `flutter pub get`
- `flutter test` *(fails: Error: Couldn't resolve the package 'flutter_gen')*


------
https://chatgpt.com/codex/tasks/task_e_68bda4a0833c833387956d007941774b