### PR TITLE
refactor: update Google Sign-In usage

### DIFF
--- a/lib/features/note/data/calendar_service.dart
+++ b/lib/features/note/data/calendar_service.dart
@@ -7,16 +7,32 @@ class CalendarServiceImpl implements CalendarService {
   CalendarServiceImpl._();
   static final CalendarServiceImpl instance = CalendarServiceImpl._();
 
-  GoogleSignIn? _googleSignIn;
-  GoogleSignIn get _signIn => _googleSignIn ??=
-      GoogleSignIn(scopes: <String>[calendar.CalendarApi.calendarScope]);
+  final _signIn = GoogleSignIn(scopes: <String>[
+    calendar.CalendarApi.calendarScope,
+  ]);
+
+  bool _initialized = false;
 
   Future<calendar.CalendarApi?> _getApi() async {
     try {
-      var account = await _signIn.signInSilently();
-      account ??= await _signIn.signIn();
+      if (!_initialized) {
+        await _signIn.initialize();
+        _initialized = true;
+      }
+      GoogleSignInAccount? account;
+      final silentSignIn = _signIn.attemptLightweightAuthentication();
+      if (silentSignIn != null) {
+        account = await silentSignIn;
+      }
+      account ??= await _signIn.authenticate(
+        scopeHint: <String>[calendar.CalendarApi.calendarScope],
+      );
       if (account == null) return null;
-      final headers = await account.authHeaders;
+      final headers = await account.authorizationClient.authorizationHeaders(
+        <String>[calendar.CalendarApi.calendarScope],
+        promptIfNecessary: true,
+      );
+      if (headers == null) return null;
       final client = _AuthClient(headers);
       return calendar.CalendarApi(client);
     } catch (e) {

--- a/test/calendar_service_test.dart
+++ b/test/calendar_service_test.dart
@@ -7,52 +7,114 @@ import 'package:notes_reminder_app/features/note/data/calendar_service.dart';
 
 class FakeSignInSuccess extends GoogleSignInPlatform {
   @override
-  Future<void> init({
-    List<String>? scopes,
-    String? signInOption,
-    String? clientId,
-    bool? forceCodeForRefreshToken,
-    String? hostedDomain,
-  }) async {}
+  Future<void> init(InitParameters params) async {}
 
   @override
-  Future<GoogleSignInUserData?> signInSilently() async =>
-      const GoogleSignInUserData(email: 'e', id: '1', displayName: 'd');
+  Future<AuthenticationResults?>? attemptLightweightAuthentication(
+      AttemptLightweightAuthenticationParameters params) async {
+    return AuthenticationResults(
+      user: const GoogleSignInUserData(
+        email: 'e',
+        id: '1',
+        displayName: 'd',
+      ),
+      authenticationTokens: const AuthenticationTokenData(
+        accessToken: 'token',
+        idToken: 'id',
+      ),
+    );
+  }
 
   @override
-  Future<GoogleSignInUserData?> signIn() async =>
-      const GoogleSignInUserData(email: 'e', id: '1', displayName: 'd');
+  Future<AuthenticationResults> authenticate(
+      AuthenticateParameters params) async {
+    return AuthenticationResults(
+      user: const GoogleSignInUserData(
+        email: 'e',
+        id: '1',
+        displayName: 'd',
+      ),
+      authenticationTokens: const AuthenticationTokenData(
+        accessToken: 'token',
+        idToken: 'id',
+      ),
+    );
+  }
 
   @override
-  Future<GoogleSignInTokenData> getTokens({
-    required String email,
-    bool? shouldRecoverAuth,
-  }) async =>
-      const GoogleSignInTokenData(accessToken: 'token', idToken: 'id');
+  Future<ClientAuthorizationTokenData?> clientAuthorizationTokensForScopes(
+      ClientAuthorizationTokensForScopesParameters params) async {
+    return const ClientAuthorizationTokenData(accessToken: 'token');
+  }
+
+  @override
+  Future<ServerAuthorizationTokenData?> serverAuthorizationTokensForScopes(
+      ServerAuthorizationTokensForScopesParameters params) async {
+    return null;
+  }
+
+  @override
+  bool supportsAuthenticate() => true;
+
+  @override
+  bool authorizationRequiresUserInteraction() => false;
+
+  @override
+  Future<void> signOut(SignOutParams params) async {}
+
+  @override
+  Future<void> disconnect(DisconnectParams params) async {}
+
+  @override
+  Stream<AuthenticationEvent>? get authenticationEvents =>
+      const Stream<AuthenticationEvent>.empty();
 }
 
 class FakeSignInFail extends GoogleSignInPlatform {
   @override
-  Future<void> init({
-    List<String>? scopes,
-    String? signInOption,
-    String? clientId,
-    bool? forceCodeForRefreshToken,
-    String? hostedDomain,
-  }) async {}
+  Future<void> init(InitParameters params) async {}
 
   @override
-  Future<GoogleSignInUserData?> signInSilently() async => null;
+  Future<AuthenticationResults?>? attemptLightweightAuthentication(
+      AttemptLightweightAuthenticationParameters params) async {
+    return null;
+  }
 
   @override
-  Future<GoogleSignInUserData?> signIn() async => null;
+  Future<AuthenticationResults> authenticate(
+      AuthenticateParameters params) async {
+    throw const GoogleSignInException(
+      code: GoogleSignInExceptionCode.canceled,
+    );
+  }
 
   @override
-  Future<GoogleSignInTokenData> getTokens({
-    required String email,
-    bool? shouldRecoverAuth,
-  }) async =>
-      const GoogleSignInTokenData(accessToken: '', idToken: '');
+  Future<ClientAuthorizationTokenData?> clientAuthorizationTokensForScopes(
+      ClientAuthorizationTokensForScopesParameters params) async {
+    return null;
+  }
+
+  @override
+  Future<ServerAuthorizationTokenData?> serverAuthorizationTokensForScopes(
+      ServerAuthorizationTokensForScopesParameters params) async {
+    return null;
+  }
+
+  @override
+  bool supportsAuthenticate() => true;
+
+  @override
+  bool authorizationRequiresUserInteraction() => false;
+
+  @override
+  Future<void> signOut(SignOutParams params) async {}
+
+  @override
+  Future<void> disconnect(DisconnectParams params) async {}
+
+  @override
+  Stream<AuthenticationEvent>? get authenticationEvents =>
+      const Stream<AuthenticationEvent>.empty();
 }
 
 class FakeHttpClient extends HttpClient {


### PR DESCRIPTION
## Summary
- initialize a single GoogleSignIn instance and migrate to new authentication API
- update calendar service tests for new Google Sign-In platform interface

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be483d3b1c83338d6120e969cc7956