### PR TITLE
Handle connectivity result list

### DIFF
--- a/integration_test/sync_and_notification_test.dart
+++ b/integration_test/sync_and_notification_test.dart
@@ -27,10 +27,16 @@ class DummyHomeWidget extends Fake implements HomeWidgetService {
 }
 
 class FakeConnectivityPlatform extends Fake implements ConnectivityPlatform {
-  final _controller = StreamController<ConnectivityResult>.broadcast();
+  final _controller = StreamController<List<ConnectivityResult>>.broadcast();
   @override
-  Stream<ConnectivityResult> get onConnectivityChanged => _controller.stream;
-  void emit(ConnectivityResult result) => _controller.add(result);
+  Stream<List<ConnectivityResult>> get onConnectivityChanged =>
+      _controller.stream;
+
+  @override
+  Future<List<ConnectivityResult>> checkConnectivity() async =>
+      [ConnectivityResult.wifi];
+
+  void emit(ConnectivityResult result) => _controller.add([result]);
 }
 
 void setupFirebase() {

--- a/lib/features/backup/data/note_sync_service.dart
+++ b/lib/features/backup/data/note_sync_service.dart
@@ -16,7 +16,7 @@ class NoteSyncServiceImpl implements NoteSyncService {
   final FirebaseAuth _auth;
   final Connectivity _connectivity;
 
-  StreamSubscription<ConnectivityResult>? _connectivitySubscription;
+  StreamSubscription<List<ConnectivityResult>>? _connectivitySubscription;
   SharedPreferences? _prefs;
 
   static const _unsyncedKey = 'unsyncedNoteIds';
@@ -60,8 +60,8 @@ class NoteSyncServiceImpl implements NoteSyncService {
       _firestore.settings = const Settings(persistenceEnabled: true);
     }
     _connectivitySubscription =
-        _connectivity.onConnectivityChanged.listen((result) {
-      if (result != ConnectivityResult.none) {
+        _connectivity.onConnectivityChanged.listen((results) {
+      if (!results.contains(ConnectivityResult.none)) {
         syncUnsyncedNotes();
       }
     });

--- a/lib/services/connectivity_service.dart
+++ b/lib/services/connectivity_service.dart
@@ -6,23 +6,25 @@ import 'package:flutter/services.dart';
 import 'package:notes_reminder_app/generated/app_localizations.dart';
 
 class ConnectivityService {
-  StreamSubscription<ConnectivityResult>? _subscription;
-  ConnectivityResult? _lastResult;
+  StreamSubscription<List<ConnectivityResult>>? _subscription;
+  List<ConnectivityResult>? _lastResult;
 
   void initialize(
     AppLocalizations l10n,
     GlobalKey<ScaffoldMessengerState> messengerKey,
   ) {
     try {
-      _subscription = Connectivity().onConnectivityChanged.listen((result) {
+      _subscription = Connectivity().onConnectivityChanged.listen((results) {
         if (_lastResult != null) {
-          if (_lastResult == ConnectivityResult.none && result != ConnectivityResult.none) {
+          final wasOffline = _lastResult!.contains(ConnectivityResult.none);
+          final isOffline = results.contains(ConnectivityResult.none);
+          if (wasOffline && !isOffline) {
             messengerKey.currentState?.showSnackBar(
               SnackBar(
                 content: Text(l10n.internetConnectionRestored),
               ),
             );
-          } else if (_lastResult != ConnectivityResult.none && result == ConnectivityResult.none) {
+          } else if (!wasOffline && isOffline) {
             messengerKey.currentState?.showSnackBar(
               SnackBar(
                 content: Text(l10n.noInternetConnection),
@@ -30,7 +32,7 @@ class ConnectivityService {
             );
           }
         }
-        _lastResult = result;
+        _lastResult = results;
       });
     } on MissingPluginException catch (e, st) {
       debugPrint('Connectivity plugin missing: $e\n$st');

--- a/test/connectivity_service_test.dart
+++ b/test/connectivity_service_test.dart
@@ -7,18 +7,19 @@ import 'package:notes_reminder_app/generated/app_localizations.dart';
 import 'package:notes_reminder_app/services/connectivity_service.dart';
 
 class FakeConnectivity extends ConnectivityPlatform {
-  final _controller = StreamController<ConnectivityResult>();
+  final _controller = StreamController<List<ConnectivityResult>>();
 
   @override
-  Stream<ConnectivityResult> get onConnectivityChanged => _controller.stream;
+  Stream<List<ConnectivityResult>> get onConnectivityChanged =>
+      _controller.stream;
 
   @override
-  Future<ConnectivityResult> checkConnectivity() async {
-    return ConnectivityResult.wifi;
+  Future<List<ConnectivityResult>> checkConnectivity() async {
+    return [ConnectivityResult.wifi];
   }
 
   void emit(ConnectivityResult result) {
-    _controller.add(result);
+    _controller.add([result]);
   }
 }
 

--- a/test/note_sync_service_test.dart
+++ b/test/note_sync_service_test.dart
@@ -8,7 +8,8 @@ class DummyRepo extends Fake implements NoteRepository {}
 
 class FakeConnectivity extends Connectivity {
   @override
-  Stream<ConnectivityResult> get onConnectivityChanged => const Stream.empty();
+  Stream<List<ConnectivityResult>> get onConnectivityChanged =>
+      const Stream.empty();
 }
 
 void main() {


### PR DESCRIPTION
## Summary
- update connectivity listeners to accept lists of results
- sync notes when any connectivity is available
- align tests with new connectivity_plus API

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf28a98f883339fa8b778d2f63ce9