### PR TITLE
Update package name references to pandora

### DIFF
--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:notes_reminder_app/main.dart' as app;
+import 'package:pandora/main.dart' as app;
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/integration_test/sync_and_notification_test.dart
+++ b/integration_test/sync_and_notification_test.dart
@@ -9,10 +9,10 @@ import 'package:integration_test/integration_test.dart';
 import 'package:mocktail/mocktail.dart';
 
 import 'package:alarm_domain/alarm_domain.dart' hide Note;
-import 'package:notes_reminder_app/features/note/note.dart';
-import 'package:notes_reminder_app/features/backup/data/note_sync_service.dart';
+import 'package:pandora/features/note/note.dart';
+import 'package:pandora/features/backup/data/note_sync_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:notes_reminder_app/generated/app_localizations.dart';
+import 'package:pandora/generated/app_localizations.dart';
 import 'package:timezone/data/latest.dart' as tzdata;
 
 class MockRepo extends Mock implements NoteRepository {}

--- a/ios/NotesReminderWidget/NotesReminderWidget.swift
+++ b/ios/NotesReminderWidget/NotesReminderWidget.swift
@@ -23,7 +23,7 @@ struct Provider: TimelineProvider {
     }
 
     private func loadNote() -> String {
-        let defaults = UserDefaults(suiteName: "group.com.example.notes_reminder_app")
+        let defaults = UserDefaults(suiteName: "group.com.example.pandora")
         return defaults?.string(forKey: "note") ?? "No notes"
     }
 }

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -25,7 +25,7 @@ import Intents
   override func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
     if userActivity.activityType == "CreateNoteIntent" {
       if let controller = window?.rootViewController as? FlutterViewController {
-        let channel = FlutterMethodChannel(name: "notes_reminder_app/actions", binaryMessenger: controller.binaryMessenger)
+        let channel = FlutterMethodChannel(name: "pandora/actions", binaryMessenger: controller.binaryMessenger)
         channel.invokeMethod("voiceToNote", arguments: nil)
       }
       return true

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Notes Reminder App</string>
+	<string>Pandora</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>notes_reminder_app</string>
+	<string>pandora</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -4,10 +4,10 @@ project(runner LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "notes_reminder_app")
+set(BINARY_NAME "pandora")
 # The unique GTK application identifier for this application. See:
 # https://wiki.gnome.org/HowDoI/ChooseApplicationID
-set(APPLICATION_ID "com.example.notes_reminder_app")
+set(APPLICATION_ID "com.example.pandora")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -46,11 +46,11 @@ static void my_application_activate(GApplication* application) {
   if (use_header_bar) {
     GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));
-    gtk_header_bar_set_title(header_bar, "notes_reminder_app");
+    gtk_header_bar_set_title(header_bar, "pandora");
     gtk_header_bar_set_show_close_button(header_bar, TRUE);
     gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
   } else {
-    gtk_window_set_title(window, "notes_reminder_app");
+    gtk_window_set_title(window, "pandora");
   }
 
   gtk_window_set_default_size(window, 1280, 720);

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -64,7 +64,7 @@
 		331C80D7294CF71000263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-		33CC10ED2044A3C60003C045 /* notes_reminder_app.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "notes_reminder_app.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CC10ED2044A3C60003C045 /* pandora.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "pandora.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Runner/Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -131,7 +131,7 @@
 		33CC10EE2044A3C60003C045 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				33CC10ED2044A3C60003C045 /* notes_reminder_app.app */,
+				33CC10ED2044A3C60003C045 /* pandora.app */,
 				331C80D5294CF71000263BE5 /* RunnerTests.xctest */,
 			);
 			name = Products;
@@ -217,7 +217,7 @@
 			);
 			name = Runner;
 			productName = Runner;
-			productReference = 33CC10ED2044A3C60003C045 /* notes_reminder_app.app */;
+			productReference = 33CC10ED2044A3C60003C045 /* pandora.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -388,7 +388,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.notesReminderApp.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/notes_reminder_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/notes_reminder_app";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/pandora.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/pandora";
 			};
 			name = Debug;
 		};
@@ -402,7 +402,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.notesReminderApp.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/notes_reminder_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/notes_reminder_app";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/pandora.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/pandora";
 			};
 			name = Release;
 		};
@@ -416,7 +416,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.notesReminderApp.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/notes_reminder_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/notes_reminder_app";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/pandora.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/pandora";
 			};
 			name = Profile;
 		};

--- a/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-               BuildableName = "notes_reminder_app.app"
+               BuildableName = "pandora.app"
                BlueprintName = "Runner"
                ReferencedContainer = "container:Runner.xcodeproj">
             </BuildableReference>
@@ -31,7 +31,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "notes_reminder_app.app"
+            BuildableName = "pandora.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -66,7 +66,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "notes_reminder_app.app"
+            BuildableName = "pandora.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -83,7 +83,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "notes_reminder_app.app"
+            BuildableName = "pandora.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -5,7 +5,7 @@
 // 'flutter create' template.
 
 // The application's name. By default this is also the title of the Flutter window.
-PRODUCT_NAME = notes_reminder_app
+PRODUCT_NAME = pandora
 
 // The application's bundle identifier
 PRODUCT_BUNDLE_IDENTIFIER = com.example.notesReminderApp

--- a/test/ai_suggestions_dialog_test.dart
+++ b/test/ai_suggestions_dialog_test.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:notes_reminder_app/generated/app_localizations.dart';
-import 'package:notes_reminder_app/widgets/ai_suggestions_dialog.dart';
-import 'package:notes_reminder_app/features/chat/domain/note_analysis.dart';
+import 'package:pandora/generated/app_localizations.dart';
+import 'package:pandora/widgets/ai_suggestions_dialog.dart';
+import 'package:pandora/features/chat/domain/note_analysis.dart';
 
 void main() {
   testWidgets('AISuggestionsDialog returns edited data', (tester) async {

--- a/test/calendar_service_test.dart
+++ b/test/calendar_service_test.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_sign_in_platform_interface/google_sign_in_platform_interface.dart';
-import 'package:notes_reminder_app/features/note/data/calendar_service.dart';
+import 'package:pandora/features/note/data/calendar_service.dart';
 
 class FakeSignInSuccess extends GoogleSignInPlatform {
   @override

--- a/test/connectivity_service_test.dart
+++ b/test/connectivity_service_test.dart
@@ -3,8 +3,8 @@ import 'dart:async';
 import 'package:connectivity_plus_platform_interface/connectivity_plus_platform_interface.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:notes_reminder_app/generated/app_localizations.dart';
-import 'package:notes_reminder_app/services/connectivity_service.dart';
+import 'package:pandora/generated/app_localizations.dart';
+import 'package:pandora/services/connectivity_service.dart';
 
 class FakeConnectivity extends ConnectivityPlatform {
   final _controller = StreamController<List<ConnectivityResult>>();

--- a/test/note_detail_screen_test.dart
+++ b/test/note_detail_screen_test.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
-import 'package:notes_reminder_app/generated/app_localizations.dart';
+import 'package:pandora/generated/app_localizations.dart';
 import 'package:alarm_domain/alarm_domain.dart';
-import 'package:notes_reminder_app/features/note/presentation/note_provider.dart';
-import 'package:notes_reminder_app/features/note/presentation/note_detail_screen.dart';
+import 'package:pandora/features/note/presentation/note_provider.dart';
+import 'package:pandora/features/note/presentation/note_detail_screen.dart';
 
 void main() {
   testWidgets('display note details', (tester) async {

--- a/test/notification_service_test.dart
+++ b/test/notification_service_test.dart
@@ -1,9 +1,9 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/services.dart';
-import 'package:notes_reminder_app/generated/app_localizations.dart';
+import 'package:pandora/generated/app_localizations.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:notes_reminder_app/features/note/data/notification_service.dart';
+import 'package:pandora/features/note/data/notification_service.dart';
 import 'package:alarm_domain/alarm_domain.dart';
 import 'package:timezone/data/latest.dart' as tzdata;
 import 'package:timezone/timezone.dart' as tz;

--- a/test/pandora_ui/text_scale_widgets_test.dart
+++ b/test/pandora_ui/text_scale_widgets_test.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:notes_reminder_app/pandora_ui/hint_chip.dart';
-import 'package:notes_reminder_app/pandora_ui/palette_list_item.dart';
-import 'package:notes_reminder_app/pandora_ui/toolbar_button.dart';
-import 'package:notes_reminder_app/pandora_ui/tokens.dart';
+import 'package:pandora/pandora_ui/hint_chip.dart';
+import 'package:pandora/pandora_ui/palette_list_item.dart';
+import 'package:pandora/pandora_ui/toolbar_button.dart';
+import 'package:pandora/pandora_ui/tokens.dart';
 
 void main() {
   testWidgets('HintChip scales with textScaleFactor', (

--- a/test/pandora_ui/toolbar_button_test.dart
+++ b/test/pandora_ui/toolbar_button_test.dart
@@ -3,8 +3,8 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/rendering.dart';
 
-import 'package:notes_reminder_app/pandora_ui/toolbar_button.dart';
-import 'package:notes_reminder_app/theme/tokens.dart';
+import 'package:pandora/pandora_ui/toolbar_button.dart';
+import 'package:pandora/theme/tokens.dart';
 
 void main() {
   testWidgets('ToolbarButton has minimum size', (WidgetTester tester) async {

--- a/test/settings_service_test.dart
+++ b/test/settings_service_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:notes_reminder_app/features/settings/data/settings_service.dart';
+import 'package:pandora/features/settings/data/settings_service.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/snackbar_test.dart
+++ b/test/snackbar_test.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:alarm_domain/alarm_domain.dart';
-import 'package:notes_reminder_app/pandora_ui/snackbar.dart';
+import 'package:pandora/pandora_ui/snackbar.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/tag_filtered_notes_list_test.dart
+++ b/test/tag_filtered_notes_list_test.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
-import 'package:notes_reminder_app/generated/app_localizations.dart';
-import 'package:notes_reminder_app/features/note/presentation/note_provider.dart';
-import 'package:notes_reminder_app/widgets/tag_filtered_notes_list.dart';
+import 'package:pandora/generated/app_localizations.dart';
+import 'package:pandora/features/note/presentation/note_provider.dart';
+import 'package:pandora/widgets/tag_filtered_notes_list.dart';
 import 'package:alarm_domain/alarm_domain.dart';
 
 void main() {

--- a/test/teach_ai_modal_test.dart
+++ b/test/teach_ai_modal_test.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:notes_reminder_app/generated/app_localizations.dart';
+import 'package:pandora/generated/app_localizations.dart';
 import 'package:alarm_domain/alarm_domain.dart';
-import 'package:notes_reminder_app/pandora_ui/teach_ai_modal.dart';
+import 'package:pandora/pandora_ui/teach_ai_modal.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:notes_reminder_app/generated/app_localizations.dart';
-import 'package:notes_reminder_app/app.dart';
-import 'package:notes_reminder_app/features/note/presentation/note_provider.dart';
+import 'package:pandora/generated/app_localizations.dart';
+import 'package:pandora/app.dart';
+import 'package:pandora/features/note/presentation/note_provider.dart';
 import 'package:provider/provider.dart';
 
 void main() {

--- a/test/widgets/tag_selector_test.dart
+++ b/test/widgets/tag_selector_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:notes_reminder_app/widgets/tag_selector.dart';
-import 'package:notes_reminder_app/theme/tokens.dart';
+import 'package:pandora/widgets/tag_selector.dart';
+import 'package:pandora/theme/tokens.dart';
 
 void main() {
   testWidgets('TagSelector uses themed colors in light and dark', (

--- a/test/widgets/toolbar_button_test.dart
+++ b/test/widgets/toolbar_button_test.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:notes_reminder_app/pandora_ui/toolbar_button.dart';
+import 'package:pandora/pandora_ui/toolbar_button.dart';
 
-import 'package:notes_reminder_app/theme/tokens.dart';
+import 'package:pandora/theme/tokens.dart';
 
 void main() {
   testWidgets('ToolbarButton enabled state respects touch target',

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Project-level configuration.
 cmake_minimum_required(VERSION 3.14)
-project(notes_reminder_app LANGUAGES CXX)
+project(pandora LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "notes_reminder_app")
+set(BINARY_NAME "pandora")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -90,12 +90,12 @@ BEGIN
         BLOCK "040904e4"
         BEGIN
             VALUE "CompanyName", "com.example" "\0"
-            VALUE "FileDescription", "notes_reminder_app" "\0"
+            VALUE "FileDescription", "pandora" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
-            VALUE "InternalName", "notes_reminder_app" "\0"
+            VALUE "InternalName", "pandora" "\0"
             VALUE "LegalCopyright", "Copyright (C) 2025 com.example. All rights reserved." "\0"
-            VALUE "OriginalFilename", "notes_reminder_app.exe" "\0"
-            VALUE "ProductName", "notes_reminder_app" "\0"
+            VALUE "OriginalFilename", "pandora.exe" "\0"
+            VALUE "ProductName", "pandora" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"
         END
     END

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -27,7 +27,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   FlutterWindow window(project);
   Win32Window::Point origin(10, 10);
   Win32Window::Size size(1280, 720);
-  if (!window.Create(L"notes_reminder_app", origin, size)) {
+  if (!window.Create(L"pandora", origin, size)) {
     return EXIT_FAILURE;
   }
   window.SetQuitOnClose(true);


### PR DESCRIPTION
## Summary
- Replace obsolete notes_reminder_app imports with pandora
- Align Linux, macOS, Windows, and iOS build files with new package name

## Testing
- `flutter test test/widget_test.dart` *(failed: command stalled after resolving dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e9bdc0f48333b6f643e281eb391b