### PR TITLE
Log MissingPluginException in connectivity service

### DIFF
--- a/lib/services/connectivity_service.dart
+++ b/lib/services/connectivity_service.dart
@@ -32,8 +32,8 @@ class ConnectivityService {
         }
         _lastResult = result;
       });
-    } on MissingPluginException {
-      // Ignore if connectivity plugin is not available (e.g., tests)
+    } on MissingPluginException catch (e, st) {
+      debugPrint('Connectivity plugin missing: $e\n$st');
     }
   }
 


### PR DESCRIPTION
## Summary
- log plugin missing errors in ConnectivityService using debugPrint

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bda6bcf6ac8333949b26e350c958da