### PR TITLE
ci: install Android cmdline tools before sdkmanager

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -9,14 +9,23 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      ANDROID_SDK_ROOT: $HOME/android-sdk
     steps:
       - uses: actions/checkout@v5
       - uses: subosito/flutter-action@v2
         with:
           channel: beta
-      - name: Install Android SDK 36 and NDK 27
+      - name: Install Android cmdline-tools
         run: |
-          yes | sdkmanager "platforms;android-36" "build-tools;36.0.0" "ndk;27.0.12077973"
+          ANDROID_SDK_ROOT=$HOME/android-sdk
+          mkdir -p $ANDROID_SDK_ROOT/cmdline-tools
+          curl -sSL https://dl.google.com/android/repository/commandlinetools-linux-10406996_latest.zip -o cmdtools.zip
+          unzip -q cmdtools.zip
+          mv cmdline-tools $ANDROID_SDK_ROOT/cmdline-tools/latest
+          echo "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin" >> $GITHUB_PATH
+      - name: Install required SDK packages
+        run: yes | sdkmanager "platforms;android-36" "build-tools;36.0.0" "ndk;27.0.12077973"
       - uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/pr-debug-build.yml
+++ b/.github/workflows/pr-debug-build.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      ANDROID_SDK_ROOT: $HOME/android-sdk
     steps:
       - uses: actions/checkout@v5
       - name: Set up Java
@@ -17,9 +19,16 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: beta
-      - name: Install Android SDK 36 and NDK 27
+      - name: Install Android cmdline-tools
         run: |
-          yes | sdkmanager "platforms;android-36" "build-tools;36.0.0" "ndk;27.0.12077973"
+          ANDROID_SDK_ROOT=$HOME/android-sdk
+          mkdir -p $ANDROID_SDK_ROOT/cmdline-tools
+          curl -sSL https://dl.google.com/android/repository/commandlinetools-linux-10406996_latest.zip -o cmdtools.zip
+          unzip -q cmdtools.zip
+          mv cmdline-tools $ANDROID_SDK_ROOT/cmdline-tools/latest
+          echo "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin" >> $GITHUB_PATH
+      - name: Install required SDK packages
+        run: yes | sdkmanager "platforms;android-36" "build-tools;36.0.0" "ndk;27.0.12077973"
       - name: Cache pub packages
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Summary
- install Android cmdline-tools prior to running `sdkmanager`
- set `ANDROID_SDK_ROOT` so subsequent steps find the SDK

## Testing
- `yes | sdkmanager "platforms;android-36" "build-tools;36.0.0" "ndk;27.0.12077973"` (interrupted after start)
- `sdkmanager --version`


------
https://chatgpt.com/codex/tasks/task_e_68be3e85288c83339c7a8716e65efeaf