### PR TITLE
Remove const from runtime-created services

### DIFF
--- a/lib/features/note/presentation/note_detail_screen.dart
+++ b/lib/features/note/presentation/note_detail_screen.dart
@@ -21,7 +21,7 @@ import 'package:notes_reminder_app/widgets/route_transitions.dart';
 class NoteDetailScreen extends StatefulWidget {
   final Note note;
   final TTSService ttsService;
-  const NoteDetailScreen({
+  NoteDetailScreen({
     super.key,
     required this.note,
     TTSService? ttsService,

--- a/lib/features/note/presentation/voice_to_note_screen.dart
+++ b/lib/features/note/presentation/voice_to_note_screen.dart
@@ -10,7 +10,7 @@ class VoiceToNoteScreen extends StatefulWidget {
   final stt.SpeechToText speech;
   final bool autoStart;
 
-  const VoiceToNoteScreen({
+  VoiceToNoteScreen({
     super.key,
     stt.SpeechToText? speech,
     this.autoStart = false,

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -43,7 +43,7 @@ class _HomeScreenState extends State<HomeScreen> {
           onThemeModeChanged: widget.onThemeModeChanged,
         ),
         NoteListForDayScreen(date: DateTime.now()),
-        const VoiceToNoteScreen(),
+        VoiceToNoteScreen(),
         ChatScreen(initialMessage: '', service: GeminiServiceImpl()),
         SettingsScreen(
           onThemeChanged: widget.onThemeChanged,

--- a/lib/widgets/notes_tab.dart
+++ b/lib/widgets/notes_tab.dart
@@ -49,7 +49,7 @@ class _NotesTabState extends State<NotesTab> {
         await Navigator.push(
           context,
           MaterialPageRoute(
-            builder: (_) => const VoiceToNoteScreen(autoStart: true),
+            builder: (_) => VoiceToNoteScreen(autoStart: true),
           ),
         );
       }
@@ -115,7 +115,7 @@ class _NotesTabState extends State<NotesTab> {
                 onPressed: () async {
                   await Navigator.push(
                     context,
-                    buildSlideFadeRoute(const VoiceToNoteScreen()),
+                    buildSlideFadeRoute(VoiceToNoteScreen()),
                   );
                 },
               ),
@@ -160,7 +160,7 @@ class _NotesTabState extends State<NotesTab> {
                           action: () => Navigator.push(
                             context,
                             MaterialPageRoute(
-                              builder: (_) => const VoiceToNoteScreen(),
+                              builder: (_) => VoiceToNoteScreen(),
                             ),
                           ),
                         ),


### PR DESCRIPTION
## Summary
- Make `VoiceToNoteScreen` and `NoteDetailScreen` constructors non-const so runtime services are created properly
- Update all `VoiceToNoteScreen` usages to remove `const`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be3ea6a080833386c111a4be85e316