### PR TITLE
Log initialization errors in startup service

### DIFF
--- a/lib/services/startup_service.dart
+++ b/lib/services/startup_service.dart
@@ -2,6 +2,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart'
     as fln;
 
@@ -37,16 +38,24 @@ class StartupService {
       await FirebaseCrashlytics.instance
           .setCrashlyticsCollectionEnabled(true);
       await FirebaseAnalytics.instance.logAppOpen();
-    } catch (_) {
+    } catch (e, st) {
       authFailed = true;
+      debugPrint('Error during Firebase initialization: $e');
+      debugPrint('$st');
+      // Rethrow if upper layers should handle the error.
+      // rethrow;
     }
 
     try {
       await _notificationService.init(
         onDidReceiveNotificationResponse: onDidReceiveNotificationResponse,
       );
-    } catch (_) {
+    } catch (e, st) {
       notificationFailed = true;
+      debugPrint('Error initializing notifications: $e');
+      debugPrint('$st');
+      // Rethrow if upper layers should handle the error.
+      // rethrow;
     }
 
     return StartupResult(


### PR DESCRIPTION
## Summary
- log Firebase and notification initialization errors with stack traces
- import `flutter/foundation.dart` for debug logging

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdaebe2be08333baf4393d2c684b87