### PR TITLE
chore(ci): move workflows to Flutter beta

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -15,8 +15,8 @@ jobs:
           java-version: '17'
       - uses: subosito/flutter-action@v2
         with:
-          channel: 'stable'
-          flutter-version: '3.22.0'
+          channel: 'beta'
+          flutter-version: '3.24.0-0.0.pre'
       - run: flutter clean
       - run: flutter pub get
       - run: flutter build apk --release

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -12,8 +12,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
-          channel: stable
-          flutter-version: '3.22.0'
+          channel: beta
+          flutter-version: '3.24.0-0.0.pre'
       - run: flutter clean
       - run: flutter pub get
       - name: Check for outdated packages

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -13,8 +13,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
-          channel: stable
-          flutter-version: '3.22.0'
+          channel: beta
+          flutter-version: '3.24.0-0.0.pre'
       - uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/pr-debug-build.yml
+++ b/.github/workflows/pr-debug-build.yml
@@ -16,8 +16,8 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: stable
-          flutter-version: '3.22.0'
+          channel: beta
+          flutter-version: '3.24.0-0.0.pre'
       - name: Cache pub packages
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Summary
- use Flutter beta channel and Flutter 3.24.0-0.0.pre in all workflows

## Testing
- `flutter pub get` *(fails: Invalid version constraint: Expected version number after "^" in "^workspace".)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbc696248833398b9431ef29c069e