### PR TITLE
chore: replace native timezone plugin

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -22,6 +22,12 @@ jobs:
           key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
       - run: flutter clean
       - run: flutter pub get
+      - name: Ensure flutter_native_timezone is absent
+        run: |
+          if flutter pub deps | grep -q flutter_native_timezone; then
+            echo 'flutter_native_timezone found in dependency tree'
+            exit 1
+          fi
       - run: flutter gen-l10n
       - name: Check for outdated dependencies
         run: flutter pub outdated

--- a/lib/features/note/data/notification_service.dart
+++ b/lib/features/note/data/notification_service.dart
@@ -1,7 +1,7 @@
 
 import 'package:flutter_local_notifications/flutter_local_notifications.dart' as fln;
 import 'package:notes_reminder_app/generated/app_localizations.dart';
-import 'package:flutter_native_timezone/flutter_native_timezone.dart';
+import 'package:flutter_timezone/flutter_timezone.dart';
 
 import 'package:timezone/data/latest.dart' as tzdata;
 import 'package:timezone/timezone.dart' as tz;


### PR DESCRIPTION
## Summary
- replace deprecated flutter_native_timezone import with flutter_timezone
- enforce absence of flutter_native_timezone via CI

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter pub deps | grep flutter_native_timezone` *(fails: command not found)*
- `flutter clean` *(fails: command not found)*
- `flutter build apk --release` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bde3ac3e908333b3e0ff7e15b0c3fd