### PR TITLE
Use package imports and add Firebase options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,5 @@ fix_agp.sh
 # Ignore old sample project
 notes_reminder_app/
 
-# Local environment and Firebase config
+# Local environment
 .env
-lib/firebase_options.dart

--- a/lib/features/backup/data/note_sync_service.dart
+++ b/lib/features/backup/data/note_sync_service.dart
@@ -7,7 +7,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-import '../../note/domain/domain.dart';
+import 'package:notes_reminder_app/features/note/domain/domain.dart';
 import 'package:alarm_data/alarm_data.dart';
 
 class NoteSyncServiceImpl implements NoteSyncService {

--- a/lib/features/chat/data/gemini_service.dart
+++ b/lib/features/chat/data/gemini_service.dart
@@ -6,8 +6,8 @@ import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:notes_reminder_app/generated/app_localizations.dart';
 
-import '../domain/chat_service.dart';
-import '../domain/note_analysis.dart';
+import 'package:notes_reminder_app/features/chat/domain/chat_service.dart';
+import 'package:notes_reminder_app/features/chat/domain/note_analysis.dart';
 
 class GeminiServiceImpl implements ChatService {
   final http.Client _client;

--- a/lib/features/chat/presentation/chat_screen.dart
+++ b/lib/features/chat/presentation/chat_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:notes_reminder_app/generated/app_localizations.dart';
-import '../domain/chat_service.dart';
+import 'package:notes_reminder_app/features/chat/domain/chat_service.dart';
 
 class ChatScreen extends StatefulWidget {
   final String initialMessage;

--- a/lib/features/note/data/calendar_service.dart
+++ b/lib/features/note/data/calendar_service.dart
@@ -1,7 +1,7 @@
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:googleapis/calendar/v3.dart' as calendar;
 import 'package:http/http.dart' as http;
-import '../domain/domain.dart';
+import 'package:notes_reminder_app/features/note/domain/domain.dart';
 
 class CalendarServiceImpl implements CalendarService {
   CalendarServiceImpl._();

--- a/lib/features/note/data/home_widget_service.dart
+++ b/lib/features/note/data/home_widget_service.dart
@@ -1,6 +1,6 @@
 import 'package:home_widget/home_widget.dart';
 
-import '../domain/domain.dart';
+import 'package:notes_reminder_app/features/note/domain/domain.dart';
 
 /// Service to update the native home screen widget with the next upcoming note.
 class HomeWidgetServiceImpl implements HomeWidgetService {

--- a/lib/features/note/data/notification_service.dart
+++ b/lib/features/note/data/notification_service.dart
@@ -7,7 +7,7 @@ import 'package:timezone/data/latest.dart' as tzdata;
 import 'package:timezone/timezone.dart' as tz;
 import 'package:flutter/foundation.dart';
 
-import '../domain/domain.dart';
+import 'package:notes_reminder_app/features/note/domain/domain.dart';
 
 class NotificationServiceImpl implements NotificationService {
   static final NotificationServiceImpl _instance =

--- a/lib/features/note/domain/get_note_by_id.dart
+++ b/lib/features/note/domain/get_note_by_id.dart
@@ -1,6 +1,6 @@
 import 'package:collection/collection.dart';
 
-import '../domain/domain.dart';
+import 'package:notes_reminder_app/features/note/domain/domain.dart';
 
 /// Retrieves a single [Note] by id using the [NoteRepository].
 class GetNoteById {

--- a/lib/features/note/presentation/note_detail_screen.dart
+++ b/lib/features/note/presentation/note_detail_screen.dart
@@ -5,18 +5,18 @@ import 'package:notes_reminder_app/generated/app_localizations.dart';
 import 'package:provider/provider.dart';
 import 'package:share_plus/share_plus.dart';
 
-import '../domain/domain.dart';
-import 'note_provider.dart';
-import '../../services/tts_service.dart';
-import '../../widgets/tag_selector.dart';
-import '../../l10n/localization_extensions.dart';
-import '../../chat/data/gemini_service.dart';
-import '../../chat/domain/note_analysis.dart';
-import '../../widgets/attachment_section.dart';
-import '../../widgets/reminder_controls.dart';
-import '../../widgets/ai_suggestions_dialog.dart';
-import '../../chat/presentation/chat_screen.dart';
-import '../../widgets/route_transitions.dart';
+import 'package:notes_reminder_app/features/note/domain/domain.dart';
+import 'package:notes_reminder_app/features/note/presentation/note_provider.dart';
+import 'package:notes_reminder_app/services/tts_service.dart';
+import 'package:notes_reminder_app/widgets/tag_selector.dart';
+import 'package:notes_reminder_app/l10n/localization_extensions.dart';
+import 'package:notes_reminder_app/features/chat/data/gemini_service.dart';
+import 'package:notes_reminder_app/features/chat/domain/note_analysis.dart';
+import 'package:notes_reminder_app/widgets/attachment_section.dart';
+import 'package:notes_reminder_app/widgets/reminder_controls.dart';
+import 'package:notes_reminder_app/widgets/ai_suggestions_dialog.dart';
+import 'package:notes_reminder_app/features/chat/presentation/chat_screen.dart';
+import 'package:notes_reminder_app/widgets/route_transitions.dart';
 
 class NoteDetailScreen extends StatefulWidget {
   final Note note;

--- a/lib/features/note/presentation/note_list_for_day_screen.dart
+++ b/lib/features/note/presentation/note_list_for_day_screen.dart
@@ -3,13 +3,13 @@ import 'package:notes_reminder_app/generated/app_localizations.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
-import '../domain/domain.dart';
-import 'note_provider.dart';
-import '../../services/auth_service.dart';
-import 'note_detail_screen.dart';
-import '../../pandora_ui/hint_chip.dart';
-import '../../widgets/note_card.dart';
-import '../../widgets/route_transitions.dart';
+import 'package:notes_reminder_app/features/note/domain/domain.dart';
+import 'package:notes_reminder_app/features/note/presentation/note_provider.dart';
+import 'package:notes_reminder_app/services/auth_service.dart';
+import 'package:notes_reminder_app/features/note/presentation/note_detail_screen.dart';
+import 'package:notes_reminder_app/pandora_ui/hint_chip.dart';
+import 'package:notes_reminder_app/widgets/note_card.dart';
+import 'package:notes_reminder_app/widgets/route_transitions.dart';
 
 class NoteListForDayScreen extends StatelessWidget {
   final DateTime date;

--- a/lib/features/note/presentation/note_provider.dart
+++ b/lib/features/note/presentation/note_provider.dart
@@ -7,12 +7,12 @@ import 'package:flutter_local_notifications/flutter_local_notifications.dart'
     show Time;
 import 'package:collection/collection.dart';
 
-import '../domain/domain.dart';
+import 'package:notes_reminder_app/features/note/domain/domain.dart';
 import 'package:alarm_data/alarm_data.dart';
-import '../data/calendar_service.dart';
-import '../data/notification_service.dart';
-import '../data/home_widget_service.dart';
-import '../../backup/data/note_sync_service.dart';
+import 'package:notes_reminder_app/features/note/data/calendar_service.dart';
+import 'package:notes_reminder_app/features/note/data/notification_service.dart';
+import 'package:notes_reminder_app/features/note/data/home_widget_service.dart';
+import 'package:notes_reminder_app/backup/data/note_sync_service.dart';
 
 int _noteComparator(Note a, Note b) {
   if (a.pinned != b.pinned) {

--- a/lib/features/note/presentation/note_search_delegate.dart
+++ b/lib/features/note/presentation/note_search_delegate.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:notes_reminder_app/generated/app_localizations.dart';
-import '../domain/domain.dart';
-import 'note_detail_screen.dart';
-import '../../services/auth_service.dart';
-import '../../widgets/route_transitions.dart';
+import 'package:notes_reminder_app/features/note/domain/domain.dart';
+import 'package:notes_reminder_app/features/note/presentation/note_detail_screen.dart';
+import 'package:notes_reminder_app/services/auth_service.dart';
+import 'package:notes_reminder_app/widgets/route_transitions.dart';
 
 class NoteSearchDelegate extends SearchDelegate {
   final List<Note> notes;

--- a/lib/features/note/presentation/voice_to_note_screen.dart
+++ b/lib/features/note/presentation/voice_to_note_screen.dart
@@ -3,8 +3,8 @@ import 'package:notes_reminder_app/generated/app_localizations.dart';
 import 'package:provider/provider.dart';
 import 'package:speech_to_text/speech_to_text.dart' as stt;
 
-import 'note_provider.dart';
-import '../../chat/data/gemini_service.dart';
+import 'package:notes_reminder_app/features/note/presentation/note_provider.dart';
+import 'package:notes_reminder_app/features/chat/data/gemini_service.dart';
 
 class VoiceToNoteScreen extends StatefulWidget {
   final stt.SpeechToText speech;

--- a/lib/features/settings/data/settings_service.dart
+++ b/lib/features/settings/data/settings_service.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-import '../../../theme/tokens.dart';
+import 'package:notes_reminder_app/theme/tokens.dart';
 import 'package:alarm_domain/alarm_domain.dart';
-import '../domain/settings_service.dart';
+import 'package:notes_reminder_app/features/settings/domain/settings_service.dart';
 
 class SettingsServiceImpl implements SettingsService {
   SettingsServiceImpl({

--- a/lib/features/settings/presentation/settings_screen.dart
+++ b/lib/features/settings/presentation/settings_screen.dart
@@ -5,12 +5,13 @@ import 'package:flutter_colorpicker/flutter_colorpicker.dart';
 import 'dart:math' as math;
 
 
-import '../domain/settings_service.dart';
 
 import 'package:alarm_domain/alarm_domain.dart';
 
 import 'package:provider/provider.dart';
-import '../../note/presentation/note_provider.dart';
+import 'package:notes_reminder_app/features/settings/domain/settings_service.dart';
+
+import 'package:notes_reminder_app/features/note/presentation/note_provider.dart';
 
 
 class SettingsScreen extends StatefulWidget {

--- a/lib/firebase_options.dart
+++ b/lib/firebase_options.dart
@@ -1,0 +1,80 @@
+import 'package:firebase_core/firebase_core.dart' show FirebaseOptions;
+import 'package:flutter/foundation.dart'
+    show defaultTargetPlatform, kIsWeb, TargetPlatform;
+
+class DefaultFirebaseOptions {
+  static FirebaseOptions get currentPlatform {
+    if (kIsWeb) {
+      return web;
+    }
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+        return android;
+      case TargetPlatform.iOS:
+        return ios;
+      case TargetPlatform.macOS:
+        return macos;
+      case TargetPlatform.windows:
+        return windows;
+      case TargetPlatform.linux:
+        return linux;
+      default:
+        throw UnsupportedError(
+          'DefaultFirebaseOptions are not supported for this platform.',
+        );
+    }
+  }
+
+  static const FirebaseOptions web = FirebaseOptions(
+    apiKey: 'test',
+    appId: 'test',
+    messagingSenderId: 'test',
+    projectId: 'test',
+    authDomain: 'test',
+    storageBucket: 'test',
+  );
+
+  static const FirebaseOptions android = FirebaseOptions(
+    apiKey: 'test',
+    appId: 'test',
+    messagingSenderId: 'test',
+    projectId: 'test',
+    storageBucket: 'test',
+  );
+
+  static const FirebaseOptions ios = FirebaseOptions(
+    apiKey: 'test',
+    appId: 'test',
+    messagingSenderId: 'test',
+    projectId: 'test',
+    iosClientId: 'test',
+    iosBundleId: 'test',
+    storageBucket: 'test',
+  );
+
+  static const FirebaseOptions macos = FirebaseOptions(
+    apiKey: 'test',
+    appId: 'test',
+    messagingSenderId: 'test',
+    projectId: 'test',
+    iosClientId: 'test',
+    iosBundleId: 'test',
+    storageBucket: 'test',
+  );
+
+  static const FirebaseOptions windows = FirebaseOptions(
+    apiKey: 'test',
+    appId: 'test',
+    messagingSenderId: 'test',
+    projectId: 'test',
+    storageBucket: 'test',
+  );
+
+  static const FirebaseOptions linux = FirebaseOptions(
+    apiKey: 'test',
+    appId: 'test',
+    messagingSenderId: 'test',
+    projectId: 'test',
+    storageBucket: 'test',
+  );
+}

--- a/lib/pandora_ui/bottom_sheet.dart
+++ b/lib/pandora_ui/bottom_sheet.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import '../theme/tokens.dart';
+import 'package:notes_reminder_app/theme/tokens.dart';
 
 /// A draggable bottom sheet that traps focus when opened.
 class PandoraBottomSheet extends StatefulWidget {

--- a/lib/pandora_ui/dismissible_wrapper.dart
+++ b/lib/pandora_ui/dismissible_wrapper.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import '../theme/tokens.dart';
+import 'package:notes_reminder_app/theme/tokens.dart';
 
 /// Wrapper adding swipe-to-dismiss behaviour to any widget.
 class DismissibleWrapper extends StatelessWidget {

--- a/lib/pandora_ui/hint_chip.dart
+++ b/lib/pandora_ui/hint_chip.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-import '../theme/tokens.dart';
+import 'package:notes_reminder_app/theme/tokens.dart';
 
 class _ChipStyle {
   final Color background;

--- a/lib/pandora_ui/palette_list_item.dart
+++ b/lib/pandora_ui/palette_list_item.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-import '../theme/tokens.dart';
-import 'tokens.dart';
+import 'package:notes_reminder_app/theme/tokens.dart';
+import 'package:notes_reminder_app/pandora_ui/tokens.dart';
 
 /// List item displaying a color swatch with an optional icon and label.
 class PaletteListItem extends StatelessWidget {

--- a/lib/pandora_ui/pandora_snackbar.dart
+++ b/lib/pandora_ui/pandora_snackbar.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:notes_reminder_app/generated/app_localizations.dart';
 
-import '../theme/tokens.dart';
+import 'package:notes_reminder_app/theme/tokens.dart';
 
 const _animationDuration = Duration(milliseconds: 150);
 

--- a/lib/pandora_ui/result_card.dart
+++ b/lib/pandora_ui/result_card.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 
 import 'package:alarm_domain/alarm_domain.dart';
-import '../utils/flutter_haptic_feedback_driver.dart';
+import 'package:notes_reminder_app/utils/flutter_haptic_feedback_driver.dart';
 
 /// A card that listens to a [Stream] of text and shows a shimmer while loading.
 class ResultCard extends StatefulWidget {

--- a/lib/pandora_ui/security_cue.dart
+++ b/lib/pandora_ui/security_cue.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import '../theme/tokens.dart';
+import 'package:notes_reminder_app/theme/tokens.dart';
 
 /// Visual indicator of how a result was processed.
 ///

--- a/lib/pandora_ui/snackbar.dart
+++ b/lib/pandora_ui/snackbar.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:alarm_domain/alarm_domain.dart';
-import '../utils/flutter_haptic_feedback_driver.dart';
+import 'package:notes_reminder_app/utils/flutter_haptic_feedback_driver.dart';
 
 /// Simple snackbar that slides in with a custom easing and triggers haptics.
 class SimpleSnackBar extends StatefulWidget {

--- a/lib/pandora_ui/teach_ai_modal.dart
+++ b/lib/pandora_ui/teach_ai_modal.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:notes_reminder_app/generated/app_localizations.dart';
 
 import 'package:alarm_domain/alarm_domain.dart';
-import '../theme/tokens.dart';
-import '../utils/flutter_haptic_feedback_driver.dart';
+import 'package:notes_reminder_app/theme/tokens.dart';
+import 'package:notes_reminder_app/utils/flutter_haptic_feedback_driver.dart';
 
 /// Simple modal dialog allowing the user to provide feedback to improve the AI.
 class TeachAiModal extends StatefulWidget {

--- a/lib/pandora_ui/toolbar_button.dart
+++ b/lib/pandora_ui/toolbar_button.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-import '../theme/tokens.dart';
+import 'package:notes_reminder_app/theme/tokens.dart';
 
 class _ToolbarButtonStyle {
 

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,18 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:notes_reminder_app/generated/app_localizations.dart';
 
-import '../widgets/notes_tab.dart';
-import '../features/chat/presentation/chat_screen.dart';
-import '../features/chat/data/gemini_service.dart';
-import '../features/note/presentation/note_list_for_day_screen.dart';
-import '../features/settings/presentation/settings_screen.dart';
-import '../features/note/presentation/voice_to_note_screen.dart';
-import '../features/settings/data/settings_service.dart';
+import 'package:notes_reminder_app/widgets/notes_tab.dart';
+import 'package:notes_reminder_app/features/chat/presentation/chat_screen.dart';
+import 'package:notes_reminder_app/features/chat/data/gemini_service.dart';
+import 'package:notes_reminder_app/features/note/presentation/note_list_for_day_screen.dart';
+import 'package:notes_reminder_app/features/settings/presentation/settings_screen.dart';
+import 'package:notes_reminder_app/features/note/presentation/voice_to_note_screen.dart';
+import 'package:notes_reminder_app/features/settings/data/settings_service.dart';
 
 import 'package:alarm_domain/alarm_domain.dart';
 
-import '../pandora_ui/palette_bottom_sheet.dart';
-import '../pandora_ui/teach_ai_modal.dart';
+import 'package:notes_reminder_app/pandora_ui/palette_bottom_sheet.dart';
+import 'package:notes_reminder_app/pandora_ui/teach_ai_modal.dart';
 
 class HomeScreen extends StatefulWidget {
   final Function(Color) onThemeChanged;

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:notes_reminder_app/generated/app_localizations.dart';
-import '../features/settings/data/settings_service.dart';
+import 'package:notes_reminder_app/features/settings/data/settings_service.dart';
 
 class OnboardingScreen extends StatefulWidget {
   final VoidCallback onFinished;

--- a/lib/services/app_initializer.dart
+++ b/lib/services/app_initializer.dart
@@ -3,10 +3,10 @@ import 'package:notes_reminder_app/generated/app_localizations.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart'
     as fln;
 
-import 'auth_service.dart';
-import '../features/settings/data/settings_service.dart';
-import '../features/note/data/notification_service.dart';
-import 'startup_service.dart';
+import 'package:notes_reminder_app/services/auth_service.dart';
+import 'package:notes_reminder_app/features/settings/data/settings_service.dart';
+import 'package:notes_reminder_app/features/note/data/notification_service.dart';
+import 'package:notes_reminder_app/services/startup_service.dart';
 
 class AppInitializationData {
   final Color themeColor;

--- a/lib/services/startup_service.dart
+++ b/lib/services/startup_service.dart
@@ -6,7 +6,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart'
     as fln;
 
-import '../firebase_options.dart';
+import 'package:notes_reminder_app/firebase_options.dart';
 import 'package:alarm_domain/alarm_domain.dart';
 
 class StartupResult {

--- a/lib/services/tts_service.dart
+++ b/lib/services/tts_service.dart
@@ -7,7 +7,8 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_tts/flutter_tts.dart';
 import 'package:http/http.dart' as http;
 
-import 'tts_platform_stub.dart' if (dart.library.io) 'dart:io';
+import 'package:notes_reminder_app/services/tts_platform_stub.dart'
+    if (dart.library.io) 'dart:io';
 
 class TTSService {
   final FlutterTts _tts;

--- a/lib/widgets/add_note_dialog.dart
+++ b/lib/widgets/add_note_dialog.dart
@@ -3,9 +3,9 @@ import 'package:notes_reminder_app/generated/app_localizations.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
-import '../features/note/presentation/note_provider.dart';
-import 'tag_selector.dart';
-import '../l10n/localization_extensions.dart';
+import 'package:notes_reminder_app/features/note/presentation/note_provider.dart';
+import 'package:notes_reminder_app/widgets/tag_selector.dart';
+import 'package:notes_reminder_app/l10n/localization_extensions.dart';
 
 class AddNoteDialog extends StatefulWidget {
   const AddNoteDialog({super.key});

--- a/lib/widgets/ai_suggestions_dialog.dart
+++ b/lib/widgets/ai_suggestions_dialog.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:notes_reminder_app/generated/app_localizations.dart';
 
-import '../features/chat/domain/note_analysis.dart';
+import 'package:notes_reminder_app/features/chat/domain/note_analysis.dart';
 
 class AISuggestionsResult {
   final String summary;

--- a/lib/widgets/notes_list.dart
+++ b/lib/widgets/notes_list.dart
@@ -5,12 +5,12 @@ import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:share_plus/share_plus.dart';
 
-import '../features/note/domain/domain.dart';
+import 'package:notes_reminder_app/features/note/domain/domain.dart';
 
-import '../features/note/presentation/note_provider.dart';
-import '../features/note/presentation/note_detail_screen.dart';
-import '../services/auth_service.dart';
-import 'note_card.dart';
+import 'package:notes_reminder_app/features/note/presentation/note_provider.dart';
+import 'package:notes_reminder_app/features/note/presentation/note_detail_screen.dart';
+import 'package:notes_reminder_app/services/auth_service.dart';
+import 'package:notes_reminder_app/widgets/note_card.dart';
 
 /// Displays a scrollable list of notes. When [gridCount] is greater than 1 a
 /// grid layout is used instead of a traditional list.

--- a/lib/widgets/notes_tab.dart
+++ b/lib/widgets/notes_tab.dart
@@ -5,18 +5,18 @@ import 'package:provider/provider.dart';
 import 'package:flutter/services.dart';
 
 
-import '../features/note/presentation/note_provider.dart';
-import '../features/settings/data/settings_service.dart';
+import 'package:notes_reminder_app/features/note/presentation/note_provider.dart';
+import 'package:notes_reminder_app/features/settings/data/settings_service.dart';
 
-import '../features/note/presentation/note_search_delegate.dart';
-import '../features/note/presentation/voice_to_note_screen.dart';
-import '../features/settings/presentation/settings_screen.dart';
-import '../pandora_ui/palette_bottom_sheet.dart';
-import '../pandora_ui/teach_ai_modal.dart';
-import '../features/note/domain/domain.dart';
-import 'add_note_dialog.dart';
-import 'tag_filtered_notes_list.dart';
-import 'route_transitions.dart';
+import 'package:notes_reminder_app/features/note/presentation/note_search_delegate.dart';
+import 'package:notes_reminder_app/features/note/presentation/voice_to_note_screen.dart';
+import 'package:notes_reminder_app/features/settings/presentation/settings_screen.dart';
+import 'package:notes_reminder_app/pandora_ui/palette_bottom_sheet.dart';
+import 'package:notes_reminder_app/pandora_ui/teach_ai_modal.dart';
+import 'package:notes_reminder_app/features/note/domain/domain.dart';
+import 'package:notes_reminder_app/widgets/add_note_dialog.dart';
+import 'package:notes_reminder_app/widgets/tag_filtered_notes_list.dart';
+import 'package:notes_reminder_app/widgets/route_transitions.dart';
 
 class NotesTab extends StatefulWidget {
   final Function(Color) onThemeChanged;

--- a/lib/widgets/pandora_ui_demo.dart
+++ b/lib/widgets/pandora_ui_demo.dart
@@ -2,13 +2,13 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
-import '../pandora_ui/bottom_sheet.dart';
-import '../pandora_ui/dismissible_wrapper.dart';
-import 'palette_list_item.dart';
-import '../pandora_ui/result_card.dart';
-import '../pandora_ui/security_cue.dart';
-import '../pandora_ui/teach_ai_modal.dart';
-import '../theme/tokens.dart';
+import 'package:notes_reminder_app/pandora_ui/bottom_sheet.dart';
+import 'package:notes_reminder_app/pandora_ui/dismissible_wrapper.dart';
+import 'package:notes_reminder_app/pandora_ui/palette_list_item.dart';
+import 'package:notes_reminder_app/pandora_ui/result_card.dart';
+import 'package:notes_reminder_app/pandora_ui/security_cue.dart';
+import 'package:notes_reminder_app/pandora_ui/teach_ai_modal.dart';
+import 'package:notes_reminder_app/theme/tokens.dart';
 
 /// Demonstrates the Pandora UI widgets in a simple screen.
 class PandoraUiDemo extends StatelessWidget {

--- a/lib/widgets/reminder_controls.dart
+++ b/lib/widgets/reminder_controls.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:notes_reminder_app/generated/app_localizations.dart';
-import '../features/note/domain/domain.dart';
+import 'package:notes_reminder_app/features/note/domain/domain.dart';
 
 class ReminderControls extends StatelessWidget {
   final DateTime? alarmTime;

--- a/lib/widgets/tag_filtered_notes_list.dart
+++ b/lib/widgets/tag_filtered_notes_list.dart
@@ -3,12 +3,12 @@ import 'package:notes_reminder_app/generated/app_localizations.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
-import '../features/note/domain/domain.dart';
-import '../features/note/presentation/note_provider.dart';
-import '../features/note/presentation/note_list_for_day_screen.dart';
-import 'notes_list.dart';
-import 'tag_filter_menu.dart';
-import 'route_transitions.dart';
+import 'package:notes_reminder_app/features/note/domain/domain.dart';
+import 'package:notes_reminder_app/features/note/presentation/note_provider.dart';
+import 'package:notes_reminder_app/features/note/presentation/note_list_for_day_screen.dart';
+import 'package:notes_reminder_app/widgets/notes_list.dart';
+import 'package:notes_reminder_app/widgets/tag_filter_menu.dart';
+import 'package:notes_reminder_app/widgets/route_transitions.dart';
 
 class TagFilteredNotesList extends StatefulWidget {
   final int gridCount;

--- a/lib/widgets/tag_selector.dart
+++ b/lib/widgets/tag_selector.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:notes_reminder_app/generated/app_localizations.dart';
-import '../theme/tokens.dart';
+import 'package:notes_reminder_app/theme/tokens.dart';
 
 class TagSelector extends StatefulWidget {
   final List<String> availableTags;


### PR DESCRIPTION
## Summary
- Generate placeholder `firebase_options.dart`
- Switch relative imports to `package:notes_reminder_app/...` across features, widgets, and services

## Testing
- `flutterfire configure` *(fails: command not found)*
- `dart format lib` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf287033c8333b6acc2a7bbe30944