### PR TITLE
chore: pin dependency versions

### DIFF
--- a/alarm_data/pubspec.yaml
+++ b/alarm_data/pubspec.yaml
@@ -12,15 +12,15 @@ dependencies:
   alarm_domain:
     path: ../alarm_domain
 
-  file_picker: ^6.2.1
-  pdf: ^3.11.3
-  path_provider: ^2.1.5
-  uuid: ^4.5.1
-  encrypt: ^5.0.3
-  cryptography: ^2.7.0
-  flutter_secure_storage: ^9.2.4
-  shared_preferences: ^2.5.3
+  file_picker: 6.2.1
+  pdf: 3.11.3
+  path_provider: 2.1.5
+  uuid: 4.5.1
+  encrypt: 5.0.3
+  cryptography: 2.7.0
+  flutter_secure_storage: 9.2.4
+  shared_preferences: 2.5.3
 
 dev_dependencies:
-  build_runner: ^2.8.0
-  json_serializable: ^6.11.1
+  build_runner: 2.8.0
+  json_serializable: 6.11.1

--- a/alarm_domain/pubspec.lock
+++ b/alarm_domain/pubspec.lock
@@ -89,14 +89,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.12.0"
-  characters:
-    dependency: transitive
-    description:
-      name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -161,11 +153,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
-  flutter:
-    dependency: "direct main"
-    description: flutter
-    source: sdk
-    version: "0.0.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -246,14 +233,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.12.17"
-  material_color_utilities:
-    dependency: transitive
-    description:
-      name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.11.1"
   meta:
     dependency: transitive
     description:
@@ -326,11 +305,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
-  sky_engine:
-    dependency: transitive
-    description: flutter
-    source: sdk
-    version: "0.0.0"
   source_gen:
     dependency: transitive
     description:
@@ -411,14 +385,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
-  vector_math:
-    dependency: transitive
-    description:
-      name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.2.0"
   watcher:
     dependency: transitive
     description:

--- a/alarm_domain/pubspec.yaml
+++ b/alarm_domain/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   sdk: ">=3.3.0 <4.0.0"
 
 dependencies:
-  json_annotation: ^4.9.0
+  json_annotation: 4.9.0
 
 dev_dependencies:
-  build_runner: ^2.8.0
-  json_serializable: ^6.11.1
+  build_runner: 2.8.0
+  json_serializable: 6.11.1

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -83,10 +83,10 @@ packages:
     dependency: "direct main"
     description:
       name: audioplayers
-      sha256: "5441fa0ceb8807a5ad701199806510e56afde2b4913d9d17c2f19f2902cf0ae4"
+      sha256: e653f162ddfcec1da2040ba2d8553fff1662b5c2a5c636f4c21a3b11bee497de
       url: "https://pub.dev"
     source: hosted
-    version: "6.5.1"
+    version: "6.5.0"
   audioplayers_android:
     dependency: transitive
     description:
@@ -280,7 +280,7 @@ packages:
     source: hosted
     version: "6.1.5"
   connectivity_plus_platform_interface:
-    dependency: "direct dev"
+    dependency: transitive
     description:
       name: connectivity_plus_platform_interface
       sha256: "42657c1715d48b167930d5f34d00222ac100475f73d10162ddf43e714932f204"
@@ -689,10 +689,10 @@ packages:
     dependency: "direct main"
     description:
       name: google_fonts
-      sha256: ebc94ed30fd13cefd397cb1658b593f21571f014b7d1197eeb41fb95f05d899a
+      sha256: b1ac0fe2832c9cc95e5e88b57d627c5e68c223b9657f4b96e1487aa9098c7b82
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.1"
+    version: "6.2.1"
   google_identity_services_web:
     dependency: transitive
     description:
@@ -982,10 +982,10 @@ packages:
     dependency: "direct main"
     description:
       name: logger
-      sha256: "55d6c23a6c15db14920e037fe7e0dc32e7cdaf3b64b4b25df2d541b5b6b81c0c"
+      sha256: ba3bc83117b2b49bdd723c0ea7848e8285a0fbc597ba09203b20d329d020c24a
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.1"
+    version: "2.0.2"
   logging:
     dependency: transitive
     description:
@@ -1022,10 +1022,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
@@ -1443,10 +1443,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.6"
   timezone:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,56 +11,56 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
-  flutter_local_notifications: ^19.4.1
-  timezone: ^0.10.1
-  flutter_native_timezone: ^2.0.0
-  lottie: ^3.3.1
-  http: ^1.5.0
+  flutter_local_notifications: 19.4.1
+  timezone: 0.10.1
+  flutter_native_timezone: 2.0.0
+  lottie: 3.3.1
+  http: 1.5.0
 
-  flutter_colorpicker: ^1.1.0
+  flutter_colorpicker: 1.1.0
 
-  flutter_slidable: ^4.0.1
+  flutter_slidable: 4.0.1
 
-  shared_preferences: ^2.5.3
-  audioplayers: ^6.5.0
-  intl: ^0.20.2
-  provider: ^6.1.5+1
-  flutter_tts: ^4.2.3
-  speech_to_text: ^7.3.0
-  share_plus: ^11.1.0
-  connectivity_plus: ^6.1.5
+  shared_preferences: 2.5.3
+  audioplayers: 6.5.0
+  intl: 0.20.2
+  provider: 6.1.5+1
+  flutter_tts: 4.2.3
+  speech_to_text: 7.3.0
+  share_plus: 11.1.0
+  connectivity_plus: 6.1.5
 
-  home_widget: ^0.8.0
+  home_widget: 0.8.0
 
 
-  local_auth: ^2.3.0
+  local_auth: 2.3.0
 
-  logger: ^2.0.2
+  logger: 2.0.2
 
-  cryptography: ^2.7.0
-  encrypt: ^5.0.3
-  flutter_secure_storage: ^9.2.4
-  file_picker: ^6.2.1
-  pdf: ^3.11.3
+  cryptography: 2.7.0
+  encrypt: 5.0.3
+  flutter_secure_storage: 9.2.4
+  file_picker: 6.2.1
+  pdf: 3.11.3
 
-  image_picker: ^1.2.0
+  image_picker: 1.2.0
 
-  path_provider: ^2.1.5
+  path_provider: 2.1.5
 
-  json_annotation: ^4.9.0
+  json_annotation: 4.9.0
 
-  firebase_core: ^4.1.0
-  cloud_firestore: ^6.0.1
-  firebase_auth: ^6.0.2
+  firebase_core: 4.1.0
+  cloud_firestore: 6.0.1
+  firebase_auth: 6.0.2
 
-  firebase_crashlytics: ^5.0.1
-  firebase_analytics: ^12.0.1
+  firebase_crashlytics: 5.0.1
+  firebase_analytics: 12.0.1
 
-  googleapis: ^14.0.0
-  google_sign_in: ^7.1.1
-  uuid: ^4.5.1
-  google_fonts: ^6.2.1
-  fuse: ^0.0.99
+  googleapis: 14.0.0
+  google_sign_in: 7.1.1
+  uuid: 4.5.1
+  google_fonts: 6.2.1
+  fuse: 0.0.99
 
   alarm_domain:
     path: alarm_domain
@@ -70,12 +70,12 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^6.0.0
-  mocktail: ^1.0.4
+  flutter_lints: 6.0.0
+  mocktail: 1.0.4
   integration_test:
     sdk: flutter
-  build_runner: ^2.8.0
-  json_serializable: ^6.11.1
+  build_runner: 2.8.0
+  json_serializable: 6.11.1
 flutter:
   generate: true
   uses-material-design: true


### PR DESCRIPTION
## Summary
- pin caret dependencies to fixed versions in root and sub-packages
- update pubspec.lock files after running `flutter pub get`

## Testing
- `flutter pub get`
- `cd alarm_domain && flutter pub get`
- `cd alarm_data && flutter pub get`


------
https://chatgpt.com/codex/tasks/task_e_68bdb563229c833386acb35b0e26f97d