### PR TITLE
refactor: update notification enums and time handling

### DIFF
--- a/lib/features/note/data/notification_service.dart
+++ b/lib/features/note/data/notification_service.dart
@@ -1,5 +1,6 @@
 
 import 'package:flutter_local_notifications/flutter_local_notifications.dart' as fln;
+import 'package:flutter/material.dart' show TimeOfDay;
 import 'package:notes_reminder_app/generated/app_localizations.dart';
 import 'package:flutter_timezone/flutter_timezone.dart';
 
@@ -74,8 +75,8 @@ class NotificationServiceImpl implements NotificationService {
       'scheduled_channel',
       loc.scheduled,
       channelDescription: loc.scheduledDesc,
-      importance: Importance.max,
-      priority: Priority.high,
+      importance: fln.AndroidNotificationImportance.max,
+      priority: fln.AndroidNotificationPriority.high,
       actions: [
         fln.AndroidNotificationAction(
           'done',
@@ -123,8 +124,8 @@ class NotificationServiceImpl implements NotificationService {
       'recurring_channel',
       loc.recurring,
       channelDescription: loc.recurringDesc,
-      importance: Importance.max,
-      priority: Priority.high,
+      importance: fln.AndroidNotificationImportance.max,
+      priority: fln.AndroidNotificationPriority.high,
     );
 
     const iosDetails = fln.DarwinNotificationDetails();
@@ -155,14 +156,14 @@ class NotificationServiceImpl implements NotificationService {
     required dynamic time,
     required dynamic l10n,
   }) async {
-    final t = time as fln.Time;
+    final t = time as TimeOfDay;
     final loc = l10n as AppLocalizations;
     final androidDetails = fln.AndroidNotificationDetails(
       'daily_channel',
       loc.daily,
       channelDescription: loc.dailyDesc,
-      importance: Importance.max,
-      priority: Priority.high,
+      importance: fln.AndroidNotificationImportance.max,
+      priority: fln.AndroidNotificationPriority.high,
     );
 
     const iosDetails = fln.DarwinNotificationDetails();
@@ -217,7 +218,7 @@ class NotificationServiceImpl implements NotificationService {
     );
   }
 
-  tz.TZDateTime _nextInstanceOfTime(fln.Time time) {
+  tz.TZDateTime _nextInstanceOfTime(TimeOfDay time) {
     final now = tz.TZDateTime.now(tz.local);
     var scheduledDate = tz.TZDateTime(
       tz.local,
@@ -226,7 +227,7 @@ class NotificationServiceImpl implements NotificationService {
       now.day,
       time.hour,
       time.minute,
-      time.second,
+      0,
     );
 
     if (scheduledDate.isBefore(now)) {
@@ -238,14 +239,14 @@ class NotificationServiceImpl implements NotificationService {
 
   fln.RepeatInterval _mapRepeatInterval(RepeatInterval interval) {
     switch (interval) {
+      case RepeatInterval.everyMinute:
+        return fln.RepeatInterval.everyMinute;
       case RepeatInterval.hourly:
         return fln.RepeatInterval.hourly;
       case RepeatInterval.daily:
         return fln.RepeatInterval.daily;
       case RepeatInterval.weekly:
         return fln.RepeatInterval.weekly;
-      case RepeatInterval.monthly:
-        return fln.RepeatInterval.everyMinute; // closest
     }
   }
 }

--- a/lib/features/note/presentation/note_provider.dart
+++ b/lib/features/note/presentation/note_provider.dart
@@ -3,8 +3,7 @@ import 'dart:collection';
 
 import 'package:flutter/foundation.dart';
 import 'package:notes_reminder_app/generated/app_localizations.dart';
-import 'package:flutter_local_notifications/flutter_local_notifications.dart'
-    show Time;
+import 'package:flutter/material.dart' show TimeOfDay;
 import 'package:collection/collection.dart';
 
 import '../domain/domain.dart';
@@ -218,7 +217,7 @@ class NoteProvider extends ChangeNotifier {
             id: notificationId,
             title: title,
             body: content,
-            time: Time(alarmTime.hour, alarmTime.minute, alarmTime.second),
+            time: TimeOfDay(hour: alarmTime.hour, minute: alarmTime.minute),
             l10n: l10n,
           );
         } else {
@@ -331,10 +330,9 @@ class NoteProvider extends ChangeNotifier {
             id: nid,
             title: note.title,
             body: note.content,
-            time: Time(
-              note.alarmTime!.hour,
-              note.alarmTime!.minute,
-              note.alarmTime!.second,
+            time: TimeOfDay(
+              hour: note.alarmTime!.hour,
+              minute: note.alarmTime!.minute,
             ),
             l10n: l10n,
           );

--- a/test/notification_service_test.dart
+++ b/test/notification_service_test.dart
@@ -2,7 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/services.dart';
 import 'package:notes_reminder_app/generated/app_localizations.dart';
 import 'package:flutter/foundation.dart';
-import 'dart:ui';
+import 'package:flutter/material.dart';
 import 'package:notes_reminder_app/features/note/data/notification_service.dart';
 import 'package:alarm_domain/alarm_domain.dart';
 import 'package:timezone/data/latest.dart' as tzdata;
@@ -109,7 +109,7 @@ void main() {
       id: 2,
       title: 't',
       body: 'b',
-      time: const Time(10, 0, 0),
+      time: const TimeOfDay(hour: 10, minute: 0),
       l10n: l10n,
     );
     final call = log.singleWhere((c) => c.method == 'zonedSchedule');
@@ -135,6 +135,19 @@ void main() {
     final androidDetails = args['androidDetails'] as Map<dynamic, dynamic>;
     expect(androidDetails['channelName'], l10n.recurring);
     expect(androidDetails['channelDescription'], l10n.recurringDesc);
+  });
+
+  test('scheduleRecurring supports everyMinute interval', () async {
+    final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+    final service = NotificationServiceImpl();
+    await service.scheduleRecurring(
+      id: 4,
+      title: 't',
+      body: 'b',
+      repeatInterval: RepeatInterval.everyMinute,
+      l10n: l10n,
+    );
+    expect(log.any((c) => c.method == 'periodicallyShow'), isTrue);
   });
 
   test('scheduleRecurring logs error when permission denied', () async {


### PR DESCRIPTION
## Summary
- replace deprecated Importance/Priority with AndroidNotificationImportance/AndroidNotificationPriority
- remove fln.Time and use TimeOfDay for daily scheduling
- handle RepeatInterval.everyMinute when mapping to plugin

## Testing
- `flutter test` *(fails: The method 'byLabelText' isn't defined for the type 'CommonFinders')*

------
https://chatgpt.com/codex/tasks/task_e_68bdf28a4940833386e86c3639ef9448