### PR TITLE
chore: update fuse dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -78,7 +78,7 @@ dependencies:
 
   google_fonts: 6.3.1
 
-  fuse: 0.0.99
+  fuse: ^0.0.99
 
   alarm_domain:
     path: alarm_domain


### PR DESCRIPTION
## Summary
- allow newer fuse releases via caret dependency constraint

## Testing
- `flutter pub get` *(fails: command not found: flutter)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf2917fcc8333ab4168ef47bf46b8