### PR TITLE
refactor: use collection for note lookup

### DIFF
--- a/lib/features/note/presentation/note_provider.dart
+++ b/lib/features/note/presentation/note_provider.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart'
     show Time;
+import 'package:collection/collection.dart';
 
 import '../domain/domain.dart';
 import 'package:alarm_data/alarm_data.dart';
@@ -136,13 +137,8 @@ class NoteProvider extends ChangeNotifier {
     await _syncService.init(_getNoteById);
   }
 
-  Note? _getNoteById(String id) {
-    try {
-      return _notes.firstWhere((n) => n.id == id);
-    } catch (_) {
-      return null;
-    }
-  }
+  Note? _getNoteById(String id) =>
+      _notes.firstWhereOrNull((n) => n.id == id);
 
   @override
   void dispose() {


### PR DESCRIPTION
## Summary
- use `firstWhereOrNull` from collection to get notes by id
- add `package:collection` import

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdaec4d12883339729fab394a4d031