### PR TITLE
refactor: update android notification constants

### DIFF
--- a/lib/features/note/data/notification_service.dart
+++ b/lib/features/note/data/notification_service.dart
@@ -75,8 +75,8 @@ class NotificationServiceImpl implements NotificationService {
       'scheduled_channel',
       loc.scheduled,
       channelDescription: loc.scheduledDesc,
-      importance: fln.AndroidNotificationImportance.max,
-      priority: fln.AndroidNotificationPriority.high,
+      importance: fln.Importance.max,
+      priority: fln.Priority.high,
       actions: [
         fln.AndroidNotificationAction(
           'done',
@@ -124,8 +124,8 @@ class NotificationServiceImpl implements NotificationService {
       'recurring_channel',
       loc.recurring,
       channelDescription: loc.recurringDesc,
-      importance: fln.AndroidNotificationImportance.max,
-      priority: fln.AndroidNotificationPriority.high,
+      importance: fln.Importance.max,
+      priority: fln.Priority.high,
     );
 
     const iosDetails = fln.DarwinNotificationDetails();
@@ -162,8 +162,8 @@ class NotificationServiceImpl implements NotificationService {
       'daily_channel',
       loc.daily,
       channelDescription: loc.dailyDesc,
-      importance: fln.AndroidNotificationImportance.max,
-      priority: fln.AndroidNotificationPriority.high,
+      importance: fln.Importance.max,
+      priority: fln.Priority.high,
     );
 
     const iosDetails = fln.DarwinNotificationDetails();


### PR DESCRIPTION
## Summary
- replace deprecated AndroidNotificationImportance and AndroidNotificationPriority constants with new Importance and Priority equivalents

## Testing
- `dart format lib/features/note/data/notification_service.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be3eb9b024833382c4e1857c903209