### PR TITLE
refactor: simplify note lookup

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart'
@@ -21,12 +22,7 @@ Future<void> _onNotificationResponse(
   final id = response.payload;
   if (id == null || !context.mounted) return;
   final noteProvider = context.read<NoteProvider>();
-  Note? note;
-  try {
-    note = noteProvider.notes.firstWhere((n) => n.id == id);
-  } catch (_) {
-    note = null;
-  }
+  final note = noteProvider.notes.firstWhereOrNull((n) => n.id == id);
   if (note == null) return;
   final locale = WidgetsBinding.instance.platformDispatcher.locale;
   final supported = AppLocalizations.delegate.isSupported(locale);


### PR DESCRIPTION
## Summary
- simplify note lookup on notification response by using `firstWhereOrNull`
- import `collection` utilities for null-safe list search

## Testing
- `flutter analyze` *(fails: numerous l10n and other unresolved references)*
- `flutter test` *(fails: missing flutter_gen and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bda687607c8333b35200feb17f2549