### PR TITLE
chore: install android cmdline tools in CI

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      ANDROID_SDK_ROOT: $HOME/android-sdk
     steps:
 
       - uses: actions/checkout@v5
@@ -18,9 +20,16 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: 'beta'
-      - name: Install Android SDK 36 and NDK 27
+      - name: Install Android CMD tools
         run: |
-          yes | sdkmanager "platforms;android-36" "build-tools;36.0.0" "ndk;27.0.12077973"
+          ANDROID_SDK_ROOT=$HOME/android-sdk
+          mkdir -p $ANDROID_SDK_ROOT/cmdline-tools
+          curl -sSL https://dl.google.com/android/repository/commandlinetools-linux-10406996_latest.zip -o cmdtools.zip
+          unzip -q cmdtools.zip
+          mv cmdline-tools $ANDROID_SDK_ROOT/cmdline-tools/latest
+          echo "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin" >> $GITHUB_PATH
+      - name: Install required SDK packages
+        run: yes | sdkmanager "platforms;android-36" "build-tools;36.0.0" "ndk;27.0.12077973"
       - run: flutter clean
       - run: flutter pub get
       - run: flutter gen-l10n


### PR DESCRIPTION
## Summary
- install Android CMD tools before using sdkmanager
- set ANDROID_SDK_ROOT in Android build workflow

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68be042303208333b191be323d3569cc