### PR TITLE
Use firstWhereOrNull for note lookup

### DIFF
--- a/lib/features/note/domain/get_note_by_id.dart
+++ b/lib/features/note/domain/get_note_by_id.dart
@@ -1,3 +1,5 @@
+import 'package:collection/collection.dart';
+
 import '../domain/domain.dart';
 
 /// Retrieves a single [Note] by id using the [NoteRepository].
@@ -9,10 +11,6 @@ class GetNoteById {
 
   Future<Note?> call(String id) async {
     final notes = await _getNotes();
-    try {
-      return notes.firstWhere((n) => n.id == id);
-    } catch (_) {
-      return null;
-    }
+    return notes.firstWhereOrNull((n) => n.id == id);
   }
 }


### PR DESCRIPTION
## Summary
- simplify GetNoteById by using `firstWhereOrNull`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bda685ea848333a981864ab50bd87b