### PR TITLE
chore: configure melos workspace and unify dependencies

### DIFF
--- a/alarm_data/pubspec.yaml
+++ b/alarm_data/pubspec.yaml
@@ -4,7 +4,9 @@ publish_to: 'none'
 version: 0.0.1
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.5.0 <4.0.0'
+
+resolution: workspace
 
 dependencies:
   flutter:
@@ -12,15 +14,15 @@ dependencies:
   alarm_domain:
     path: ../alarm_domain
 
-  file_picker: ^6.2.1
-  pdf: ^3.11.3
-  path_provider: ^2.1.5
-  uuid: ^4.5.1
-  encrypt: ^5.0.3
-  cryptography: ^2.7.0
-  flutter_secure_storage: ^9.2.4
-  shared_preferences: ^2.5.3
+  file_picker: ^workspace
+  pdf: ^workspace
+  path_provider: ^workspace
+  uuid: ^workspace
+  encrypt: ^workspace
+  cryptography: ^workspace
+  flutter_secure_storage: ^workspace
+  shared_preferences: ^workspace
 
 dev_dependencies:
-  build_runner: ^2.8.0
-  json_serializable: ^6.11.1
+  build_runner: ^workspace
+  json_serializable: ^workspace

--- a/alarm_domain/pubspec.yaml
+++ b/alarm_domain/pubspec.yaml
@@ -4,11 +4,13 @@ version: 0.0.1
 author: ""
 
 environment:
-  sdk: ">=3.3.0 <4.0.0"
+  sdk: ">=3.5.0 <4.0.0"
+
+resolution: workspace
 
 dependencies:
-  json_annotation: ^4.9.0
+  json_annotation: ^workspace
 
 dev_dependencies:
-  build_runner: ^2.8.0
-  json_serializable: ^6.11.1
+  build_runner: ^workspace
+  json_serializable: ^workspace

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,8 +3,18 @@ description: "Notes & Reminders App"
 publish_to: 'none'
 version: 1.0.0+1
 
+workspace:
+  - alarm_domain
+  - alarm_data
+
+melos:
+  packages:
+    - .
+    - alarm_domain
+    - alarm_data
+
 environment:
-  sdk: ">=3.3.0 <4.0.0"
+  sdk: ">=3.5.0 <4.0.0"
 
 dependencies:
   flutter:
@@ -76,6 +86,7 @@ dev_dependencies:
     sdk: flutter
   build_runner: ^2.8.0
   json_serializable: ^6.11.1
+  melos: ^7.1.0
 flutter:
   generate: true
   uses-material-design: true


### PR DESCRIPTION
## Summary
- setup workspace configuration for Melos in pubspec
- align alarm_data and alarm_domain packages on shared dependency versions

## Testing
- `melos bootstrap` *(fails: Because notes_reminder_app depends on integration_test from sdk which doesn't exist (the Flutter SDK is not available))*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb55ef7c88333aecfd654716c65c9