### PR TITLE
chore: add dependabot and fix CI for bot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pub"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -31,6 +31,7 @@ jobs:
       - run: flutter test
       - run: flutter test --coverage
       - uses: codecov/codecov-action@v4
+        if: github.actor != 'dependabot[bot]'
         with:
           file: coverage/lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- configure Dependabot for pub and GitHub Actions
- skip codecov step when Dependabot opens a PR so CI runs

## Testing
- `flutter test` *(fails: Couldn't resolve the package 'flutter_gen')*

------
https://chatgpt.com/codex/tasks/task_e_68bdb55dcb0483338adbee64a008bea9