### PR TITLE
Inject SettingsService via providers

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -4,7 +4,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 
 import 'screens/home_screen.dart';
 import 'screens/onboarding_screen.dart';
-import 'features/settings/data/settings_service.dart';
+import 'features/settings/domain/settings_service.dart';
 import 'services/connectivity_service.dart';
 import 'theme/tokens.dart';
 import 'widgets/route_transitions.dart';
@@ -17,6 +17,7 @@ class MyApp extends StatefulWidget {
   final bool notificationFailed;
   final bool hasSeenOnboarding;
   final ConnectivityService connectivityService;
+  final SettingsService settingsService;
   const MyApp({
     super.key,
     required this.themeColor,
@@ -24,6 +25,7 @@ class MyApp extends StatefulWidget {
     required this.themeMode,
     required this.hasSeenOnboarding,
     required this.connectivityService,
+    required this.settingsService,
     this.authFailed = false,
     this.notificationFailed = false,
   });
@@ -62,17 +64,17 @@ class _MyAppState extends State<MyApp> {
 
   void updateTheme(Color newColor) async {
     setState(() => _themeColor = newColor);
-    await SettingsService().saveThemeColor(newColor);
+    await widget.settingsService.saveThemeColor(newColor);
   }
 
   void updateFontScale(double newScale) async {
     setState(() => _fontScale = newScale);
-    await SettingsService().saveFontScale(newScale);
+    await widget.settingsService.saveFontScale(newScale);
   }
 
   void updateThemeMode(ThemeMode newMode) async {
     setState(() => _themeMode = newMode);
-    await SettingsService().saveThemeMode(newMode);
+    await widget.settingsService.saveThemeMode(newMode);
   }
 
   void _completeOnboarding() {

--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -8,6 +8,8 @@ import 'features/note/data/home_widget_service.dart';
 import 'features/backup/data/note_sync_service.dart';
 import 'package:alarm_data/alarm_data.dart';
 import 'package:alarm_domain/alarm_domain.dart';
+import 'features/settings/domain/settings_service.dart';
+import 'features/settings/data/settings_service.dart';
 
 /// Wraps the given [child] with all application level providers.
 class AppProviders extends StatelessWidget {
@@ -42,6 +44,9 @@ class AppProviders extends StatelessWidget {
           create: (context) => NoteSyncServiceImpl(
             repository: context.read<NoteRepository>(),
           ),
+        ),
+        Provider<SettingsService>(
+          create: (_) => SettingsServiceImpl(),
         ),
         ChangeNotifierProvider<NoteProvider>(
           create: (context) => NoteProvider(

--- a/lib/features/settings/presentation/settings_screen.dart
+++ b/lib/features/settings/presentation/settings_screen.dart
@@ -17,14 +17,12 @@ class SettingsScreen extends StatefulWidget {
   final Function(Color) onThemeChanged;
   final Function(double) onFontScaleChanged;
   final Function(ThemeMode) onThemeModeChanged;
-  final SettingsService settingsService;
 
   const SettingsScreen({
     super.key,
     required this.onThemeChanged,
     required this.onFontScaleChanged,
     required this.onThemeModeChanged,
-    required this.settingsService,
   });
 
   @override
@@ -43,7 +41,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   @override
   void initState() {
     super.initState();
-    _settings = widget.settingsService;
+    _settings = context.read<SettingsService>();
     _settings.loadRequireAuth().then((v) {
       if (mounted) {
         setState(() => _requireAuth = v);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ import 'features/note/presentation/note_provider.dart';
 import 'services/app_initializer.dart';
 import 'services/connectivity_service.dart';
 import 'screens/error_screen.dart';
+import 'features/settings/domain/settings_service.dart';
 
 Future<void> _onNotificationResponse(
   fln.NotificationResponse response,
@@ -43,8 +44,10 @@ void main() {
   runApp(
     AppProviders(
       child: Builder(
-        builder: (context) => FutureBuilder<AppInitializationData>(
-          future: AppInitializer().initialize(
+        builder: (context) {
+          final settingsService = context.read<SettingsService>();
+          return FutureBuilder<AppInitializationData>(
+          future: AppInitializer(settingsService: settingsService).initialize(
             onDidReceiveNotificationResponse: (response) =>
                 _onNotificationResponse(response, context),
           ),
@@ -68,9 +71,11 @@ void main() {
               authFailed: data.authFailed,
               notificationFailed: data.notificationFailed,
               connectivityService: ConnectivityService(),
+              settingsService: settingsService,
             );
           },
-        ),
+        );
+        },
       ),
     ),
   );

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -7,7 +7,6 @@ import '../features/chat/data/gemini_service.dart';
 import '../features/note/presentation/note_list_for_day_screen.dart';
 import '../features/settings/presentation/settings_screen.dart';
 import '../features/note/presentation/voice_to_note_screen.dart';
-import '../features/settings/data/settings_service.dart';
 
 import 'package:alarm_domain/alarm_domain.dart';
 
@@ -49,7 +48,6 @@ class _HomeScreenState extends State<HomeScreen> {
           onThemeChanged: widget.onThemeChanged,
           onFontScaleChanged: widget.onFontScaleChanged,
           onThemeModeChanged: widget.onThemeModeChanged,
-          settingsService: SettingsServiceImpl(),
         ),
       ];
   }

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:notes_reminder_app/generated/app_localizations.dart';
-import '../features/settings/data/settings_service.dart';
+import '../features/settings/domain/settings_service.dart';
+import 'package:provider/provider.dart';
 
 class OnboardingScreen extends StatefulWidget {
   final VoidCallback onFinished;
@@ -33,7 +34,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
   ];
 
   Future<void> _finish() async {
-    await SettingsService().saveHasSeenOnboarding(true);
+    await context.read<SettingsService>().saveHasSeenOnboarding(true);
     widget.onFinished();
   }
 

--- a/lib/services/app_initializer.dart
+++ b/lib/services/app_initializer.dart
@@ -4,7 +4,7 @@ import 'package:flutter_local_notifications/flutter_local_notifications.dart'
     as fln;
 
 import 'auth_service.dart';
-import '../features/settings/data/settings_service.dart';
+import '../features/settings/domain/settings_service.dart';
 import '../features/note/data/notification_service.dart';
 import 'startup_service.dart';
 
@@ -27,11 +27,14 @@ class AppInitializationData {
 }
 
 class AppInitializer {
+  final SettingsService settingsService;
+  AppInitializer({required this.settingsService});
+
   Future<AppInitializationData> initialize({
     Future<void> Function(fln.NotificationResponse)?
         onDidReceiveNotificationResponse,
   }) async {
-    final settings = SettingsService();
+    final settings = settingsService;
     final notificationService = NotificationServiceImpl();
     final futures = await Future.wait([
       StartupService(notificationService).initialize(

--- a/lib/widgets/notes_tab.dart
+++ b/lib/widgets/notes_tab.dart
@@ -6,7 +6,7 @@ import 'package:flutter/services.dart';
 
 
 import '../features/note/presentation/note_provider.dart';
-import '../features/settings/data/settings_service.dart';
+import '../features/settings/domain/settings_service.dart';
 
 import '../features/note/presentation/note_search_delegate.dart';
 import '../features/note/presentation/voice_to_note_screen.dart';
@@ -54,7 +54,8 @@ class _NotesTabState extends State<NotesTab> {
     });
   }
 
-  Future<String> _loadMascot() => SettingsServiceImpl().loadMascotPath();
+  Future<String> _loadMascot() =>
+      context.read<SettingsService>().loadMascotPath();
 
   void _addNote() {
     showDialog(context: context, builder: (_) => const AddNoteDialog());
@@ -127,7 +128,6 @@ class _NotesTabState extends State<NotesTab> {
                         onThemeChanged: widget.onThemeChanged,
                         onFontScaleChanged: widget.onFontScaleChanged,
                         onThemeModeChanged: widget.onThemeModeChanged,
-                        settingsService: SettingsServiceImpl(),
                       ),
                     ),
                   );
@@ -171,7 +171,6 @@ class _NotesTabState extends State<NotesTab> {
                                 onThemeChanged: widget.onThemeChanged,
                                 onFontScaleChanged: widget.onFontScaleChanged,
                                 onThemeModeChanged: widget.onThemeModeChanged,
-                                settingsService: SettingsServiceImpl(),
                               ),
                             ),
                           ),


### PR DESCRIPTION
## Summary
- Provide a singleton `SettingsServiceImpl` via `AppProviders`
- Inject `SettingsService` into initialization and app widgets instead of instantiating directly
- Use the injected service for settings persistence across screens

## Testing
- ⚠️ `dart format lib/app_providers.dart lib/services/app_initializer.dart lib/main.dart lib/app.dart lib/screens/home_screen.dart lib/widgets/notes_tab.dart lib/features/settings/presentation/settings_screen.dart lib/screens/onboarding_screen.dart` (command not found)
- ⚠️ `apt-get install -y dart` (Unable to locate package)
- ⚠️ `flutter test` (command not found)

------
https://chatgpt.com/codex/tasks/task_e_68bdf28b7c5083338e936e8ef3ea72f8