### PR TITLE
chore: update l10n config

### DIFF
--- a/l10n.yaml
+++ b/l10n.yaml
@@ -2,4 +2,3 @@ arb-dir: lib/l10n
 template-arb-file: app_en.arb
 output-localization-file: app_localizations.dart
 output-dir: lib/generated
-synthetic-package: false


### PR DESCRIPTION
## Summary
- remove synthetic-package flag from l10n.yaml to use Flutter's default generation

## Testing
- `flutter gen-l10n` *(fails: hangs after building flutter tool)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf2862e28833385f2fb57056396a0