### PR TITLE
chore: add dependency overrides

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -96,6 +96,11 @@ dev_dependencies:
   build_runner: 2.8.0
   json_serializable: 6.11.1
 
+dependency_overrides:
+  http: 1.5.0
+  intl: 0.20.2
+  file_picker: 10.3.2
+
 flutter:
   generate: true
   uses-material-design: true


### PR DESCRIPTION
## Summary
- add dependency_overrides for http, intl, and file_picker to pin versions across the workspace

## Testing
- `melos bootstrap` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be58eb2e108333bb58515e78c7ee0d