### PR TITLE
fix: correct note sync import path

### DIFF
--- a/lib/features/note/presentation/note_provider.dart
+++ b/lib/features/note/presentation/note_provider.dart
@@ -11,7 +11,7 @@ import 'package:alarm_data/alarm_data.dart';
 import 'package:notes_reminder_app/features/note/data/calendar_service.dart';
 import 'package:notes_reminder_app/features/note/data/notification_service.dart';
 import 'package:notes_reminder_app/features/note/data/home_widget_service.dart';
-import 'package:notes_reminder_app/backup/data/note_sync_service.dart';
+import 'package:notes_reminder_app/features/backup/data/note_sync_service.dart';
 
 int _noteComparator(Note a, Note b) {
   if (a.pinned != b.pinned) {


### PR DESCRIPTION
## Summary
- fix note_provider note_sync_service import path

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be3e9fc0f48333a9601c2e2428db26