### PR TITLE
chore: add alarm_data import to settings screen

### DIFF
--- a/lib/features/settings/presentation/settings_screen.dart
+++ b/lib/features/settings/presentation/settings_screen.dart
@@ -7,6 +7,7 @@ import 'dart:math' as math;
 
 import '../domain/settings_service.dart';
 
+import 'package:alarm_data/alarm_data.dart';
 import 'package:alarm_domain/alarm_domain.dart';
 
 import 'package:provider/provider.dart';


### PR DESCRIPTION
## Summary
- import `alarm_data` in settings screen so NoteRepositoryImpl is available

## Testing
- `dart analyze lib/features/settings/presentation/settings_screen.dart` *(fails: command not found)*
- `flutter analyze lib/features/settings/presentation/settings_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf28e88cc8333b19485f02a47a4a6