### PR TITLE
refactor: update Google Sign-In usage

### DIFF
--- a/lib/pandora_ui/palette_bottom_sheet.dart
+++ b/lib/pandora_ui/palette_bottom_sheet.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:fuse/fuse.dart';
+import 'package:fuzzy/fuzzy.dart';
 import 'package:notes_reminder_app/generated/app_localizations.dart';
 
 import 'package:alarm_domain/alarm_domain.dart';
@@ -26,15 +26,15 @@ class _PaletteBottomSheet extends StatefulWidget {
 }
 
 class _PaletteBottomSheetState extends State<_PaletteBottomSheet> {
-  late final Fuse<Command> _fuse;
+  late final Fuzzy<Command> _fuzzy;
   late List<Command> _results;
 
   @override
   void initState() {
     super.initState();
-    _fuse = Fuse(
+    _fuzzy = Fuzzy(
       widget.commands,
-      options: FuseOptions(
+      options: FuzzyOptions(
         keys: [
           WeightedKey<Command>(
             name: 'title',
@@ -58,7 +58,7 @@ class _PaletteBottomSheetState extends State<_PaletteBottomSheet> {
         _results = widget.commands;
       } else {
         _results =
-            _fuse.search(query).map((result) => result.item).toList();
+            _fuzzy.search(query).map((result) => result.item).toList();
       }
     });
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -78,7 +78,7 @@ dependencies:
 
   google_fonts: 6.3.1
 
-  fuse: ^0.0.99
+  fuzzy: ^0.5.1
 
   alarm_domain:
     path: alarm_domain

--- a/test/calendar_service_test.dart
+++ b/test/calendar_service_test.dart
@@ -7,52 +7,114 @@ import 'package:notes_reminder_app/features/note/data/calendar_service.dart';
 
 class FakeSignInSuccess extends GoogleSignInPlatform {
   @override
-  Future<void> init({
-    List<String>? scopes,
-    String? signInOption,
-    String? clientId,
-    bool? forceCodeForRefreshToken,
-    String? hostedDomain,
-  }) async {}
+  Future<void> init(InitParameters params) async {}
 
   @override
-  Future<GoogleSignInUserData?> signInSilently() async =>
-      const GoogleSignInUserData(email: 'e', id: '1', displayName: 'd');
+  Future<AuthenticationResults?>? attemptLightweightAuthentication(
+      AttemptLightweightAuthenticationParameters params) async {
+    return AuthenticationResults(
+      user: const GoogleSignInUserData(
+        email: 'e',
+        id: '1',
+        displayName: 'd',
+      ),
+      authenticationTokens: const AuthenticationTokenData(
+        accessToken: 'token',
+        idToken: 'id',
+      ),
+    );
+  }
 
   @override
-  Future<GoogleSignInUserData?> signIn() async =>
-      const GoogleSignInUserData(email: 'e', id: '1', displayName: 'd');
+  Future<AuthenticationResults> authenticate(
+      AuthenticateParameters params) async {
+    return AuthenticationResults(
+      user: const GoogleSignInUserData(
+        email: 'e',
+        id: '1',
+        displayName: 'd',
+      ),
+      authenticationTokens: const AuthenticationTokenData(
+        accessToken: 'token',
+        idToken: 'id',
+      ),
+    );
+  }
 
   @override
-  Future<GoogleSignInTokenData> getTokens({
-    required String email,
-    bool? shouldRecoverAuth,
-  }) async =>
-      const GoogleSignInTokenData(accessToken: 'token', idToken: 'id');
+  Future<ClientAuthorizationTokenData?> clientAuthorizationTokensForScopes(
+      ClientAuthorizationTokensForScopesParameters params) async {
+    return const ClientAuthorizationTokenData(accessToken: 'token');
+  }
+
+  @override
+  Future<ServerAuthorizationTokenData?> serverAuthorizationTokensForScopes(
+      ServerAuthorizationTokensForScopesParameters params) async {
+    return null;
+  }
+
+  @override
+  bool supportsAuthenticate() => true;
+
+  @override
+  bool authorizationRequiresUserInteraction() => false;
+
+  @override
+  Future<void> signOut(SignOutParams params) async {}
+
+  @override
+  Future<void> disconnect(DisconnectParams params) async {}
+
+  @override
+  Stream<AuthenticationEvent>? get authenticationEvents =>
+      const Stream<AuthenticationEvent>.empty();
 }
 
 class FakeSignInFail extends GoogleSignInPlatform {
   @override
-  Future<void> init({
-    List<String>? scopes,
-    String? signInOption,
-    String? clientId,
-    bool? forceCodeForRefreshToken,
-    String? hostedDomain,
-  }) async {}
+  Future<void> init(InitParameters params) async {}
 
   @override
-  Future<GoogleSignInUserData?> signInSilently() async => null;
+  Future<AuthenticationResults?>? attemptLightweightAuthentication(
+      AttemptLightweightAuthenticationParameters params) async {
+    return null;
+  }
 
   @override
-  Future<GoogleSignInUserData?> signIn() async => null;
+  Future<AuthenticationResults> authenticate(
+      AuthenticateParameters params) async {
+    throw const GoogleSignInException(
+      code: GoogleSignInExceptionCode.canceled,
+    );
+  }
 
   @override
-  Future<GoogleSignInTokenData> getTokens({
-    required String email,
-    bool? shouldRecoverAuth,
-  }) async =>
-      const GoogleSignInTokenData(accessToken: '', idToken: '');
+  Future<ClientAuthorizationTokenData?> clientAuthorizationTokensForScopes(
+      ClientAuthorizationTokensForScopesParameters params) async {
+    return null;
+  }
+
+  @override
+  Future<ServerAuthorizationTokenData?> serverAuthorizationTokensForScopes(
+      ServerAuthorizationTokensForScopesParameters params) async {
+    return null;
+  }
+
+  @override
+  bool supportsAuthenticate() => true;
+
+  @override
+  bool authorizationRequiresUserInteraction() => false;
+
+  @override
+  Future<void> signOut(SignOutParams params) async {}
+
+  @override
+  Future<void> disconnect(DisconnectParams params) async {}
+
+  @override
+  Stream<AuthenticationEvent>? get authenticationEvents =>
+      const Stream<AuthenticationEvent>.empty();
 }
 
 class FakeHttpClient extends HttpClient {


### PR DESCRIPTION
## Summary
- initialize a single GoogleSignIn instance and migrate to new authentication API
- update calendar service tests for new Google Sign-In platform interface
- restore fuzzy search dependency and adapt palette bottom sheet

## Testing
- `flutter test` *(fails: command not found)*
- `dart pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be483d3b1c83338d6120e969cc7956