### PR TITLE
Log errors during note operations

### DIFF
--- a/lib/features/note/presentation/note_provider.dart
+++ b/lib/features/note/presentation/note_provider.dart
@@ -197,8 +197,8 @@ class NoteProvider extends ChangeNotifier {
     bool pinned = false,
     required AppLocalizations l10n,
   }) async {
+    final id = DateTime.now().microsecondsSinceEpoch.toString();
     try {
-      final id = DateTime.now().microsecondsSinceEpoch.toString();
       int? notificationId;
       String? eventId;
       if (alarmTime != null) {
@@ -258,7 +258,10 @@ class NoteProvider extends ChangeNotifier {
 
       await addNote(note);
       return true;
-    } catch (e) {
+    } catch (e, st) {
+      debugPrint('Failed to create note $id: $e\n$st');
+      await _syncService.markUnsynced(id);
+      notifyListeners();
       return false;
     }
   }
@@ -357,7 +360,8 @@ class NoteProvider extends ChangeNotifier {
       notifyListeners();
       await _syncService.syncNote(updated);
       return true;
-    } catch (e) {
+    } catch (e, st) {
+      debugPrint('Failed to update note ${note.id}: $e\n$st');
       await _syncService.markUnsynced(note.id);
       notifyListeners();
       return false;


### PR DESCRIPTION
## Summary
- log detailed errors for note creation and update failures
- mark newly created notes as unsynced when creation fails

## Testing
- `dart format lib/features/note/presentation/note_provider.dart` *(command not found: dart)*
- `flutter analyze` *(command not found: flutter)*
- `flutter test` *(command not found: flutter)*


------
https://chatgpt.com/codex/tasks/task_e_68bdaec4ec808333b06d467e9d8d4639