### PR TITLE
Guard Chat setState after async await

### DIFF
--- a/lib/features/chat/presentation/chat_screen.dart
+++ b/lib/features/chat/presentation/chat_screen.dart
@@ -39,11 +39,14 @@ class _ChatScreenState extends State<ChatScreen> {
     try {
       final reply =
           await _geminiService.chat(userText, AppLocalizations.of(context)!);
+      if (!mounted) return;
       setState(() => _messages.insert(0, Message(reply, false)));
     } catch (e) {
+      if (!mounted) return;
       setState(() => _messages.insert(
           0, Message(AppLocalizations.of(context)!.errorWithMessage(e.toString()), false)));
     } finally {
+      if (!mounted) return;
       setState(() => _isLoading = false);
     }
   }


### PR DESCRIPTION
## Summary
- Avoid calling setState after widget disposal in ChatScreen by checking `mounted` after async chat completion.

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdaecb71d48333930af7619c9c63e0