### PR TITLE
fix: correct note sync service import path

### DIFF
--- a/lib/features/note/presentation/note_provider.dart
+++ b/lib/features/note/presentation/note_provider.dart
@@ -11,7 +11,7 @@ import 'package:alarm_data/alarm_data.dart';
 import 'package:notes_reminder_app/features/note/data/calendar_service.dart';
 import 'package:notes_reminder_app/features/note/data/notification_service.dart';
 import 'package:notes_reminder_app/features/note/data/home_widget_service.dart';
-import 'package:notes_reminder_app/backup/data/note_sync_service.dart';
+import 'package:notes_reminder_app/features/backup/data/note_sync_service.dart';
 
 int _noteComparator(Note a, Note b) {
   if (a.pinned != b.pinned) {


### PR DESCRIPTION
## Summary
- ensure NoteProvider imports NoteSyncServiceImpl from features backup data

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be3eb4aa2c8333a0fa336b7cdb1a53