### PR TITLE
chore: rely on latest flutter beta in CI

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -16,7 +16,6 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: 'beta'
-          flutter-version: '3.24.0-0.0.pre'
       - run: flutter clean
       - run: flutter pub get
       - run: flutter build apk --release

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -13,7 +13,6 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: beta
-          flutter-version: '3.24.0-0.0.pre'
       - run: flutter clean
       - run: flutter pub get
       - name: Check for outdated packages

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -14,7 +14,6 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: beta
-          flutter-version: '3.24.0-0.0.pre'
       - uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/pr-debug-build.yml
+++ b/.github/workflows/pr-debug-build.yml
@@ -17,7 +17,6 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: beta
-          flutter-version: '3.24.0-0.0.pre'
       - name: Cache pub packages
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Summary
- remove pinned Flutter prerelease version from CI workflows

## Testing
- `flutter --version --no-version-check --suppress-analytics`
- `flutter pub get` *(fails: Failed to update packages)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbfce6b6c8333bb12218a3de77b62