### PR TITLE
fix: ensure AES key uses Uint8List

### DIFF
--- a/alarm_data/lib/src/datasources/db_service.dart
+++ b/alarm_data/lib/src/datasources/db_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:math';
+import 'dart:typed_data';
 
 import 'package:encrypt/encrypt.dart' as encrypt;
 import 'package:cryptography/cryptography.dart';
@@ -51,7 +52,7 @@ class DbService {
     final algorithm = AesGcm.with256bits();
     final secretKey = SecretKey(keyBytes);
     final legacyEncrypter = encrypt.Encrypter(
-      encrypt.AES(encrypt.Key(keyBytes)),
+      encrypt.AES(encrypt.Key(Uint8List.fromList(keyBytes))),
     );
     final list = (jsonDecode(raw) as List).cast<Map<String, dynamic>>();
     final notes = <Note>[];
@@ -71,9 +72,10 @@ class DbService {
           final decrypted = await algorithm.decrypt(box, secretKey: secretKey);
           m['content'] = utf8.decode(decrypted);
         } else {
-          final iv = ivString != null
-              ? encrypt.IV.fromBase64(ivString)
-              : encrypt.IV.fromLength(16);
+          final iv =
+              ivString != null
+                  ? encrypt.IV.fromBase64(ivString)
+                  : encrypt.IV.fromLength(16);
           final decrypted = legacyEncrypter.decrypt64(content, iv: iv);
           m['content'] = decrypted;
         }
@@ -115,9 +117,10 @@ class DbService {
     Note note, {
     String? password,
   }) async {
-    final keyBytes = password != null
-        ? await _deriveKeyFromPassword(password)
-        : await _getKey();
+    final keyBytes =
+        password != null
+            ? await _deriveKeyFromPassword(password)
+            : await _getKey();
     final algorithm = AesGcm.with256bits();
     final secretKey = SecretKey(keyBytes);
     final m = note.toJson();
@@ -137,13 +140,14 @@ class DbService {
     Map<String, dynamic> data, {
     String? password,
   }) async {
-    final keyBytes = password != null
-        ? await _deriveKeyFromPassword(password)
-        : await _getKey();
+    final keyBytes =
+        password != null
+            ? await _deriveKeyFromPassword(password)
+            : await _getKey();
     final algorithm = AesGcm.with256bits();
     final secretKey = SecretKey(keyBytes);
     final legacyEncrypter = encrypt.Encrypter(
-      encrypt.AES(encrypt.Key(keyBytes)),
+      encrypt.AES(encrypt.Key(Uint8List.fromList(keyBytes))),
     );
     final ivString = data['iv'];
     final tagString = data['tag'];
@@ -157,9 +161,10 @@ class DbService {
       final decrypted = await algorithm.decrypt(box, secretKey: secretKey);
       data['content'] = utf8.decode(decrypted);
     } else {
-      final iv = ivString != null
-          ? encrypt.IV.fromBase64(ivString)
-          : encrypt.IV.fromLength(16);
+      final iv =
+          ivString != null
+              ? encrypt.IV.fromBase64(ivString)
+              : encrypt.IV.fromLength(16);
       final decrypted = legacyEncrypter.decrypt64(content, iv: iv);
       data['content'] = decrypted;
     }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1008,10 +1008,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
@@ -1429,10 +1429,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.6"
   timezone:
     dependency: "direct main"
     description:


### PR DESCRIPTION
## Summary
- use `Uint8List.fromList` when building AES keys to satisfy encryption API requirements

## Testing
- `flutter gen-l10n`
- `dart run build_runner build --delete-conflicting-outputs`
- `flutter analyze` *(fails: 431 issues)*
- `flutter build apk --debug -v` *(fails: No Android SDK found)*

------
https://chatgpt.com/codex/tasks/task_e_68bde8cb226c8333a20222222444c16a