### PR TITLE
Log init errors in NoteProvider

### DIFF
--- a/lib/features/note/presentation/note_provider.dart
+++ b/lib/features/note/presentation/note_provider.dart
@@ -39,10 +39,12 @@ class NoteProvider extends ChangeNotifier {
 
   final SplayTreeSet<Note> _notes = SplayTreeSet<Note>(_noteComparator);
   String _draft = '';
+  Object? _initError;
 
   Stream<SyncStatus> get syncStatus => _syncService.syncStatus;
   Set<String> get unsyncedNoteIds => _syncService.unsyncedNoteIds;
   bool isSynced(String id) => _syncService.isSynced(id);
+  Object? get initError => _initError;
 
   NoteProvider._({
     required GetNotes getNotes,
@@ -79,8 +81,10 @@ class NoteProvider extends ChangeNotifier {
            ),
        _snoozeNote = snoozeNote ?? SnoozeNote(notificationService) {
     unawaited(
-      _init().catchError((e) {
-        /* log or set error state */
+      _init().catchError((e, s) {
+        _initError = e;
+        debugPrint('NoteProvider init failed: $e');
+        notifyListeners();
       }),
     );
   }


### PR DESCRIPTION
## Summary
- log initialization failures in `NoteProvider`
- expose `initError` to allow consumers to detect init failures

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdaed106808333a2ba26b0060eacfd