### PR TITLE
refactor: remove unused backup service

### DIFF
--- a/lib/features/settings/data/settings_service.dart
+++ b/lib/features/settings/data/settings_service.dart
@@ -8,9 +8,7 @@ import '../domain/settings_service.dart';
 class SettingsServiceImpl implements SettingsService {
   SettingsServiceImpl({
     SharedPreferences? sharedPreferences,
-    required BackupService backupService,
-  })  : _preferences = sharedPreferences,
-        _backupService = backupService;
+  }) : _preferences = sharedPreferences;
 
   static const _kThemeColor = 'theme_color';
   static const _kMascotPath = 'mascot_path';
@@ -22,7 +20,6 @@ class SettingsServiceImpl implements SettingsService {
   static const _kHasSeenOnboarding = 'has_seen_onboarding';
 
   SharedPreferences? _preferences;
-  final BackupService _backupService; // ignore: unused_field
 
   Future<SharedPreferences> get _sp async {
     _preferences ??= await SharedPreferences.getInstance();

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -9,7 +9,6 @@ import '../features/settings/presentation/settings_screen.dart';
 import '../features/note/presentation/voice_to_note_screen.dart';
 import '../features/settings/data/settings_service.dart';
 
-import '../features/backup/data/backup_service.dart';
 import 'package:alarm_domain/alarm_domain.dart';
 
 import '../pandora_ui/palette_bottom_sheet.dart';
@@ -50,8 +49,7 @@ class _HomeScreenState extends State<HomeScreen> {
           onThemeChanged: widget.onThemeChanged,
           onFontScaleChanged: widget.onFontScaleChanged,
           onThemeModeChanged: widget.onThemeModeChanged,
-          settingsService:
-              SettingsServiceImpl(backupService: BackupServiceImpl()),
+          settingsService: SettingsServiceImpl(),
         ),
       ];
   }

--- a/lib/widgets/notes_tab.dart
+++ b/lib/widgets/notes_tab.dart
@@ -7,7 +7,6 @@ import 'package:flutter/services.dart';
 
 import '../features/note/presentation/note_provider.dart';
 import '../features/settings/data/settings_service.dart';
-import '../features/backup/data/backup_service.dart';
 
 import '../features/note/presentation/note_search_delegate.dart';
 import '../features/note/presentation/voice_to_note_screen.dart';
@@ -55,8 +54,7 @@ class _NotesTabState extends State<NotesTab> {
     });
   }
 
-  Future<String> _loadMascot() =>
-      SettingsServiceImpl(backupService: BackupServiceImpl()).loadMascotPath();
+  Future<String> _loadMascot() => SettingsServiceImpl().loadMascotPath();
 
   void _addNote() {
     showDialog(context: context, builder: (_) => const AddNoteDialog());
@@ -129,8 +127,7 @@ class _NotesTabState extends State<NotesTab> {
                         onThemeChanged: widget.onThemeChanged,
                         onFontScaleChanged: widget.onFontScaleChanged,
                         onThemeModeChanged: widget.onThemeModeChanged,
-                        settingsService: SettingsServiceImpl(
-                            backupService: BackupServiceImpl()),
+                        settingsService: SettingsServiceImpl(),
                       ),
                     ),
                   );
@@ -174,8 +171,7 @@ class _NotesTabState extends State<NotesTab> {
                                 onThemeChanged: widget.onThemeChanged,
                                 onFontScaleChanged: widget.onFontScaleChanged,
                                 onThemeModeChanged: widget.onThemeModeChanged,
-                                settingsService: SettingsServiceImpl(
-                                    backupService: BackupServiceImpl()),
+                                settingsService: SettingsServiceImpl(),
                               ),
                             ),
                           ),

--- a/test/settings_service_test.dart
+++ b/test/settings_service_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:notes_reminder_app/features/settings/data/settings_service.dart';
-import 'package:notes_reminder_app/features/backup/data/backup_service.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -12,32 +11,28 @@ void main() {
   });
 
   test('save and load theme color', () async {
-    final service =
-        SettingsServiceImpl(backupService: BackupServiceImpl());
+    final service = SettingsServiceImpl();
     await service.saveThemeColor(Colors.red);
     final color = await service.loadThemeColor();
     expect(color, Colors.red);
   });
 
   test('save and load mascot path', () async {
-    final service =
-        SettingsServiceImpl(backupService: BackupServiceImpl());
+    final service = SettingsServiceImpl();
     await service.saveMascotPath('path.json');
     final path = await service.loadMascotPath();
     expect(path, 'path.json');
   });
 
   test('save and load font scale', () async {
-    final service =
-        SettingsServiceImpl(backupService: BackupServiceImpl());
+    final service = SettingsServiceImpl();
     await service.saveFontScale(1.5);
     final scale = await service.loadFontScale();
     expect(scale, 1.5);
   });
 
   test('save and load require auth', () async {
-    final service =
-        SettingsServiceImpl(backupService: BackupServiceImpl());
+    final service = SettingsServiceImpl();
     await service.saveRequireAuth(true);
     final value = await service.loadRequireAuth();
     expect(value, true);
@@ -45,8 +40,7 @@ void main() {
 
 
   test('save and load has seen onboarding', () async {
-    final service =
-        SettingsServiceImpl(backupService: BackupServiceImpl());
+    final service = SettingsServiceImpl();
     await service.saveHasSeenOnboarding(true);
     final value = await service.loadHasSeenOnboarding();
     expect(value, true);
@@ -54,8 +48,7 @@ void main() {
   });
 
   test('default values returned when not set', () async {
-    final service =
-        SettingsServiceImpl(backupService: BackupServiceImpl());
+    final service = SettingsServiceImpl();
     final color = await service.loadThemeColor();
     final path = await service.loadMascotPath();
     final scale = await service.loadFontScale();


### PR DESCRIPTION
## Summary
- remove `BackupService` from `SettingsServiceImpl`
- update call sites to use default `SettingsServiceImpl`
- adjust settings service tests

## Testing
- `flutter test test/settings_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bda6abd7b4833388dd14df34c16d0e