### PR TITLE
chore: update AGP tooling versions

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-8.1-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -19,8 +19,8 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.1.1" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.23" apply false
+    id("com.android.application") version "8.6.0" apply false
+    id("org.jetbrains.kotlin.android") version "2.1.0" apply false
     id("com.google.gms.google-services") version "4.4.2" apply false
     id("com.google.firebase.crashlytics") version "2.9.9" apply false
 }

--- a/fix_agp.sh
+++ b/fix_agp.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
-REQUIRED_AGP="8.1.1"
-REQUIRED_GRADLE="8.1"
-REQUIRED_KOTLIN="1.9.23"
+REQUIRED_AGP="8.6.0"
+REQUIRED_GRADLE="8.7"
+REQUIRED_KOTLIN="2.1.0"
 
 # Đọc phiên bản AGP đang dùng
 CURRENT_AGP=$(grep 'com.android.application' -n android/settings.gradle.kts \
@@ -13,8 +13,7 @@ echo "Current AGP version: ${CURRENT_AGP:-not found}"
 # Cập nhật AGP nếu cần
 if [ -z "$CURRENT_AGP" ] || [ "$(printf '%s\n' "$CURRENT_AGP" "$REQUIRED_AGP" | sort -V | head -n1)" != "$REQUIRED_AGP" ]; then
   echo "Updating Android Gradle Plugin to $REQUIRED_AGP"
-  sed -i \
-    's/id("com.android.application") version "[^"]\+"/id("com.android.application") version "'$REQUIRED_AGP'" apply false/' \
+  sed -i -e "s/id(\"com.android.application\").*/id(\"com.android.application\") version \"$REQUIRED_AGP\" apply false/" \
     android/settings.gradle.kts
 else
   echo "AGP already ≥ $REQUIRED_AGP"
@@ -28,8 +27,7 @@ echo "Current Kotlin version: ${CURRENT_KOTLIN:-not found}"
 # Cập nhật Kotlin plugin nếu cần
 if [ -z "$CURRENT_KOTLIN" ] || [ "$(printf '%s\n' "$CURRENT_KOTLIN" "$REQUIRED_KOTLIN" | sort -V | head -n1)" != "$REQUIRED_KOTLIN" ]; then
   echo "Updating Kotlin plugin to $REQUIRED_KOTLIN"
-  sed -i \
-    's/id("org.jetbrains.kotlin.android") version "[^"]\+"/id("org.jetbrains.kotlin.android") version "'$REQUIRED_KOTLIN'" apply false/' \
+  sed -i -e "s/id(\"org.jetbrains.kotlin.android\").*/id(\"org.jetbrains.kotlin.android\") version \"$REQUIRED_KOTLIN\" apply false/" \
     android/settings.gradle.kts
 else
   echo "Kotlin plugin already ≥ $REQUIRED_KOTLIN"


### PR DESCRIPTION
## Summary
- align fix_agp.sh with AGP 8.6.0, Kotlin 2.1.0 and Gradle 8.7
- ensure settings.gradle and Gradle wrapper reflect required versions

## Testing
- `bash fix_agp.sh` *(fails: flutter: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc917887883338d56dad6e1bfe2d4