### PR TITLE
chore: target Android API 36 with NDK 27

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -18,6 +18,9 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: 'beta'
+      - name: Install Android SDK 36 and NDK 27
+        run: |
+          yes | sdkmanager "platforms;android-36" "build-tools;36.0.0" "ndk;27.0.12077973"
       - run: flutter clean
       - run: flutter pub get
       - run: flutter gen-l10n

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -14,6 +14,9 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: beta
+      - name: Install Android SDK 36 and NDK 27
+        run: |
+          yes | sdkmanager "platforms;android-36" "build-tools;36.0.0" "ndk;27.0.12077973"
       - uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/pr-debug-build.yml
+++ b/.github/workflows/pr-debug-build.yml
@@ -17,6 +17,9 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: beta
+      - name: Install Android SDK 36 and NDK 27
+        run: |
+          yes | sdkmanager "platforms;android-36" "build-tools;36.0.0" "ndk;27.0.12077973"
       - name: Cache pub packages
         uses: actions/cache@v4
         with:

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -8,12 +8,13 @@ plugins {
 
 android {
     namespace = "com.example.notes_reminder_app"
-    compileSdk = 35
+    compileSdk = 36
+    ndkVersion = "27.0.12077973"
 
     defaultConfig {
         applicationId = "com.example.notes_reminder_app"
         minSdk = flutter.minSdkVersion
-        targetSdk = 35
+        targetSdk = 36
         versionCode = 1
         versionName = "1.0"
     }


### PR DESCRIPTION
## Summary
- update app build to compile and target Android 36
- ensure CI installs Android SDK 36 and NDK 27

## Testing
- `flutter build apk` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf28535f48333bb6c0e2dc3d20f27