### PR TITLE
chore: raise Dart SDK minimum to 3.7

### DIFF
--- a/alarm_data/pubspec.yaml
+++ b/alarm_data/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 0.0.1
 
 environment:
-  sdk: '>=3.5.0 <4.0.0'
+  sdk: ">=3.7.0 <4.0.0"
 
 resolution: workspace
 

--- a/alarm_domain/pubspec.yaml
+++ b/alarm_domain/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 author: ""
 
 environment:
-  sdk: ">=3.5.0 <4.0.0"
+  sdk: ">=3.7.0 <4.0.0"
 
 resolution: workspace
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ melos:
     - alarm_data
 
 environment:
-  sdk: ">=3.5.0 <4.0.0"
+  sdk: ">=3.7.0 <4.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Summary
- raise Dart SDK constraints to `>=3.7.0 <4.0.0` across packages

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbc6525d08333a8cd98a6f5ccb7fe