### PR TITLE
Handle notification callback with dynamic argument

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,10 +17,11 @@ import 'screens/error_screen.dart';
 import 'features/settings/domain/settings_service.dart';
 
 Future<void> _onNotificationResponse(
-  fln.NotificationResponse response,
+  dynamic response,
   BuildContext context,
 ) async {
-  final id = response.payload;
+  final notificationResponse = response as fln.NotificationResponse;
+  final id = notificationResponse.payload;
   if (id == null || !context.mounted) return;
   final noteProvider = context.read<NoteProvider>();
   final note = noteProvider.notes.firstWhereOrNull((n) => n.id == id);
@@ -29,12 +30,12 @@ Future<void> _onNotificationResponse(
   final supported = AppLocalizations.delegate.isSupported(locale);
   final effectiveLocale = supported ? locale : const Locale('en');
   final l10n = await AppLocalizations.delegate.load(effectiveLocale);
-  if (response.actionId == 'done') {
+  if (notificationResponse.actionId == 'done') {
     await noteProvider.updateNote(
       note.copyWith(alarmTime: null, notificationId: null, active: false),
       l10n,
     );
-  } else if (response.actionId == 'snooze') {
+  } else if (notificationResponse.actionId == 'snooze') {
     await noteProvider.snoozeNote(note, l10n);
   }
 }

--- a/lib/services/app_initializer.dart
+++ b/lib/services/app_initializer.dart
@@ -33,8 +33,7 @@ class AppInitializer {
   AppInitializer({required this.settingsService});
 
   Future<AppInitializationData> initialize({
-    Future<void> Function(fln.NotificationResponse)?
-        onDidReceiveNotificationResponse,
+    Future<void> Function(dynamic)? onDidReceiveNotificationResponse,
   }) async {
     final settings = settingsService;
     final notificationService = NotificationServiceImpl();

--- a/lib/services/startup_service.dart
+++ b/lib/services/startup_service.dart
@@ -24,8 +24,7 @@ class StartupService {
   StartupService(this._notificationService);
 
   Future<StartupResult> initialize({
-    Future<void> Function(fln.NotificationResponse)?
-        onDidReceiveNotificationResponse,
+    Future<void> Function(dynamic)? onDidReceiveNotificationResponse,
   }) async {
     bool authFailed = false;
     bool notificationFailed = false;


### PR DESCRIPTION
## Summary
- Accept dynamic notification responses in startup and app initialization services
- Cast notification responses in main to maintain compatibility with `flutter_local_notifications`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be3ec4fe188333b7609408015ce28f